### PR TITLE
refactor: rework export screen with accurate file size and no record limit

### DIFF
--- a/src/services/NativeLocationService.ts
+++ b/src/services/NativeLocationService.ts
@@ -219,12 +219,11 @@ class NativeLocationService {
 
   /**
    * Fetches all locations for export
-   * @param limit Maximum records to export (default: 5000)
    */
-  static async getExportData(limit: number = 5000): Promise<any[]> {
+  static async getExportData(): Promise<any[]> {
     this.ensureModule();
     return this.safeExecute(
-      () => LocationServiceModule.getTableData("locations", limit, 0),
+      () => LocationServiceModule.getTableData("locations", 1000000, 0),
       [],
       "getExportData failed"
     );


### PR DESCRIPTION
Remove the 5000 record export limit, calculate actual file size via Blob instead of per-record estimates, warn users before exporting files larger than 10MB and cache fetched data to avoid redundant fetches