### PR TITLE
feat: send speed with one decimal precision instead of integer.

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/sync/PayloadBuilder.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/PayloadBuilder.kt
@@ -44,7 +44,7 @@ class PayloadBuilder {
             }
 
             if (location.hasSpeed()) {
-                put(fieldMap["vel"] ?: "vel", location.speed.roundToInt())
+                put(fieldMap["vel"] ?: "vel", Math.round(location.speed * 10.0f) / 10.0)
             }
             put(fieldMap["batt"] ?: "batt", batteryLevel)
             put(fieldMap["bs"] ?: "bs", batteryStatus)


### PR DESCRIPTION
Add speed rounding, zero speed, and bearing exclusion tests