### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/dietrichmax/colota/security/code-scanning/1](https://github.com/dietrichmax/colota/security/code-scanning/1)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for the `test` job to the minimum required, instead of relying on repository/organization defaults. The job only needs to read repository contents (for `actions/checkout`), so `contents: read` is sufficient.

The best fix without changing functionality is:

- Add a `permissions` block under the `test` job, parallel to `runs-on`, setting `contents: read`.
- Leave the existing `permissions: contents: write` on the `build-and-release` job unchanged, since that job publishes a GitHub Release and legitimately needs write access.

Concretely, in `.github/workflows/build-release.yml`, modify the `test` job section around lines 16–23 so that it includes:

```yaml
  test:
    name: Lint & Test
    runs-on: ubuntu-latest
    permissions:
      contents: read
    steps:
      ...
```

No additional imports, methods, or definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
