### PR TITLE
fix: resolve blank screen on app restart with active tracking

### DIFF
--- a/android/app/src/main/java/com/locata/LocationServiceModule.kt
+++ b/android/app/src/main/java/com/locata/LocationServiceModule.kt
@@ -113,18 +113,21 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
     override fun getName(): String = "LocationServiceModule"
 
     // Lifecycle
-    override fun onHostResume() { 
-        isAppInForeground = true 
+    override fun onHostResume() {
+        isAppInForeground = true
     }
-    
-    override fun onHostPause() { 
-        isAppInForeground = false 
+
+    override fun onHostPause() {
+        isAppInForeground = false
     }
-    
-    override fun onHostDestroy() { 
-    isAppInForeground = false
-        // Cancel all running coroutines safely
+
+    override fun onHostDestroy() {
+        isAppInForeground = false
+    }
+
+    override fun invalidate() {
         moduleScope.cancel()
+        super.invalidate()
     }
 
 

--- a/src/hooks/useLocationTracking.ts
+++ b/src/hooks/useLocationTracking.ts
@@ -222,6 +222,21 @@ export function useLocationTracking(
   );
 
   /**
+   * Reconnects React state to an already-running native service.
+   * Used after app restart when tracking_enabled is true in the DB.
+   * Does NOT request permissions or restart the service.
+   */
+  const reconnect = useCallback(() => {
+    if (isTrackingRef.current) {
+      console.log("[useLocationTracking] Already tracking, skip reconnect");
+      return;
+    }
+
+    console.log("[useLocationTracking] Reconnecting to active service");
+    setTracking(true);
+  }, []);
+
+  /**
    * Cleanup on unmount
    * NOTE: Does NOT stop tracking - service continues in background
    */
@@ -241,6 +256,7 @@ export function useLocationTracking(
     startTracking,
     stopTracking,
     restartTracking,
+    reconnect,
     settings,
   };
 }

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -104,6 +104,7 @@ export interface LocationTrackingResult {
   startTracking: (overrideSettings?: Settings) => Promise<void>;
   stopTracking: () => void;
   restartTracking: (newSettings?: Settings) => Promise<void>;
+  reconnect: () => void;
   settings: Settings;
 }
 


### PR DESCRIPTION
The app showed a permanent grey/blank screen when reopened after being killed while location tracking was active.

Root causes:
- TrackingProvider returned null while isLoading was true, blocking the entire UI tree
- LocationServiceModule.onHostDestroy() cancelled moduleScope, causing all subsequent native bridge calls (getAllSettings) to silently hang when the module was reused after activity recreation

Changes:
- Remove rendering gate in TrackingProvider — always render children
- Move moduleScope.cancel() from onHostDestroy to invalidate()
- Add reconnect() method for lightweight state sync on app restart without re-requesting permissions or restarting the service
- Add 5s safety timeout for initialization in case native calls hang

Closes #18