### PR TITLE
Harden codebase: fix sync logic, UX feedback, battery safety, and audit issues

### DIFF
--- a/apps/mobile/android/app/src/foss/java/com/Colota/location/NativeLocationProvider.kt
+++ b/apps/mobile/android/app/src/foss/java/com/Colota/location/NativeLocationProvider.kt
@@ -26,7 +26,7 @@ class NativeLocationProvider(context: Context) : LocationProvider {
         context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
     /** Maps each callback to its GPS listener and optional network listener. */
-    private val listenerMap = mutableMapOf<LocationUpdateCallback, List<LocationListener>>()
+    private val listenerMap = java.util.concurrent.ConcurrentHashMap<LocationUpdateCallback, List<LocationListener>>()
 
     override fun requestLocationUpdates(
         intervalMs: Long,

--- a/apps/mobile/android/app/src/gms/java/com/Colota/location/GmsLocationProvider.kt
+++ b/apps/mobile/android/app/src/gms/java/com/Colota/location/GmsLocationProvider.kt
@@ -19,7 +19,7 @@ class GmsLocationProvider(context: Context) : LocationProvider {
     private val fusedClient: FusedLocationProviderClient =
         LocationServices.getFusedLocationProviderClient(context)
 
-    private val callbackMap = mutableMapOf<LocationUpdateCallback, LocationCallback>()
+    private val callbackMap = java.util.concurrent.ConcurrentHashMap<LocationUpdateCallback, LocationCallback>()
 
     override fun requestLocationUpdates(
         intervalMs: Long,

--- a/apps/mobile/android/app/src/main/java/com/colota/data/GeofenceHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/data/GeofenceHelper.kt
@@ -98,35 +98,39 @@ class GeofenceHelper(private val context: Context) {
 
     fun getGeofencesAsArray(): WritableArray {
         val array = Arguments.createArray()
-        
-        dbHelper.readableDatabase.query(
-            DatabaseHelper.TABLE_GEOFENCES, 
-            null, null, null, null, null, 
-            "created_at DESC"
-        ).use { cursor ->
-            val idIdx = cursor.getColumnIndexOrThrow("id")
-            val nameIdx = cursor.getColumnIndexOrThrow("name")
-            val latIdx = cursor.getColumnIndexOrThrow("latitude")
-            val lonIdx = cursor.getColumnIndexOrThrow("longitude")
-            val radiusIdx = cursor.getColumnIndexOrThrow("radius")
-            val enabledIdx = cursor.getColumnIndexOrThrow("enabled")
-            val pauseIdx = cursor.getColumnIndexOrThrow("pause_tracking")
-            val createdIdx = cursor.getColumnIndexOrThrow("created_at")
-            
-            while (cursor.moveToNext()) {
-                array.pushMap(Arguments.createMap().apply {
-                    putInt("id", cursor.getInt(idIdx))
-                    putString("name", cursor.getString(nameIdx))
-                    putDouble("lat", cursor.getDouble(latIdx))
-                    putDouble("lon", cursor.getDouble(lonIdx))
-                    putDouble("radius", cursor.getDouble(radiusIdx))
-                    putBoolean("enabled", cursor.getInt(enabledIdx) == 1)
-                    putBoolean("pauseTracking", cursor.getInt(pauseIdx) == 1)
-                    putDouble("createdAt", cursor.getLong(createdIdx).toDouble())
-                })
+
+        try {
+            dbHelper.readableDatabase.query(
+                DatabaseHelper.TABLE_GEOFENCES,
+                null, null, null, null, null,
+                "created_at DESC"
+            ).use { cursor ->
+                val idIdx = cursor.getColumnIndexOrThrow("id")
+                val nameIdx = cursor.getColumnIndexOrThrow("name")
+                val latIdx = cursor.getColumnIndexOrThrow("latitude")
+                val lonIdx = cursor.getColumnIndexOrThrow("longitude")
+                val radiusIdx = cursor.getColumnIndexOrThrow("radius")
+                val enabledIdx = cursor.getColumnIndexOrThrow("enabled")
+                val pauseIdx = cursor.getColumnIndexOrThrow("pause_tracking")
+                val createdIdx = cursor.getColumnIndexOrThrow("created_at")
+
+                while (cursor.moveToNext()) {
+                    array.pushMap(Arguments.createMap().apply {
+                        putInt("id", cursor.getInt(idIdx))
+                        putString("name", cursor.getString(nameIdx))
+                        putDouble("lat", cursor.getDouble(latIdx))
+                        putDouble("lon", cursor.getDouble(lonIdx))
+                        putDouble("radius", cursor.getDouble(radiusIdx))
+                        putBoolean("enabled", cursor.getInt(enabledIdx) == 1)
+                        putBoolean("pauseTracking", cursor.getInt(pauseIdx) == 1)
+                        putDouble("createdAt", cursor.getLong(createdIdx).toDouble())
+                    })
+                }
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load geofences as array", e)
         }
-        
+
         return array
     }
 

--- a/apps/mobile/android/app/src/main/java/com/colota/service/ServiceConfig.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/ServiceConfig.kt
@@ -35,13 +35,13 @@ data class ServiceConfig(
             
             return ServiceConfig(
                 endpoint = saved["endpoint"] ?: "",
-                interval = saved["interval"]?.toLongOrNull() ?: 1000L,
+                interval = saved["interval"]?.toLongOrNull() ?: 5000L,
                 minUpdateDistance = saved["minUpdateDistance"]?.toFloatOrNull() ?: 0f,
                 syncIntervalSeconds = saved["syncInterval"]?.toIntOrNull() ?: 0,
                 maxRetries = saved["maxRetries"]?.toIntOrNull() ?: 5,
                 accuracyThreshold = saved["accuracyThreshold"]?.toFloatOrNull() ?: 50.0f,
-                filterInaccurateLocations = saved["filterInaccurateLocations"]?.toBoolean() ?: true,
-                retryIntervalSeconds = saved["retryInterval"]?.toIntOrNull() ?: 300,
+                filterInaccurateLocations = saved["filterInaccurateLocations"]?.toBoolean() ?: false,
+                retryIntervalSeconds = saved["retryInterval"]?.toIntOrNull() ?: 30,
                 isOfflineMode = saved["isOfflineMode"]?.toBoolean() ?: false,
                 isWifiOnlySync = saved["isWifiOnlySync"]?.toBoolean() ?: false,
                 fieldMap = saved["fieldMap"],

--- a/apps/mobile/android/app/src/main/java/com/colota/util/TimedCache.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/util/TimedCache.kt
@@ -18,6 +18,7 @@ class TimedCache<T>(
     @Volatile private var value: T? = null
     @Volatile private var lastCheck: Long = 0
 
+    @Synchronized
     fun get(): T {
         val now = System.currentTimeMillis()
         if (value == null || (now - lastCheck) > ttlMs) {
@@ -27,6 +28,7 @@ class TimedCache<T>(
         return value!!
     }
 
+    @Synchronized
     fun invalidate() {
         lastCheck = 0
     }

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -262,8 +262,13 @@ export function TrackMap({ locations, selectedPoint, colors, isDark }: Props) {
       document.addEventListener("message", handleInternalMessage);
 
       map.on("moveend", () => {
+        var centered = true;
+        if (currentExtent) {
+          var viewExtent = map.getView().calculateExtent(map.getSize());
+          centered = ol.extent.containsExtent(viewExtent, currentExtent);
+        }
         window.ReactNativeWebView.postMessage(
-          JSON.stringify({ type: "CENTERED", value: true })
+          JSON.stringify({ type: "CENTERED", value: centered })
         );
       });
 

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -31,11 +31,12 @@ export function SyncStrategySettings({
   const [accuracyThresholdInput, setAccuracyTresholdInput] = useState(settings.accuracyThreshold.toString())
   const [showAdvanced, setShowAdvanced] = useState(false)
 
-  // Sync inputs with settings changes
+  // Sync inputs with settings changes (e.g. preset selection)
   useEffect(() => {
     setIntervalInput(settings.interval.toString())
     setDistanceInput(settings.distance?.toString() || "0")
-  }, [settings.interval, settings.distance])
+    setAccuracyTresholdInput(settings.accuracyThreshold.toString())
+  }, [settings.interval, settings.distance, settings.accuracyThreshold])
 
   const handleNumericChange = useCallback(
     (key: "interval" | "distance" | "accuracyThreshold", value: string, min: number = 0) => {
@@ -46,11 +47,10 @@ export function SyncStrategySettings({
       const num = Number(value)
       if (!isNaN(num) && num >= min) {
         const next = { ...settings, [key]: num, syncPreset: "custom" as const }
-        onSettingsChange(next)
         onDebouncedSave(next)
       }
     },
-    [settings, onSettingsChange, onDebouncedSave]
+    [settings, onDebouncedSave]
   )
 
   const handleNumericBlur = useCallback(
@@ -92,6 +92,7 @@ export function SyncStrategySettings({
         retryInterval: config.retryInterval
       }
 
+      onSettingsChange(next)
       onImmediateSave(next)
     },
     [settings, onSettingsChange, onImmediateSave]

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -97,6 +97,14 @@ describe("SyncStrategySettings", () => {
 
       fireEvent.press(getByTestId("preset-balanced"))
 
+      expect(mockOnSettingsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          syncPreset: "balanced",
+          interval: TRACKING_PRESETS.balanced.interval,
+          distance: TRACKING_PRESETS.balanced.distance,
+          syncInterval: TRACKING_PRESETS.balanced.syncInterval
+        })
+      )
       expect(mockOnImmediateSave).toHaveBeenCalledWith(
         expect.objectContaining({
           syncPreset: "balanced",
@@ -173,7 +181,12 @@ describe("SyncStrategySettings", () => {
           syncPreset: "custom"
         })
       )
-      expect(mockOnDebouncedSave).toHaveBeenCalled()
+      expect(mockOnDebouncedSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          syncInterval: 300,
+          syncPreset: "custom"
+        })
+      )
     })
   })
 

--- a/apps/mobile/src/contexts/TrackingProvider.tsx
+++ b/apps/mobile/src/contexts/TrackingProvider.tsx
@@ -14,6 +14,7 @@ import { logger } from "../utils/logger"
 type TrackingContextType = {
   settings: Settings
   setSettings: (s: Settings) => Promise<void>
+  updateSettingsLocal: (s: Settings) => void
   coords: LocationCoords | null
   tracking: boolean
   isLoading: boolean
@@ -243,6 +244,7 @@ export function TrackingProvider({ children }: { children: React.ReactNode }) {
     () => ({
       settings,
       setSettings,
+      updateSettingsLocal: setSettingsState,
       coords,
       tracking,
       isLoading,

--- a/apps/mobile/src/hooks/__tests__/useAutoSave.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useAutoSave.test.ts
@@ -73,7 +73,7 @@ describe("useAutoSave", () => {
       expect(saveFn2).toHaveBeenCalledTimes(1)
     })
 
-    it("sets saving=true during save, then schedules restart", async () => {
+    it("sets saving=true during save, then restarts immediately", async () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
       const restartFn = jest.fn().mockResolvedValue(undefined)
       const { result } = renderHook(() => useAutoSave())
@@ -86,14 +86,8 @@ describe("useAutoSave", () => {
         jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
       })
 
-      // After save completes, restart is debounced
+      // After debounced save completes, restart fires immediately (no second debounce)
       expect(saveFn).toHaveBeenCalled()
-      expect(restartFn).not.toHaveBeenCalled()
-
-      await act(async () => {
-        jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
-      })
-
       expect(restartFn).toHaveBeenCalledTimes(1)
     })
 
@@ -106,12 +100,7 @@ describe("useAutoSave", () => {
         result.current.debouncedSaveAndRestart(saveFn, restartFn)
       })
 
-      // Trigger save
-      await act(async () => {
-        jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
-      })
-
-      // Trigger restart
+      // Trigger save + restart (restart fires immediately after debounced save)
       await act(async () => {
         jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
       })
@@ -152,10 +141,7 @@ describe("useAutoSave", () => {
         result.current.debouncedSaveAndRestart(saveFn, restartFn)
       })
 
-      await act(async () => {
-        jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
-      })
-
+      // Save + restart both fire after debounce (restart is immediate after save)
       await act(async () => {
         jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
       })

--- a/apps/mobile/src/hooks/useAutoSave.ts
+++ b/apps/mobile/src/hooks/useAutoSave.ts
@@ -33,17 +33,17 @@ export function useAutoSave() {
         setSaving(true)
         try {
           await saveFn()
-          restartTimeout.set(async () => {
-            try {
-              await restartFn()
-              setSaveSuccess(true)
-              successTimeout.set(() => setSaveSuccess(false), SAVE_SUCCESS_DISPLAY_MS)
-            } catch (err) {
-              logger.error("[useAutoSave] Restart failed:", err)
-            } finally {
-              setSaving(false)
-            }
-          }, AUTOSAVE_DEBOUNCE_MS)
+          // Restart immediately — input was already debounced by saveTimeout
+          restartTimeout.clear()
+          try {
+            await restartFn()
+            setSaveSuccess(true)
+            successTimeout.set(() => setSaveSuccess(false), SAVE_SUCCESS_DISPLAY_MS)
+          } catch (err) {
+            logger.error("[useAutoSave] Restart failed:", err)
+          } finally {
+            setSaving(false)
+          }
         } catch (err) {
           setSaving(false)
           logger.error("[useAutoSave] Save failed:", err)

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -84,8 +84,14 @@ export function AuthSettingsScreen({}: ScreenProps) {
   const headerEntries = Object.entries(config.customHeaders)
 
   const addHeader = useCallback(() => {
+    // Use a unique placeholder key to avoid overwriting existing empty entries
+    let key = ""
+    let i = 1
+    while (key in config.customHeaders) {
+      key = `Header-${i++}`
+    }
     updateConfig({
-      customHeaders: { ...config.customHeaders, "": "" }
+      customHeaders: { ...config.customHeaders, [key]: "" }
     })
   }, [config, updateConfig])
 

--- a/apps/mobile/src/screens/ExportDataScreen.tsx
+++ b/apps/mobile/src/screens/ExportDataScreen.tsx
@@ -58,7 +58,7 @@ export function ExportDataScreen() {
 
     const content = EXPORT_FORMATS[selectedFormat].convert(cachedData.current)
     setFileSize(formatBytes(getByteSize(content)))
-  }, [selectedFormat])
+  }, [selectedFormat, stats.totalLocations])
 
   const handleExport = async (format: ExportFormat) => {
     if (stats.totalLocations === 0) {
@@ -125,14 +125,6 @@ export function ExportDataScreen() {
       } catch (shareError: any) {
         logger.warn("[ExportDataScreen] Share error:", shareError)
       }
-
-      setTimeout(async () => {
-        try {
-          await NativeLocationService.deleteFile(filePath)
-        } catch (err) {
-          logger.warn("[ExportDataScreen] Failed to cleanup temp file:", err)
-        }
-      }, 2000)
     } catch (error) {
       logger.error("[ExportDataScreen] Export failed:", error)
       Alert.alert("Export Failed", "Unable to export your data. Please try again.")

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -64,7 +64,8 @@ class NativeLocationService {
       accuracyThreshold: settings.accuracyThreshold,
       isOfflineMode: settings.isOfflineMode,
       isWifiOnlySync: settings.isWifiOnlySync,
-      httpMethod: settings.httpMethod
+      httpMethod: settings.httpMethod,
+      customFields: Object.fromEntries(settings.customFields.filter((f) => f.key).map((f) => [f.key, f.value]))
     }
 
     logger.debug(

--- a/apps/mobile/src/utils/exportConverters.ts
+++ b/apps/mobile/src/utils/exportConverters.ts
@@ -19,7 +19,17 @@ export const getByteSize = (content: string): number => {
   let bytes = 0
   for (let i = 0; i < content.length; i++) {
     const code = content.charCodeAt(i)
-    bytes += code <= 0x7f ? 1 : code <= 0x7ff ? 2 : 3
+    if (code <= 0x7f) {
+      bytes += 1
+    } else if (code <= 0x7ff) {
+      bytes += 2
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate — pair encodes a 4-byte UTF-8 character
+      bytes += 4
+      i++ // skip the low surrogate
+    } else {
+      bytes += 3
+    }
   }
   return bytes
 }


### PR DESCRIPTION
- Fix false "synced" indicator in SyncManager (counted permanently failed items as success)
- Add @Volatile to SyncManager config fields for thread-safe reads
- Fix delayed visual feedback on SyncStrategySettings grid/toggle buttons by separating local state updates from persistence (updateSettingsLocal)
- Add ongoing battery critical check during tracking (stops service if <5%)
- Reduce stats polling from 3s to 30s when not actively tracking
- Fix TrackMap center button always showing centered state
- Remove redundant JS-side export file cleanup (native shareFile handles it)
- Fix double-persist on SyncStrategySettings numeric inputs and grid select
- Fix getByteSize surrogate pair handling for accurate export file size
- Add file size preview dependency on totalLocations in ExportDataScreen
- Remove dead isZoneChange logic from LocationForegroundService
- Wrap GeofenceHelper.getGeofencesAsArray in try-catch
- Minor hardening: TimedCache generics, DatabaseHelper cursor safety, LocationServiceModule null checks, ServiceConfig defaults