### PR TITLE
fix: remove pulse animation from UserLocationOverlay to prevent map s…

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -67,6 +67,7 @@ Emits events back to JavaScript:
 - `onLocationUpdate` - new GPS fix received
 - `onTrackingStopped` - service stopped (user action or OOM kill)
 - `onSyncError` - 3+ consecutive sync failures
+- `onSyncProgress` - batch sync progress updates with `{sent, failed, total}`
 - `onPauseZoneChange` - entered or exited a geofence pause zone
 - `onProfileSwitch` - a tracking profile was activated or deactivated
 
@@ -101,7 +102,7 @@ Handles all notification logic for the tracking service:
 
 ### DatabaseHelper
 
-SQLite database singleton with six tables:
+SQLite database singleton with five tables:
 
 | Table               | Purpose                                      |
 | ------------------- | -------------------------------------------- |
@@ -180,10 +181,10 @@ The app uses [MapLibre GL Native](https://github.com/maplibre/maplibre-react-nat
 | Component | Purpose |
 | --- | --- |
 | `ColotaMapView` | Shared base map component wrapping MapLibre's `MapView` with OpenFreeMap vector tiles, dark mode style transformation, custom compass, and attribution |
-| `DashboardMap` | Live tracking map with user marker (animated pulse), accuracy circle, geofence polygons with labels, auto-center, and center button |
+| `DashboardMap` | Live tracking map with user marker, accuracy circle, geofence polygons with labels, auto-center, and center button |
 | `TrackMap` | Location history map with speed-colored track segments, tappable point markers with popups, start/end markers, fit-to-track bounds, and speed legend |
 | `GeofenceLayers` | Shared geofence rendering (fill polygons, stroke outlines, labels) used by DashboardMap and GeofenceScreen |
-| `UserLocationOverlay` | User position dot with accuracy circle and pulse animation, used by DashboardMap and GeofenceScreen |
+| `UserLocationOverlay` | User position dot with accuracy circle, used by DashboardMap and GeofenceScreen |
 | `MapCenterButton` | Reusable button overlay to re-center the map |
 
 Supporting utilities in `mapUtils.ts`:

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -156,7 +156,7 @@ export function DashboardMap({ coords, tracking, activeZoneName, activeProfileNa
           <GeofenceLayers fills={geofenceData.fills} labels={geofenceData.labels} haloColor={colors.card} />
 
           {/* Accuracy circle + user marker */}
-          <UserLocationOverlay coords={coords} tracking={tracking} isPaused={!!currentPauseZone} colors={colors} />
+          <UserLocationOverlay coords={coords} isPaused={!!currentPauseZone} colors={colors} />
         </ColotaMapView>
       ) : (
         <View style={[styles.stateContainer, { backgroundColor: colors.card }]}>

--- a/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
+++ b/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
@@ -3,17 +3,17 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useMemo, useState, useEffect } from "react"
+import React, { useMemo } from "react"
 import { View, StyleSheet } from "react-native"
 import { ShapeSource, CircleLayer, MarkerView } from "@maplibre/maplibre-react-native"
 import type { LocationCoords, ThemeColors } from "../../../types/global"
 
 /** meters-per-pixel at zoom 0 on the equator (Web Mercator constant) */
 const METERS_PER_PX_Z0 = 156543.03
+const MARKER_ANCHOR = { x: 0.5, y: 0.5 }
 
 interface Props {
   coords: LocationCoords
-  tracking: boolean
   isPaused: boolean
   colors: ThemeColors
 }
@@ -22,30 +22,10 @@ interface Props {
  * Shared overlay for DashboardMap and GeofenceScreen:
  *  – accuracy circle (CircleLayer with zoom-based radius)
  *  – user position dot (MarkerView)
- *  – pulsing stroke on the accuracy circle when actively tracking
  */
-export function UserLocationOverlay({ coords, tracking, isPaused, colors }: Props) {
-  const isActive = tracking && !isPaused
+export function UserLocationOverlay({ coords, isPaused, colors }: Props) {
   const markerColor = isPaused ? colors.textDisabled : colors.primary
 
-  // Smooth pulse: 4 fps sine wave, full cycle every 2 s
-  const [pulseValue, setPulseValue] = useState(0)
-  useEffect(() => {
-    if (!isActive) {
-      setPulseValue(0)
-      return
-    }
-    const sine = [0, 0.38, 0.71, 0.92, 1, 0.92, 0.71, 0.38]
-    let phase = 0
-    const id = setInterval(() => {
-      phase = (phase + 1) % 8
-      setPulseValue(sine[phase])
-    }, 250)
-    return () => clearInterval(id)
-  }, [isActive])
-
-  // Compute radiusFactor for zoom-based meter→pixel conversion.
-  // circleRadius = radiusFactor × 2^zoom  (matches Web Mercator scaling)
   const radiusFactor = useMemo(() => {
     if (!coords.accuracy || coords.accuracy <= 0) return 0
     return coords.accuracy / (METERS_PER_PX_Z0 * Math.cos((coords.latitude * Math.PI) / 180))
@@ -74,23 +54,26 @@ export function UserLocationOverlay({ coords, tracking, isPaused, colors }: Prop
       circleColor: colors.primary,
       circleOpacity: 0.12,
       circleStrokeColor: colors.primary,
-      circleStrokeWidth: isActive ? 1.5 + pulseValue * 1.5 : 1.5,
-      circleStrokeOpacity: isActive ? 0.3 + pulseValue * 0.4 : 0.4
+      circleStrokeWidth: 1.5,
+      circleStrokeOpacity: 0.4
     }),
-    [radiusFactor, colors.primary, isActive, pulseValue]
+    [radiusFactor, colors.primary]
+  )
+
+  const markerCoordinate = useMemo(
+    () => [coords.longitude, coords.latitude] as [number, number],
+    [coords.longitude, coords.latitude]
   )
 
   return (
     <>
-      {/* Accuracy circle */}
       {accuracyGeoJSON && (
         <ShapeSource id="user-accuracy" shape={accuracyGeoJSON}>
           <CircleLayer id="user-accuracy-fill" style={accuracyStyle} />
         </ShapeSource>
       )}
 
-      {/* User position dot */}
-      <MarkerView coordinate={[coords.longitude, coords.latitude]} anchor={{ x: 0.5, y: 0.5 }} allowOverlap>
+      <MarkerView coordinate={markerCoordinate} anchor={MARKER_ANCHOR} allowOverlap>
         <View style={[styles.markerDot, { backgroundColor: markerColor }]} />
       </MarkerView>
     </>

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -304,7 +304,7 @@ export function GeofenceScreen({}: ScreenProps) {
 
             {/* Accuracy circle + user marker */}
             {coords && tracking && (
-              <UserLocationOverlay coords={coords} tracking={tracking} isPaused={!!currentPauseZone} colors={colors} />
+              <UserLocationOverlay coords={coords} isPaused={!!currentPauseZone} colors={colors} />
             )}
           </ColotaMapView>
         ) : null}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colota",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
…nap-back

The 250ms setInterval driving the pulse animation caused continuous re-renders, giving MapLibre's MarkerView new coordinate references each tick and overriding user panning. Also updates architecture docs (table count, removed animation references, added onSyncProgress event).