### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,4 +1,6 @@
 name: Docs Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/dietrichmax/colota/security/code-scanning/4](https://github.com/dietrichmax/colota/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this workflow, the job only needs to read the repository contents to check out code and run builds, so `contents: read` at the workflow level is sufficient. No steps require write access to issues, pull requests, or repository contents.

The best fix without changing existing functionality is to add a workflow-level `permissions` section near the top of `.github/workflows/docs-check.yml`, between `name: Docs Check` and the `on:` block. This will apply `contents: read` to all jobs (currently only `build`) unless overridden, satisfying CodeQL’s requirement and following least-privilege practices. No imports or additional methods are needed, since this is purely a YAML configuration change.

Concretely, in `.github/workflows/docs-check.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Docs Check`) and before the `on:` section that starts at line 3.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
