### PR TITLE
Fix notification bugs and extract NotificationHelper

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,12 +33,12 @@ jobs:
       - run: npx -w @colota/mobile tsc --noEmit
       - run: npm test -w @colota/mobile
 
-  build-and-release:
-    name: Build & Publish Release
+  build:
+    name: Build Release APKs
     needs: test
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout code
@@ -114,16 +114,13 @@ jobs:
             -Pandroid.useAndroidX=true \
             -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=512m"
 
-      - name: Publish to GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload APKs
+        uses: actions/upload-artifact@v4
         with:
-          files: |
-            apps/mobile/android/app/build/outputs/apk/gms/release/app-gms-arm64-v8a-release.apk
-            apps/mobile/android/app/build/outputs/apk/gms/release/app-gms-armeabi-v7a-release.apk
-            apps/mobile/android/app/build/outputs/apk/foss/release/app-foss-arm64-v8a-release.apk
-            apps/mobile/android/app/build/outputs/apk/foss/release/app-foss-armeabi-v7a-release.apk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: release-apks
+          path: |
+            apps/mobile/android/app/build/outputs/apk/gms/release/*.apk
+            apps/mobile/android/app/build/outputs/apk/foss/release/*.apk
 
       - name: Secure Cleanup
         if: always()

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -83,10 +83,19 @@ Each flavor provides a `LocationProviderFactory` that returns the correct implem
 An Android foreground service that runs continuously for GPS tracking. Manages:
 
 - GPS location capture via the `LocationProvider` abstraction
-- Foreground notification (required by Android)
 - Pause zone detection (geofencing)
+- Battery critical shutdown (1-4% while discharging)
 - Location accuracy filtering
 - Queuing data for server sync
+
+### NotificationHelper
+
+Handles all notification logic for the tracking service:
+
+- Channel creation and notification building
+- Status text generation (coordinates, sync status, pause zones)
+- Throttled updates (10s minimum interval, 2m minimum movement)
+- Deduplication to avoid unnecessary notification redraws
 
 ### DatabaseHelper
 

--- a/apps/docs/docs/development/local-setup.md
+++ b/apps/docs/docs/development/local-setup.md
@@ -111,7 +111,7 @@ colota/
 │   │   │   └── app/src/
 │   │   │       ├── main/java/com/colota/
 │   │   │       │   ├── bridge/      # React Native bridge
-│   │   │       │   ├── service/     # Foreground service & config
+│   │   │       │   ├── service/     # Foreground service, config & notifications
 │   │   │       │   ├── data/        # SQLite & geofencing
 │   │   │       │   ├── sync/        # Network sync & payloads
 │   │   │       │   ├── util/        # Helpers & encryption
@@ -165,7 +165,8 @@ Test files are located in `apps/mobile/android/app/src/test/java/com/Colota/`. T
 - **DatabaseHelper** — Data model, cutoff calculations, batch operations
 - **SecureStorageHelper** — Basic Auth, Bearer token, custom headers, JSON parsing
 - **DeviceInfoHelper** — Battery threshold logic, status code mapping, percentage calculation
-- **LocationForegroundService** — Notification throttling, sync formatting, zone state machine, battery shutdown
+- **NotificationHelper** — Status text generation, throttling, movement filter, deduplication
+- **LocationForegroundService** — Battery shutdown, accuracy filtering, zone state machine
 - **ServiceConfig** — Database/Intent/ReadableMap parsing, defaults, round-trips
 - **PayloadBuilder** — JSON payload construction and field map parsing
 - **GeofenceHelper** — Haversine distance calculations and radius checks

--- a/apps/mobile/android/app/src/main/java/com/colota/service/NotificationHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/NotificationHelper.kt
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+package com.Colota.service
+
+import android.app.*
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.Colota.MainActivity
+import java.util.Locale
+
+/**
+ * Handles all notification-related logic for the location tracking service:
+ * channel creation, notification building, status text generation,
+ * throttling, movement filtering, and deduplication.
+ */
+class NotificationHelper(
+    private val context: Context,
+    private val notificationManager: NotificationManager
+) {
+
+    private var lastText: String? = null
+    private var lastUpdateTime: Long = 0
+    private var lastCoords: Pair<Double, Double>? = null
+    private var lastQueuedCount: Int = 0
+
+    companion object {
+        const val CHANNEL_ID = "location_service_channel"
+        const val NOTIFICATION_ID = 1
+        const val THROTTLE_MS = 10000L
+        const val MIN_MOVEMENT_METERS = 2f
+    }
+
+    fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Location Tracking",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Shows active tracking status and sync queue"
+                setShowBadge(false)
+            }
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    fun buildTrackingNotification(statusText: String): Notification {
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle("Colota Tracking")
+            .setContentText(statusText)
+            .setSmallIcon(android.R.drawable.ic_menu_mylocation)
+            .setOngoing(true)
+            .setSilent(true)
+            .setContentIntent(pendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+    }
+
+    fun buildStoppedNotification(reason: String): Notification {
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle("Colota: Stopped")
+            .setContentText(reason)
+            .setSmallIcon(android.R.drawable.ic_lock_power_off)
+            .setOngoing(false)
+            .setAutoCancel(true)
+            .build()
+    }
+
+    /**
+     * Returns the best status text for the initial startForeground notification.
+     */
+    fun getInitialStatus(
+        insidePauseZone: Boolean,
+        currentZoneName: String?,
+        lastKnownLocation: android.location.Location?
+    ): String = when {
+        insidePauseZone -> "Paused: ${currentZoneName ?: "Unknown"}"
+        lastKnownLocation != null -> String.format(
+            Locale.US, "%.5f, %.5f",
+            lastKnownLocation.latitude, lastKnownLocation.longitude
+        )
+        else -> "Searching GPS..."
+    }
+
+    /**
+     * Builds the notification status text from current tracking state.
+     */
+    fun buildStatusText(
+        isPaused: Boolean,
+        zoneName: String?,
+        lat: Double?,
+        lon: Double?,
+        queuedCount: Int,
+        lastSyncTime: Long
+    ): String = when {
+        isPaused -> "Paused: ${zoneName ?: "Unknown"}"
+        lat != null && lon != null -> {
+            val coords = String.format(Locale.US, "%.5f, %.5f", lat, lon)
+            if (queuedCount > 0 && lastSyncTime > 0) {
+                "$coords (Queued: $queuedCount · ${formatTimeSinceSync(lastSyncTime)})"
+            } else if (queuedCount > 0) {
+                "$coords (Queued: $queuedCount)"
+            } else if (lastSyncTime > 0) {
+                "$coords (Synced)"
+            } else {
+                coords
+            }
+        }
+        else -> "Searching GPS..."
+    }
+
+    /**
+     * Formats elapsed time since last successful sync.
+     */
+    fun formatTimeSinceSync(lastSyncTime: Long, now: Long = System.currentTimeMillis()): String {
+        if (lastSyncTime == 0L) return "Never"
+
+        val elapsedMs = now - lastSyncTime
+        val elapsedMinutes = (elapsedMs / 60000).toInt()
+
+        return when {
+            elapsedMinutes < 1 -> "Just now"
+            elapsedMinutes == 1 -> "1 min ago"
+            elapsedMinutes < 60 -> "$elapsedMinutes min ago"
+            elapsedMinutes < 120 -> "1h ago"
+            else -> "${elapsedMinutes / 60} h ago"
+        }
+    }
+
+    /** Returns true if the update should be suppressed (too soon since last update). */
+    fun shouldThrottle(now: Long): Boolean = (now - lastUpdateTime) < THROTTLE_MS
+
+    /** Returns true if movement is below the minimum threshold. */
+    fun shouldFilterByMovement(distanceMeters: Float): Boolean = distanceMeters < MIN_MOVEMENT_METERS
+
+    /**
+     * Full notification update with throttle, movement filter, and dedup.
+     * Returns true if the notification was actually posted.
+     */
+    fun update(
+        lat: Double? = null,
+        lon: Double? = null,
+        isPaused: Boolean = false,
+        zoneName: String? = null,
+        queuedCount: Int = 0,
+        lastSyncTime: Long = 0L,
+        forceUpdate: Boolean = false
+    ): Boolean {
+        val now = System.currentTimeMillis()
+
+        val queueCountChanged = queuedCount != lastQueuedCount
+
+        // Throttle + movement filter (zone changes always pass forceUpdate=true)
+        // Bypass movement filter when queue count changed so status text stays current
+        if (!forceUpdate && !queueCountChanged && lat != null && lon != null) {
+            if (shouldThrottle(now)) return false
+
+            val prev = lastCoords
+            if (prev != null) {
+                val distance = FloatArray(1)
+                android.location.Location.distanceBetween(
+                    prev.first, prev.second, lat, lon, distance
+                )
+                if (shouldFilterByMovement(distance[0])) return false
+            }
+        }
+
+        lastUpdateTime = now
+        if (lat != null && lon != null) {
+            lastCoords = Pair(lat, lon)
+        }
+
+        val statusText = buildStatusText(isPaused, zoneName, lat, lon, queuedCount, lastSyncTime)
+
+        // Dedup: skip if notification text hasn't changed
+        val cacheKey = "$statusText-$queuedCount"
+        if (cacheKey == lastText) return false
+
+        lastText = cacheKey
+        lastQueuedCount = queuedCount
+        notificationManager.notify(NOTIFICATION_ID, buildTrackingNotification(statusText))
+        return true
+    }
+}

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -2,203 +2,18 @@ package com.Colota.service
 
 import org.junit.Assert.*
 import org.junit.Test
-import java.util.Locale
 
 /**
  * Tests for LocationForegroundService's pure logic:
- * - Notification throttling decisions
- * - Time-since-last-sync formatting
- * - Notification status text generation
  * - Battery critical shutdown conditions during tracking
+ * - Accuracy filter decisions
+ * - Zone transition state machine
  *
+ * Notification logic tests are in NotificationHelperTest.
  * The actual Android Service lifecycle and LocationProvider interactions
  * are not tested here (require instrumented tests).
  */
 class LocationForegroundServiceTest {
-
-    // --- Notification throttle logic ---
-
-    @Test
-    fun `notification updates within 10s are throttled`() {
-        val lastUpdate = 1000L
-        val now = 5000L
-        val throttleMs = 10000L
-
-        val shouldThrottle = (now - lastUpdate) < throttleMs
-        assertTrue(shouldThrottle)
-    }
-
-    @Test
-    fun `notification updates after 10s are allowed`() {
-        val lastUpdate = 1000L
-        val now = 12000L
-        val throttleMs = 10000L
-
-        val shouldThrottle = (now - lastUpdate) < throttleMs
-        assertFalse(shouldThrottle)
-    }
-
-    @Test
-    fun `notification updates at exactly 10s are allowed`() {
-        val lastUpdate = 1000L
-        val now = 11000L
-        val throttleMs = 10000L
-
-        val shouldThrottle = (now - lastUpdate) < throttleMs
-        assertFalse(shouldThrottle)
-    }
-
-    // --- Movement filter logic ---
-
-    @Test
-    fun `movement less than 2m is filtered`() {
-        val distanceMeters = 1.5f
-        val shouldFilter = distanceMeters < 2
-        assertTrue(shouldFilter)
-    }
-
-    @Test
-    fun `movement of exactly 2m is not filtered`() {
-        val distanceMeters = 2.0f
-        val shouldFilter = distanceMeters < 2
-        assertFalse(shouldFilter)
-    }
-
-    @Test
-    fun `movement greater than 2m is not filtered`() {
-        val distanceMeters = 5.0f
-        val shouldFilter = distanceMeters < 2
-        assertFalse(shouldFilter)
-    }
-
-    // --- getTimeSinceLastSync formatting ---
-
-    @Test
-    fun `time since sync shows Never when no sync happened`() {
-        assertEquals("Never", formatTimeSinceSync(lastSyncTime = 0L, now = 1000L))
-    }
-
-    @Test
-    fun `time since sync shows Just now for less than 1 min`() {
-        val now = 100000L
-        val lastSync = now - 30000L // 30 seconds ago
-        assertEquals("Just now", formatTimeSinceSync(lastSync, now))
-    }
-
-    @Test
-    fun `time since sync shows 1 min ago`() {
-        val now = 100000L
-        val lastSync = now - 60000L // exactly 1 minute
-        assertEquals("1 min ago", formatTimeSinceSync(lastSync, now))
-    }
-
-    @Test
-    fun `time since sync shows N min ago for less than 1 hour`() {
-        val now = 100000L
-        val lastSync = now - 1500000L // 25 minutes
-        assertEquals("25 min ago", formatTimeSinceSync(lastSync, now))
-    }
-
-    @Test
-    fun `time since sync shows 1h ago for 60-119 minutes`() {
-        val now = 10000000L
-        val lastSync = now - 3600000L // 60 minutes
-        assertEquals("1h ago", formatTimeSinceSync(lastSync, now))
-    }
-
-    @Test
-    fun `time since sync shows Nh ago for 120+ minutes`() {
-        val now = 10000000L
-        val lastSync = now - 7200000L // 120 minutes
-        assertEquals("2 h ago", formatTimeSinceSync(lastSync, now))
-    }
-
-    @Test
-    fun `time since sync shows 5h ago for 300 minutes`() {
-        val now = 100000000L
-        val lastSync = now - 18000000L // 300 minutes
-        assertEquals("5 h ago", formatTimeSinceSync(lastSync, now))
-    }
-
-    // --- Notification status text generation ---
-
-    @Test
-    fun `status text shows Paused with zone name when in pause zone`() {
-        val text = buildStatusText(
-            isPaused = true,
-            zoneName = "Home",
-            lat = 52.0,
-            lon = 13.0,
-            queuedCount = 0,
-            lastSyncTime = 0L
-        )
-        assertEquals("Paused: Home", text)
-    }
-
-    @Test
-    fun `status text shows Paused Unknown when zone name is null`() {
-        val text = buildStatusText(
-            isPaused = true,
-            zoneName = null,
-            lat = 52.0,
-            lon = 13.0,
-            queuedCount = 0,
-            lastSyncTime = 0L
-        )
-        assertEquals("Paused: Unknown", text)
-    }
-
-    @Test
-    fun `status text shows coordinates when tracking normally`() {
-        val text = buildStatusText(
-            isPaused = false,
-            zoneName = null,
-            lat = 52.51630,
-            lon = 13.37770,
-            queuedCount = 0,
-            lastSyncTime = 0L
-        )
-        assertEquals("52.51630, 13.37770", text)
-    }
-
-    @Test
-    fun `status text shows Synced when queue empty and has synced`() {
-        val text = buildStatusText(
-            isPaused = false,
-            zoneName = null,
-            lat = 52.0,
-            lon = 13.0,
-            queuedCount = 0,
-            lastSyncTime = System.currentTimeMillis()
-        )
-        assertEquals("52.00000, 13.00000 (Synced)", text)
-    }
-
-    @Test
-    fun `status text shows queued count when has queue but never synced`() {
-        val text = buildStatusText(
-            isPaused = false,
-            zoneName = null,
-            lat = 52.0,
-            lon = 13.0,
-            queuedCount = 15,
-            lastSyncTime = 0L
-        )
-        assertEquals("52.00000, 13.00000 (Queued: 15)", text)
-    }
-
-    @Test
-    fun `status text shows Searching GPS when no coordinates`() {
-        val text = buildStatusText(
-            isPaused = false,
-            zoneName = null,
-            lat = null,
-            lon = null,
-            queuedCount = 0,
-            lastSyncTime = 0L
-        )
-        assertEquals("Searching GPS...", text)
-    }
 
     // --- Battery critical during tracking (handleLocationUpdate logic) ---
 
@@ -321,75 +136,9 @@ class LocationForegroundServiceTest {
         assertTrue(shouldReEnter)
     }
 
-    // --- Deduplication logic ---
-
-    @Test
-    fun `same notification text is deduplicated`() {
-        val lastText = "52.52000, 13.40500-3"
-        val newText = "52.52000, 13.40500-3"
-        assertFalse(shouldUpdateNotification(lastText, newText))
-    }
-
-    @Test
-    fun `different notification text is not deduplicated`() {
-        val lastText = "52.52000, 13.40500-3"
-        val newText = "52.52100, 13.40600-3"
-        assertTrue(shouldUpdateNotification(lastText, newText))
-    }
-
-    @Test
-    fun `first notification update always proceeds`() {
-        assertTrue(shouldUpdateNotification(null, "52.52000, 13.40500-0"))
-    }
-
     // --- Helper methods replicating logic under test ---
-
-    private fun formatTimeSinceSync(lastSyncTime: Long, now: Long): String {
-        if (lastSyncTime == 0L) return "Never"
-
-        val elapsedMs = now - lastSyncTime
-        val elapsedMinutes = (elapsedMs / 60000).toInt()
-
-        return when {
-            elapsedMinutes < 1 -> "Just now"
-            elapsedMinutes == 1 -> "1 min ago"
-            elapsedMinutes < 60 -> "$elapsedMinutes min ago"
-            elapsedMinutes < 120 -> "1h ago"
-            else -> "${elapsedMinutes / 60} h ago"
-        }
-    }
-
-    private fun buildStatusText(
-        isPaused: Boolean,
-        zoneName: String?,
-        lat: Double?,
-        lon: Double?,
-        queuedCount: Int,
-        lastSyncTime: Long
-    ): String {
-        return when {
-            isPaused -> "Paused: ${zoneName ?: "Unknown"}"
-            lat != null && lon != null -> {
-                val coords = String.format(Locale.US, "%.5f, %.5f", lat, lon)
-                if (queuedCount > 0 && lastSyncTime > 0) {
-                    "$coords (Last sync: ${formatTimeSinceSync(lastSyncTime, System.currentTimeMillis())})"
-                } else if (queuedCount > 0) {
-                    "$coords (Queued: $queuedCount)"
-                } else if (lastSyncTime > 0) {
-                    "$coords (Synced)"
-                } else {
-                    coords
-                }
-            }
-            else -> "Searching GPS..."
-        }
-    }
 
     private fun shouldStopForBattery(battery: Int, batteryStatus: Int): Boolean {
         return battery in 1..4 && batteryStatus == 1
-    }
-
-    private fun shouldUpdateNotification(lastText: String?, newText: String): Boolean {
-        return newText != lastText
     }
 }

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/NotificationHelperTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/NotificationHelperTest.kt
@@ -1,0 +1,226 @@
+package com.Colota.service
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Tests for NotificationHelper's pure logic:
+ * - Status text generation (all branches)
+ * - Time-since-last-sync formatting
+ * - Throttle decisions
+ * - Movement filter decisions
+ * - Deduplication
+ * - Initial status text
+ */
+class NotificationHelperTest {
+
+    // --- formatTimeSinceSync ---
+
+    @Test
+    fun `time since sync shows Never when no sync happened`() {
+        assertEquals("Never", formatTimeSinceSync(lastSyncTime = 0L, now = 1000L))
+    }
+
+    @Test
+    fun `time since sync shows Just now for less than 1 min`() {
+        val now = 100000L
+        val lastSync = now - 30000L
+        assertEquals("Just now", formatTimeSinceSync(lastSync, now))
+    }
+
+    @Test
+    fun `time since sync shows 1 min ago`() {
+        val now = 100000L
+        val lastSync = now - 60000L
+        assertEquals("1 min ago", formatTimeSinceSync(lastSync, now))
+    }
+
+    @Test
+    fun `time since sync shows N min ago for less than 1 hour`() {
+        val now = 100000L
+        val lastSync = now - 1500000L
+        assertEquals("25 min ago", formatTimeSinceSync(lastSync, now))
+    }
+
+    @Test
+    fun `time since sync shows 1h ago for 60-119 minutes`() {
+        val now = 10000000L
+        val lastSync = now - 3600000L
+        assertEquals("1h ago", formatTimeSinceSync(lastSync, now))
+    }
+
+    @Test
+    fun `time since sync shows Nh ago for 120+ minutes`() {
+        val now = 10000000L
+        val lastSync = now - 7200000L
+        assertEquals("2 h ago", formatTimeSinceSync(lastSync, now))
+    }
+
+    @Test
+    fun `time since sync shows 5h ago for 300 minutes`() {
+        val now = 100000000L
+        val lastSync = now - 18000000L
+        assertEquals("5 h ago", formatTimeSinceSync(lastSync, now))
+    }
+
+    // --- buildStatusText ---
+
+    @Test
+    fun `status text shows Paused with zone name`() {
+        val text = buildStatusText(true, "Home", 52.0, 13.0, 0, 0L)
+        assertEquals("Paused: Home", text)
+    }
+
+    @Test
+    fun `status text shows Paused Unknown when zone name is null`() {
+        val text = buildStatusText(true, null, 52.0, 13.0, 0, 0L)
+        assertEquals("Paused: Unknown", text)
+    }
+
+    @Test
+    fun `status text shows coordinates when tracking normally`() {
+        val text = buildStatusText(false, null, 52.51630, 13.37770, 0, 0L)
+        assertEquals("52.51630, 13.37770", text)
+    }
+
+    @Test
+    fun `status text shows Synced when queue empty and has synced`() {
+        val text = buildStatusText(false, null, 52.0, 13.0, 0, System.currentTimeMillis())
+        assertEquals("52.00000, 13.00000 (Synced)", text)
+    }
+
+    @Test
+    fun `status text shows queued count when never synced`() {
+        val text = buildStatusText(false, null, 52.0, 13.0, 15, 0L)
+        assertEquals("52.00000, 13.00000 (Queued: 15)", text)
+    }
+
+    @Test
+    fun `status text shows queued count and last sync when both present`() {
+        val now = System.currentTimeMillis()
+        val text = buildStatusText(false, null, 52.0, 13.0, 7, now - 30000L)
+        assertEquals("52.00000, 13.00000 (Queued: 7 · Just now)", text)
+    }
+
+    @Test
+    fun `status text shows Searching GPS when no coordinates`() {
+        val text = buildStatusText(false, null, null, null, 0, 0L)
+        assertEquals("Searching GPS...", text)
+    }
+
+    @Test
+    fun `status text uses locale-safe coordinate formatting`() {
+        // Verifies no comma-separated decimals on non-US locales
+        val text = buildStatusText(false, null, -33.86882, 151.20930, 0, 0L)
+        assertTrue(text.contains("-33.86882"))
+        assertTrue(text.contains("151.20930"))
+        assertFalse(text.contains(",209"))  // Would appear with German locale
+    }
+
+    @Test
+    fun `paused takes priority over coordinates`() {
+        val text = buildStatusText(true, "Office", 52.0, 13.0, 5, System.currentTimeMillis())
+        assertEquals("Paused: Office", text)
+    }
+
+    // --- shouldThrottle ---
+
+    @Test
+    fun `throttle suppresses within 10s`() {
+        assertTrue(shouldThrottle(lastUpdateTime = 1000L, now = 5000L))
+    }
+
+    @Test
+    fun `throttle allows after 10s`() {
+        assertFalse(shouldThrottle(lastUpdateTime = 1000L, now = 12000L))
+    }
+
+    @Test
+    fun `throttle allows at exactly 10s`() {
+        assertFalse(shouldThrottle(lastUpdateTime = 1000L, now = 11000L))
+    }
+
+    // --- shouldFilterByMovement ---
+
+    @Test
+    fun `movement less than 2m is filtered`() {
+        assertTrue(shouldFilterByMovement(1.5f))
+    }
+
+    @Test
+    fun `movement of exactly 2m is not filtered`() {
+        assertFalse(shouldFilterByMovement(2.0f))
+    }
+
+    @Test
+    fun `movement greater than 2m is not filtered`() {
+        assertFalse(shouldFilterByMovement(5.0f))
+    }
+
+    // --- Deduplication ---
+
+    @Test
+    fun `same cache key is deduplicated`() {
+        assertFalse(shouldUpdate("52.52000, 13.40500-3", "52.52000, 13.40500-3"))
+    }
+
+    @Test
+    fun `different cache key is not deduplicated`() {
+        assertTrue(shouldUpdate("52.52000, 13.40500-3", "52.52100, 13.40600-3"))
+    }
+
+    @Test
+    fun `first update always proceeds`() {
+        assertTrue(shouldUpdate(null, "52.52000, 13.40500-0"))
+    }
+
+    @Test
+    fun `queue count change triggers update even if text same`() {
+        assertTrue(shouldUpdate("52.00000, 13.00000 (Synced)-0", "52.00000, 13.00000 (Synced)-5"))
+    }
+
+    // --- Helper methods that mirror NotificationHelper logic ---
+
+    private fun formatTimeSinceSync(lastSyncTime: Long, now: Long): String {
+        if (lastSyncTime == 0L) return "Never"
+        val elapsedMs = now - lastSyncTime
+        val elapsedMinutes = (elapsedMs / 60000).toInt()
+        return when {
+            elapsedMinutes < 1 -> "Just now"
+            elapsedMinutes == 1 -> "1 min ago"
+            elapsedMinutes < 60 -> "$elapsedMinutes min ago"
+            elapsedMinutes < 120 -> "1h ago"
+            else -> "${elapsedMinutes / 60} h ago"
+        }
+    }
+
+    private fun buildStatusText(
+        isPaused: Boolean, zoneName: String?,
+        lat: Double?, lon: Double?,
+        queuedCount: Int, lastSyncTime: Long
+    ): String = when {
+        isPaused -> "Paused: ${zoneName ?: "Unknown"}"
+        lat != null && lon != null -> {
+            val coords = String.format(java.util.Locale.US, "%.5f, %.5f", lat, lon)
+            if (queuedCount > 0 && lastSyncTime > 0) {
+                "$coords (Queued: $queuedCount · ${formatTimeSinceSync(lastSyncTime, System.currentTimeMillis())})"
+            } else if (queuedCount > 0) {
+                "$coords (Queued: $queuedCount)"
+            } else if (lastSyncTime > 0) {
+                "$coords (Synced)"
+            } else {
+                coords
+            }
+        }
+        else -> "Searching GPS..."
+    }
+
+    private fun shouldThrottle(lastUpdateTime: Long, now: Long): Boolean =
+        (now - lastUpdateTime) < NotificationHelper.THROTTLE_MS
+
+    private fun shouldFilterByMovement(distance: Float): Boolean =
+        distance < NotificationHelper.MIN_MOVEMENT_METERS
+
+    private fun shouldUpdate(lastText: String?, newText: String): Boolean =
+        newText != lastText
+}


### PR DESCRIPTION
- Fix "Searching GPS..." flash on manual flush/zone actions by skipping notification reset for lightweight service actions
- Fix stale queue count after clearing queue by adding ACTION_REFRESH_NOTIFICATION to invalidate cache
- Fix locale-dependent coordinate formatting (commas on German locales)
- Show queue count alongside last sync time instead of hiding it
- Bypass movement filter when queue count changes so updates aren't suppressed while stationary
- Extract NotificationHelper from LocationForegroundService for single-responsibility and direct testability
- Add NotificationHelperTest (26 tests), slim LocationForegroundServiceTest to service-only logic (14 tests)
- Update architecture and local-setup docs
- Replace auto-publish with upload-artifact in build workflow