### PR TITLE
Fix accuracy threshold, Wi-Fi sync persistence, and other bugs

### DIFF
--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -63,7 +63,7 @@ export function DashboardMap({ coords, tracking, activeZoneName }: Props) {
       const data = await NativeLocationService.getGeofences()
       setGeofences(data)
     } catch (err) {
-      logger.error("[GeofenceScreen] Failed to load geofences:", err)
+      logger.error("[DashboardMap] Failed to load geofences:", err)
     }
   }, [])
 
@@ -78,7 +78,7 @@ export function DashboardMap({ coords, tracking, activeZoneName }: Props) {
         const zoneName = await NativeLocationService.checkCurrentPauseZone()
         setCurrentPauseZone(zoneName)
       } catch (err) {
-        logger.error("[GeofenceScreen] Failed to check pause zone:", err)
+        logger.error("[DashboardMap] Failed to check pause zone:", err)
       }
     }
 

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -69,7 +69,7 @@ export function ConnectionSettings({
 
       // Optional fields with real values from the location
       if (fieldMap.alt) payload[fieldMap.alt] = recentLocation.altitude ?? 0
-      if (fieldMap.vel) payload[fieldMap.vel] = recentLocation.velocity ?? 0
+      if (fieldMap.vel) payload[fieldMap.vel] = recentLocation.speed ?? 0
       if (fieldMap.batt) payload[fieldMap.batt] = recentLocation.battery ?? 0
       if (fieldMap.bs) payload[fieldMap.bs] = recentLocation.batteryStatus ?? 0
       if (fieldMap.bear) payload[fieldMap.bear] = recentLocation.bearing ?? 0
@@ -82,10 +82,14 @@ export function ConnectionSettings({
         // proceed without auth headers
       }
 
-      const response = await fetch(endpointInput, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeaders },
-        body: JSON.stringify(payload)
+      const method = settings.httpMethod ?? "POST"
+      const params = new URLSearchParams(Object.entries(payload).map(([k, v]) => [k, String(v)]))
+      const url =
+        method === "GET" ? `${endpointInput}${endpointInput.includes("?") ? "&" : "?"}${params}` : endpointInput
+      const response = await fetch(url, {
+        method,
+        headers: method === "GET" ? authHeaders : { "Content-Type": "application/json", ...authHeaders },
+        ...(method === "GET" ? {} : { body: JSON.stringify(payload) })
       })
 
       if (response.ok) {

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -28,7 +28,7 @@ export function SyncStrategySettings({
 }: SyncStrategySettingsProps) {
   const [intervalInput, setIntervalInput] = useState(settings.interval.toString())
   const [distanceInput, setDistanceInput] = useState(settings.distance?.toString() || "0")
-  const [accuracyTresholdInput, setAccuracyTresholdInput] = useState(settings.accuracyThreshold.toString())
+  const [accuracyThresholdInput, setAccuracyTresholdInput] = useState(settings.accuracyThreshold.toString())
   const [showAdvanced, setShowAdvanced] = useState(false)
 
   // Sync inputs with settings changes
@@ -38,10 +38,10 @@ export function SyncStrategySettings({
   }, [settings.interval, settings.distance])
 
   const handleNumericChange = useCallback(
-    (key: "interval" | "distance" | "accuracyTreshold", value: string, min: number = 0) => {
+    (key: "interval" | "distance" | "accuracyThreshold", value: string, min: number = 0) => {
       if (key === "interval") setIntervalInput(value)
       if (key === "distance") setDistanceInput(value)
-      if (key === "accuracyTreshold") setAccuracyTresholdInput(value)
+      if (key === "accuracyThreshold") setAccuracyTresholdInput(value)
 
       const num = Number(value)
       if (!isNaN(num) && num >= min) {
@@ -54,22 +54,23 @@ export function SyncStrategySettings({
   )
 
   const handleNumericBlur = useCallback(
-    (key: "interval" | "distance" | "accuracyTreshold", min: number = 0) => {
-      const currentStr = key === "interval" ? intervalInput : key === "distance" ? distanceInput : accuracyTresholdInput
+    (key: "interval" | "distance" | "accuracyThreshold", min: number = 0) => {
+      const currentStr =
+        key === "interval" ? intervalInput : key === "distance" ? distanceInput : accuracyThresholdInput
       let val = Number(currentStr)
 
       if (isNaN(val) || val < min) {
         val = min
         if (key === "interval") setIntervalInput(min.toString())
         if (key === "distance") setDistanceInput(min.toString())
-        if (key === "accuracyTreshold") setAccuracyTresholdInput(min.toString())
+        if (key === "accuracyThreshold") setAccuracyTresholdInput(min.toString())
 
         const next = { ...settings, [key]: val }
         onSettingsChange(next)
         onImmediateSave(next)
       }
     },
-    [intervalInput, distanceInput, accuracyTresholdInput, settings, onSettingsChange, onImmediateSave]
+    [intervalInput, distanceInput, accuracyThresholdInput, settings, onSettingsChange, onImmediateSave]
   )
 
   const handlePresetSelect = useCallback(
@@ -328,9 +329,9 @@ export function SyncStrategySettings({
                 <View style={[styles.nestedSetting, { borderLeftColor: colors.border }]}>
                   <NumericInput
                     label="Accuracy Threshold"
-                    value={accuracyTresholdInput}
-                    onChange={(val) => handleNumericChange("accuracyTreshold", val, 50)}
-                    onBlur={() => handleNumericBlur("accuracyTreshold", 50)}
+                    value={accuracyThresholdInput}
+                    onChange={(val) => handleNumericChange("accuracyThreshold", val, 50)}
+                    onBlur={() => handleNumericBlur("accuracyThreshold", 50)}
                     unit="meters"
                     placeholder="50"
                     hint="Reject readings with accuracy worse than this"

--- a/apps/mobile/src/contexts/TrackingProvider.tsx
+++ b/apps/mobile/src/contexts/TrackingProvider.tsx
@@ -47,6 +47,7 @@ function parseRawSettings(allRaw: Record<string, string>): Settings {
       : DEFAULT_SETTINGS.accuracyThreshold,
 
     isOfflineMode: allRaw.isOfflineMode === "true",
+    isWifiOnlySync: allRaw.isWifiOnlySync === "true",
     endpoint: allRaw.endpoint ?? DEFAULT_SETTINGS.endpoint,
     syncPreset: (allRaw.syncPreset as any) ?? DEFAULT_SETTINGS.syncPreset,
     filterInaccurateLocations: allRaw.filterInaccurateLocations === "true",

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -94,14 +94,6 @@ class NativeLocationService {
   }
 
   /**
-   * Checks if the foreground service is currently running
-   */
-  static async isServiceRunning(): Promise<boolean> {
-    this.ensureModule()
-    return this.safeExecute(() => LocationServiceModule.isServiceRunning(), false, "isServiceRunning failed")
-  }
-
-  /**
    * Checks if tracking is enabled (from persistent settings)
    */
   static async isTrackingActive(): Promise<boolean> {

--- a/apps/mobile/src/utils/exportConverters.ts
+++ b/apps/mobile/src/utils/exportConverters.ts
@@ -16,7 +16,12 @@ export const formatBytes = (bytes: number): string => {
 }
 
 export const getByteSize = (content: string): number => {
-  return new Blob([content]).size
+  let bytes = 0
+  for (let i = 0; i < content.length; i++) {
+    const code = content.charCodeAt(i)
+    bytes += code <= 0x7f ? 1 : code <= 0x7ff ? 2 : 3
+  }
+  return bytes
 }
 
 export const convertToCSV = (data: LocationCoords[]): string => {


### PR DESCRIPTION
- Fix accuracyThreshold typo causing setting changes to be silently lost
- Parse isWifiOnlySync on app restart so it persists across sessions
- Fix velocity → speed field mismatch in test connection payload
- Respect httpMethod setting in test connection (GET sends query params)
- Replace Blob with RN-safe UTF-8 byte counter in export size calc
- Remove dead isServiceRunning method with no native implementation
- Fix DashboardMap logger prefix (was copy-pasted from GeofenceScreen)