### PR TITLE
fix: guard speed with hasSpeed() and calculate fallback from GPS points

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
@@ -85,7 +85,11 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
                         putNull("altitude")
                     }
                     
-                    putDouble("speed", location.speed.toDouble())
+                    if (location.hasSpeed()) {
+                        putDouble("speed", location.speed.toDouble())
+                    } else {
+                        putNull("speed")
+                    }
                     putDouble("bearing", if (location.hasBearing()) location.bearing.toDouble() else 0.0)
                     putDouble("timestamp", location.time.toDouble())
                     putInt("battery", battery) 

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/PayloadBuilder.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/PayloadBuilder.kt
@@ -43,7 +43,9 @@ class PayloadBuilder {
                 put(fieldMap["alt"] ?: "alt", location.altitude.roundToInt())
             }
 
-            put(fieldMap["vel"] ?: "vel", location.speed.roundToInt())
+            if (location.hasSpeed()) {
+                put(fieldMap["vel"] ?: "vel", location.speed.roundToInt())
+            }
             put(fieldMap["batt"] ?: "batt", batteryLevel)
             put(fieldMap["bs"] ?: "bs", batteryStatus)
             put(fieldMap["tst"] ?: "tst", timestamp)

--- a/apps/mobile/android/app/src/test/java/com/Colota/bridge/LocationServiceModuleTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/bridge/LocationServiceModuleTest.kt
@@ -346,6 +346,7 @@ class LocationServiceModuleTest {
             every { bearing } returns 90f
             every { time } returns 1700000000000L
             every { hasAltitude() } returns false
+            every { hasSpeed() } returns true
             every { hasBearing() } returns true
         }
     }

--- a/apps/mobile/android/app/src/test/java/com/Colota/sync/PayloadBuilderTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/sync/PayloadBuilderTest.kt
@@ -94,6 +94,21 @@ class PayloadBuilderTest {
     }
 
     @Test
+    fun `buildPayload excludes speed when not available`() {
+        val location = createMockLocation(lat = 52.0, lon = 13.0, acc = 5.0f, speed = 0.0f, hasSpeed = false)
+
+        val payload = builder.buildPayload(
+            location = location,
+            batteryLevel = 80,
+            batteryStatus = 2,
+            fieldMap = emptyMap(),
+            timestamp = 1700000000L
+        )
+
+        assertFalse(payload.has("vel"))
+    }
+
+    @Test
     fun `buildPayload includes bearing when available`() {
         val location = createMockLocation(
             lat = 52.0, lon = 13.0, acc = 5.0f, speed = 0.0f,
@@ -199,6 +214,7 @@ class PayloadBuilderTest {
         speed: Float,
         hasAltitude: Boolean = false,
         altitude: Double = 0.0,
+        hasSpeed: Boolean = true,
         hasBearing: Boolean = false,
         bearing: Float = 0.0f
     ): Location = mockk {
@@ -206,6 +222,7 @@ class PayloadBuilderTest {
         every { longitude } returns lon
         every { accuracy } returns acc
         every { this@mockk.speed } returns speed
+        every { hasSpeed() } returns hasSpeed
         every { hasAltitude() } returns hasAltitude
         every { this@mockk.altitude } returns altitude
         every { hasBearing() } returns hasBearing

--- a/apps/mobile/src/utils/exportConverters.ts
+++ b/apps/mobile/src/utils/exportConverters.ts
@@ -65,7 +65,7 @@ export const convertToGeoJSON = (data: LocationCoords[]): string => {
       type: "Feature",
       geometry: {
         type: "Point",
-        coordinates: [item.longitude || 0, item.latitude || 0]
+        coordinates: [item.longitude ?? 0, item.latitude ?? 0]
       },
       properties: {
         id: i,
@@ -104,12 +104,12 @@ export const convertToGPX = (data: LocationCoords[]): string => {
     const isoTime = new Date(timestamp).toISOString()
     gpx += `
       <trkpt lat="${item.latitude.toFixed(6)}" lon="${item.longitude.toFixed(6)}">
-        <ele>${item.altitude || 0}</ele>
+        <ele>${item.altitude ?? 0}</ele>
         <time>${isoTime}</time>
         <extensions>
-          <accuracy>${item.accuracy || 0}</accuracy>
-          <speed>${item.speed || 0}</speed>
-          <battery>${item.battery || 0}</battery>
+          <accuracy>${item.accuracy ?? 0}</accuracy>
+          <speed>${item.speed ?? 0}</speed>
+          <battery>${item.battery ?? 0}</battery>
         </extensions>
       </trkpt>`
   })
@@ -139,7 +139,7 @@ export const convertToKML = (data: LocationCoords[]): string => {
       <LineString>
         <tessellate>1</tessellate>
         <coordinates>
-          ${data.map((item) => `${item.longitude},${item.latitude},${item.altitude || 0}`).join("\n          ")}
+          ${data.map((item) => `${item.longitude},${item.latitude},${item.altitude ?? 0}`).join("\n          ")}
         </coordinates>
       </LineString>
     </Placemark>`
@@ -150,9 +150,9 @@ export const convertToKML = (data: LocationCoords[]): string => {
     kml += `
     <Placemark>
       <TimeStamp><when>${isoTime}</when></TimeStamp>
-      <description>Accuracy: ${item.accuracy}m, Speed: ${item.speed}m/s</description>
+      <description>Accuracy: ${item.accuracy}m, Speed: ${item.speed ?? 0}m/s</description>
       <Point>
-        <coordinates>${item.longitude},${item.latitude},${item.altitude || 0}</coordinates>
+        <coordinates>${item.longitude},${item.latitude},${item.altitude ?? 0}</coordinates>
       </Point>
     </Placemark>`
   })


### PR DESCRIPTION
Some Android devices never report
hasSpeed()=true, causing speed to always be 0. Add hasSpeed() guards in saveLocation, PayloadBuilder, and sendLocationEvent to store null instead of a misleading 0.

Add applySpeedFallback() that calculates distance/time between consecutive GPS points when the device doesn't provide speed natively. Uses Location.setSpeed() to inject the result so all downstream consumers pick it up automatically.

Partially addresses #160