### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-latest-release.yml
+++ b/.github/workflows/build-latest-release.yml
@@ -21,6 +21,8 @@ jobs:
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/dietrichmax/colota/security/code-scanning/2](https://github.com/dietrichmax/colota/security/code-scanning/2)

To fix the problem, explicitly set minimal `GITHUB_TOKEN` permissions for the `test` job so it no longer relies on potentially broad repository defaults. Since the `test` job only needs to read the repository contents (for `actions/checkout`) and does not perform any writes via the GitHub API, the least-privilege configuration is `permissions: contents: read`.

Concretely, in `.github/workflows/build-latest-release.yml`, under `jobs: test:`, add a `permissions:` block between `runs-on: ubuntu-latest` (line 23) and `steps:` (line 24). This block should set `contents: read`. No other functionality, steps, or jobs need to change, and no imports or external dependencies are required. The `build-and-release` job already has an explicit `permissions` block and should be left as is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
