### PR TITLE
Add offline banner to maps and network check to server connection

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/LocationServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/LocationServiceModule.kt
@@ -32,6 +32,7 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
     private val deviceInfo = DeviceInfoHelper(reactContext)
     private val geofenceHelper = GeofenceHelper(reactContext)
     private val secureStorage = SecureStorageHelper.getInstance(reactContext)
+    private val networkManager = NetworkManager(reactContext)
 
     // Coroutine scope for async operations
     private val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -453,6 +454,15 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
         Arguments.createMap().apply {
             settingsMap.forEach { (k, v) -> putString(k, v) }
         }
+    }
+
+    // ==============================================================
+    // NETWORK
+    // ==============================================================
+
+    @ReactMethod
+    fun isNetworkAvailable(promise: Promise) {
+        promise.resolve(networkManager.isNetworkAvailable())
     }
 
     // ==============================================================

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -339,6 +339,18 @@ class NativeLocationService {
   }
 
   // ============================================================================
+  // NETWORK
+  // ============================================================================
+
+  /**
+   * Checks if the device has an active internet connection
+   */
+  static async isNetworkAvailable(): Promise<boolean> {
+    this.ensureModule()
+    return this.safeExecute(() => LocationServiceModule.isNetworkAvailable(), false, "isNetworkAvailable failed")
+  }
+
+  // ============================================================================
   // BATTERY OPTIMIZATION
   // ============================================================================
 


### PR DESCRIPTION
Expose NetworkManager.isNetworkAvailable() to React Native via LocationServiceModule. Show "Map tiles unavailable" banner on dashboard and geofence maps when device has no internet. Server connection now skips HTTP pings when offline and shows "Device offline".