### PR TITLE
Fix stale tracking state after location permission revocation

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -255,7 +255,7 @@ class LocationForegroundService : Service() {
             )
         } catch (e: SecurityException) {
             Log.e(TAG, "Location permission missing", e)
-            stopSelf()
+            stopForegroundServiceWithReason("Location permission missing")
         }
     }
 


### PR DESCRIPTION
Check location permission before reconnecting on app startup. Android kills the process on permission revoke, leaving tracking_enabled stale. Also use proper service shutdown path on SecurityException.