### PR TITLE
Remove unused geofence enabled field and add success feedback

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
@@ -360,16 +360,15 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun updateGeofence(
-        id: Int, 
-        name: String?, 
-        lat: Double?, 
-        lon: Double?, 
-        radius: Double?, 
-        enabled: Boolean?, 
-        pause: Boolean?, 
+        id: Int,
+        name: String?,
+        lat: Double?,
+        lon: Double?,
+        radius: Double?,
+        pause: Boolean?,
         promise: Promise
-    ) = executeAsync(promise) { 
-        val result = geofenceHelper.updateGeofence(id, name, lat, lon, radius, enabled, pause)
+    ) = executeAsync(promise) {
+        val result = geofenceHelper.updateGeofence(id, name, lat, lon, radius, pause)
         if (result) {
             geofenceHelper.invalidateCache() 
             triggerZoneRecheck()

--- a/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
@@ -96,6 +96,8 @@ class DatabaseHelper private constructor(context: Context) :
             )
         """)
 
+        // TODO: Remove unused columns (enabled, notify_enter, notify_exit) in a future
+        // DB version migration. They are no longer read or written by application code.
         db.execSQL("""
             CREATE TABLE $TABLE_GEOFENCES (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -284,7 +284,6 @@ class NativeLocationService {
       update.lat ?? null,
       update.lon ?? null,
       update.radius ?? null,
-      update.enabled ?? null,
       update.pauseTracking ?? null
     )
   }

--- a/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
+++ b/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
@@ -237,7 +237,6 @@ describe("NativeLocationService", () => {
         lat: 48.1,
         lon: 11.5,
         radius: 100,
-        enabled: true,
         pauseTracking: true
       })
 

--- a/apps/mobile/src/types/global.ts
+++ b/apps/mobile/src/types/global.ts
@@ -35,7 +35,6 @@ export interface Geofence {
   lat: number
   lon: number
   radius: number
-  enabled: boolean
   pauseTracking: boolean
   createdAt?: number
 }


### PR DESCRIPTION
Stop reading/writing the enabled column across Kotlin and TypeScript layers (column kept in DB schema for future migration). Add FloatingSaveIndicator feedback on geofence create/delete.