### PR TITLE
Fix Android Auto not triggering driving profile

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -174,6 +174,7 @@ dependencies {
     gmsImplementation 'com.google.android.gms:play-services-location:21.0.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'androidx.security:security-crypto:1.1.0'
+    implementation 'androidx.car.app:app:1.7.0'
     
       if (isHermesEnabled) {
         implementation("com.facebook.react:hermes-android")

--- a/apps/mobile/android/app/src/main/java/com/colota/service/ConditionMonitor.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/ConditionMonitor.kt
@@ -5,21 +5,26 @@
 
 package com.Colota.service
 
-import android.app.UiModeManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.res.Configuration
 import android.os.BatteryManager
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
+import androidx.car.app.connection.CarConnection
+import androidx.lifecycle.Observer
 import com.Colota.BuildConfig
 
 /**
- * Monitors device conditions (charging state, Android Auto / car mode)
+ * Monitors device conditions (charging state, Android Auto connection)
  * and notifies ProfileManager when conditions change.
  *
- * All receivers are registered programmatically so they only run while
+ * Android Auto is detected via the [CarConnection] API, which reliably
+ * reports projection and native car connections.
+ *
+ * All observers are registered programmatically so they only run while
  * the foreground service is active.
  */
 class ConditionMonitor(
@@ -31,29 +36,29 @@ class ConditionMonitor(
     }
 
     private var chargingReceiver: BroadcastReceiver? = null
-    private var carModeReceiver: BroadcastReceiver? = null
+    private var carConnection: CarConnection? = null
+    private var carConnectionObserver: Observer<Int>? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     fun start() {
-        // Unregister first to prevent duplicate receivers on repeated start() calls
+        // Unregister first to prevent duplicate observers on repeated start() calls
         stop()
 
         registerChargingMonitor()
-        registerCarModeMonitor()
+        startCarConnectionMonitor()
 
-        // Read initial states
+        // Read initial charging state
         val charging = readCurrentChargingState()
-        val carMode = readCurrentCarModeState()
         profileManager.onChargingStateChanged(charging)
-        profileManager.onCarModeStateChanged(carMode)
 
         if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Condition monitors started — charging: $charging, carMode: $carMode")
+            Log.d(TAG, "Condition monitors started — charging: $charging")
         }
     }
 
     fun stop() {
         chargingReceiver = unregisterSafely(chargingReceiver)
-        carModeReceiver = unregisterSafely(carModeReceiver)
+        stopCarConnectionMonitor()
 
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Condition monitors stopped")
@@ -90,33 +95,34 @@ class ConditionMonitor(
         context.registerReceiver(chargingReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
     }
 
-    private fun registerCarModeMonitor() {
-        carModeReceiver = object : BroadcastReceiver() {
-            override fun onReceive(context: Context, intent: Intent) {
-                when (intent.action) {
-                    UiModeManager.ACTION_ENTER_CAR_MODE -> {
-                        if (BuildConfig.DEBUG) Log.d(TAG, "Car mode entered")
-                        profileManager.onCarModeStateChanged(true)
-                    }
-                    UiModeManager.ACTION_EXIT_CAR_MODE -> {
-                        if (BuildConfig.DEBUG) Log.d(TAG, "Car mode exited")
-                        profileManager.onCarModeStateChanged(false)
-                    }
-                    Intent.ACTION_CONFIGURATION_CHANGED -> {
-                        val isCarMode = readCurrentCarModeState()
-                        if (BuildConfig.DEBUG) Log.d(TAG, "Configuration changed - carMode: $isCarMode")
-                        profileManager.onCarModeStateChanged(isCarMode)
-                    }
-                }
+    private fun startCarConnectionMonitor() {
+        val connection = CarConnection(context)
+        carConnection = connection
+
+        val observer = Observer<Int> { connectionType ->
+            val connected = connectionType != CarConnection.CONNECTION_TYPE_NOT_CONNECTED
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "CarConnection type: $connectionType (connected: $connected)")
             }
+            profileManager.onCarModeStateChanged(connected)
+        }
+        carConnectionObserver = observer
+
+        mainHandler.post {
+            connection.type.observeForever(observer)
+        }
+    }
+
+    private fun stopCarConnectionMonitor() {
+        val observer = carConnectionObserver ?: return
+        val connection = carConnection ?: return
+
+        mainHandler.post {
+            connection.type.removeObserver(observer)
         }
 
-        val filter = IntentFilter().apply {
-            addAction(UiModeManager.ACTION_ENTER_CAR_MODE)
-            addAction(UiModeManager.ACTION_EXIT_CAR_MODE)
-            addAction(Intent.ACTION_CONFIGURATION_CHANGED)
-        }
-        context.registerReceiver(carModeReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        carConnectionObserver = null
+        carConnection = null
     }
 
     private fun readCurrentChargingState(): Boolean {
@@ -124,10 +130,5 @@ class ConditionMonitor(
         val status = batteryIntent?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
         return status == BatteryManager.BATTERY_STATUS_CHARGING ||
                status == BatteryManager.BATTERY_STATUS_FULL
-    }
-
-    private fun readCurrentCarModeState(): Boolean {
-        val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
-        return uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_CAR
     }
 }


### PR DESCRIPTION
Replace legacy UiModeManager car mode detection with the CarConnection API (androidx.car.app:app:1.7.0), which reliably detects Android Auto projection connections.