### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -11,6 +11,9 @@ on:
       - '**.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     name: Lint & Test


### PR DESCRIPTION
Potential fix for [https://github.com/dietrichmax/colota/security/code-scanning/5](https://github.com/dietrichmax/colota/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required `GITHUB_TOKEN` scopes. This can be defined at the top level (applying to all jobs) or within the specific job. Since there is only one job, we can add it at the workflow root for clarity and future extensibility.

The best minimal fix without changing existing functionality is:
- Add a top-level `permissions` block after the `on:` section to restrict `contents` to `read`, which is sufficient for `actions/checkout` to read the repository. None of the steps appear to need write access to repository contents, issues, or pull requests.
- The `codecov/codecov-action` normally uses its own token (`CODECOV_TOKEN`) or other mechanisms; it does not require elevated `GITHUB_TOKEN` write perms just to upload coverage. If in this repository it happens to rely on `GITHUB_TOKEN`, read-level `contents` is still sufficient for its GitHub API usage.

Concretely, in `.github/workflows/lint-test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. No imports or additional definitions are needed, as this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
