### PR TITLE
Add prominent location disclosure modal for Google Play compliance

### DIFF
--- a/apps/mobile/src/components/index.ts
+++ b/apps/mobile/src/components/index.ts
@@ -22,6 +22,7 @@ export { NumericInput } from "./ui/NumericInput"
 export { FloatingSaveIndicator } from "./ui/FloatingSaveIndicator"
 export { Footer } from "./ui/Footer"
 export { SpinningLoader } from "./ui/SpinningLoader"
+export { LocationDisclosureModal } from "./ui/LocationDisclosureModal"
 
 // ============================================================================
 // Feature Components - Dashboard

--- a/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
@@ -1,0 +1,159 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import React, { useState, useRef, useEffect, useCallback } from "react"
+import { Modal, View, Text, TouchableOpacity, StyleSheet, BackHandler } from "react-native"
+import { useTheme } from "../../hooks/useTheme"
+import { fonts } from "../../styles/typography"
+import { fontSizes } from "@colota/shared"
+import { MapPin } from "lucide-react-native"
+import { registerDisclosureCallback } from "../../services/LocationServicePermission"
+
+/**
+ * Prominent in-app disclosure modal for location data collection.
+ * Required by Google Play's User Data policy.
+ *
+ * Uses the app's theme (not system AlertDialog) to avoid
+ * looking like an Android system prompt.
+ */
+export function LocationDisclosureModal() {
+  const { colors } = useTheme()
+  const [visible, setVisible] = useState(false)
+  const resolveRef = useRef<((value: boolean) => void) | null>(null)
+
+  useEffect(() => {
+    registerDisclosureCallback(() => {
+      return new Promise<boolean>((resolve) => {
+        resolveRef.current = resolve
+        setVisible(true)
+      })
+    })
+  }, [])
+
+  // Block hardware back button while visible
+  useEffect(() => {
+    if (!visible) return
+    const handler = BackHandler.addEventListener("hardwareBackPress", () => true)
+    return () => handler.remove()
+  }, [visible])
+
+  const handleAgree = useCallback(() => {
+    setVisible(false)
+    resolveRef.current?.(true)
+    resolveRef.current = null
+  }, [])
+
+  const handleNotNow = useCallback(() => {
+    setVisible(false)
+    resolveRef.current?.(false)
+    resolveRef.current = null
+  }, [])
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" statusBarTranslucent>
+      <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
+        <View style={[styles.card, { backgroundColor: colors.cardElevated, borderRadius: colors.borderRadius + 4 }]}>
+          {/* Icon */}
+          <View style={[styles.iconContainer, { backgroundColor: colors.primary + "15" }]}>
+            <MapPin size={28} color={colors.primary} />
+          </View>
+
+          {/* Title */}
+          <Text style={[styles.title, { color: colors.text }]}>Location Data Collection</Text>
+
+          {/* Body */}
+          <Text style={[styles.body, { color: colors.textSecondary }]}>
+            Colota collects location data to enable GPS tracking and sending your position to your configured server,
+            even when the app is closed or not in use.
+          </Text>
+
+          <Text style={[styles.body, { color: colors.textSecondary, marginTop: 8 }]}>
+            This data is sent only to the server you set up. No data is shared with third parties.
+          </Text>
+
+          <Text style={[styles.body, { color: colors.textSecondary, marginTop: 8 }]}>
+            The app also needs notification and battery permissions to keep tracking running reliably.
+          </Text>
+
+          {/* Buttons */}
+          <View style={styles.buttons}>
+            <TouchableOpacity
+              style={[styles.button, styles.secondaryButton, { borderColor: colors.border }]}
+              onPress={handleNotNow}
+              activeOpacity={0.7}
+            >
+              <Text style={[styles.buttonText, { color: colors.textSecondary }]}>Not Now</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.button, styles.primaryButton, { backgroundColor: colors.primary }]}
+              onPress={handleAgree}
+              activeOpacity={0.7}
+            >
+              <Text style={[styles.buttonText, { color: colors.textOnPrimary }]}>Agree</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 32
+  },
+  card: {
+    width: "100%",
+    padding: 24,
+    elevation: 8,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 12
+  },
+  iconContainer: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    justifyContent: "center",
+    alignItems: "center",
+    alignSelf: "center",
+    marginBottom: 16
+  },
+  title: {
+    fontSize: fontSizes.cardTitle,
+    ...fonts.bold,
+    textAlign: "center",
+    marginBottom: 16
+  },
+  body: {
+    fontSize: fontSizes.body,
+    ...fonts.regular,
+    lineHeight: 20
+  },
+  buttons: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 24
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: "center"
+  },
+  primaryButton: {},
+  secondaryButton: {
+    borderWidth: 1.5
+  },
+  buttonText: {
+    fontSize: fontSizes.label,
+    ...fonts.semiBold
+  }
+})

--- a/apps/mobile/src/contexts/TrackingProvider.tsx
+++ b/apps/mobile/src/contexts/TrackingProvider.tsx
@@ -8,6 +8,7 @@ import { Settings, DEFAULT_SETTINGS, LocationCoords, ApiTemplateName, HttpMethod
 import { useLocationTracking } from "../hooks/useLocationTracking"
 import NativeLocationService from "../services/NativeLocationService"
 import SettingsService from "../services/SettingsService"
+import { LocationDisclosureModal } from "../components/ui/LocationDisclosureModal"
 import { logger } from "../utils/logger"
 
 type TrackingContextType = {
@@ -252,7 +253,12 @@ export function TrackingProvider({ children }: { children: React.ReactNode }) {
     [settings, coords, tracking, isLoading, error, setSettings, startTracking, stopTracking, restartTracking]
   )
 
-  return <TrackingContext.Provider value={value}>{children}</TrackingContext.Provider>
+  return (
+    <TrackingContext.Provider value={value}>
+      <LocationDisclosureModal />
+      {children}
+    </TrackingContext.Provider>
+  )
 }
 
 /**

--- a/apps/mobile/src/contexts/__tests__/TrackingProvider.test.tsx
+++ b/apps/mobile/src/contexts/__tests__/TrackingProvider.test.tsx
@@ -16,6 +16,10 @@ jest.mock("../../services/SettingsService", () => ({
   updateSetting: jest.fn().mockResolvedValue(true)
 }))
 
+jest.mock("../../components/ui/LocationDisclosureModal", () => ({
+  LocationDisclosureModal: () => null
+}))
+
 const mockStartTracking = jest.fn().mockResolvedValue(undefined)
 const mockStopTracking = jest.fn()
 const mockRestartTracking = jest.fn().mockResolvedValue(undefined)


### PR DESCRIPTION
Google Play rejected the app for missing a prominent in-app disclosure before requesting location permissions. Adds a custom themed modal that meets all Google Play User Data policy requirements.