### PR TITLE
Fix cleared queue items falsely counting as sent

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
@@ -248,6 +248,13 @@ class SyncManager(
                 val toRemove = successfulIds + permanentlyFailedIds
                 if (toRemove.isNotEmpty()) {
                     dbHelper.removeBatchFromQueue(toRemove)
+
+                    // Delete locations of permanently failed items (never sent)
+                    val failedLocationIds = chunk
+                        .filter { it.queueId in permanentlyFailedIds }
+                        .map { it.locationId }
+                    dbHelper.deleteLocations(failedLocationIds)
+
                     totalProcessed += toRemove.size
                     totalSucceeded += successfulIds.size
                     totalFailed += permanentlyFailedIds.size


### PR DESCRIPTION
When clearing the queue or discarding permanently failed items, the corresponding location records are now also removed from the locations table. Previously they stayed behind and inflated the "sent" count since getSentCount = total - queued.