### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -13,6 +13,9 @@ concurrency:
   group: build-check-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Debug APKs


### PR DESCRIPTION
Potential fix for [https://github.com/dietrichmax/colota/security/code-scanning/3](https://github.com/dietrichmax/colota/security/code-scanning/3)

To fix the problem, explicitly define restricted `GITHUB_TOKEN` permissions for this workflow. Since the workflow only checks out code and runs builds/tests, it should only need read access to repository contents. The best minimal fix is to add a root-level `permissions` block with `contents: read`, which will apply to all jobs (currently just `build`) that do not override it. This avoids changing any functionality while constraining the token.

Concretely, in `.github/workflows/build-check.yml`, insert a `permissions:` section near the top-level (for example, after `concurrency:` and before `jobs:`), with `contents: read`. No imports or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
