### PR TITLE
Fix custom fields missing from payload and settings restart behavior

### DIFF
--- a/apps/mobile/src/hooks/useLocationTracking.ts
+++ b/apps/mobile/src/hooks/useLocationTracking.ts
@@ -230,6 +230,13 @@ export function useLocationTracking(settings: Settings): LocationTrackingResult 
    */
   const restartTracking = useCallback(
     async (newSettings?: Settings) => {
+      // Only restart if tracking is active — settings are persisted separately,
+      // so they'll be picked up when the user starts tracking later.
+      if (!isTrackingRef.current) {
+        logger.debug("[useLocationTracking] Not tracking, skip restart (settings saved separately)")
+        return
+      }
+
       if (restartingRef.current) {
         logger.debug("[useLocationTracking] Restart already in progress, queuing")
         restartQueuedRef.current = true


### PR DESCRIPTION
Custom fields were silently dropped because parseCustomFields only handled the JSON array format from the DB, not the flat object format passed via Intent from the React Native bridge.

Also prevent settings changes from restarting tracking when the service isn't running, which would trigger unnecessary permission requests.