### PR TITLE
fix: resolve race condition in profile switching that stops tracking

### DIFF
--- a/apps/mobile/android/app/src/gms/java/com/Colota/location/GmsLocationProvider.kt
+++ b/apps/mobile/android/app/src/gms/java/com/Colota/location/GmsLocationProvider.kt
@@ -10,10 +10,7 @@ import android.location.Location
 import android.os.Looper
 import com.google.android.gms.location.*
 
-/**
- * Location provider backed by Google Play Services FusedLocationProviderClient.
- * Used in the GMS product flavor (Google Play distribution).
- */
+/** FusedLocationProviderClient-based provider for GMS flavor. */
 class GmsLocationProvider(context: Context) : LocationProvider {
 
     private val fusedClient: FusedLocationProviderClient =
@@ -34,10 +31,9 @@ class GmsLocationProvider(context: Context) : LocationProvider {
         }
         callbackMap[callback] = gmsCallback
 
-        val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, intervalMs * 2)
+        val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, intervalMs)
             .setMinUpdateIntervalMillis(intervalMs)
             .setMinUpdateDistanceMeters(minDistanceMeters)
-            .setMaxUpdateDelayMillis(intervalMs * 2)
             .build()
 
         try {

--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -14,14 +14,16 @@ interface Props {
   success: boolean
   /** Optional custom message. When provided, controls visibility instead of saving/success. */
   message?: string | null
+  isError?: boolean
   colors: {
     info: string
     success: string
+    error: string
     text: string
   }
 }
 
-export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, message, colors }) => {
+export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, message, isError, colors }) => {
   const hasMessage = message != null
   const visible = hasMessage || saving || success
 
@@ -50,8 +52,8 @@ export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, messag
         style={[
           styles.badge,
           {
-            backgroundColor: saving ? colors.info : colors.success,
-            shadowColor: saving ? colors.info : colors.success
+            backgroundColor: saving ? colors.info : isError ? colors.error : colors.success,
+            shadowColor: saving ? colors.info : isError ? colors.error : colors.success
           }
         ]}
       >


### PR DESCRIPTION
Profile config changes restarted location updates asynchronously via a coroutine, allowing multiple restarts to pile up and leave the service with no active listener. This caused duplicate locations followed by tracking silently stopping on every profile switch.

- Make applyProfileConfig restart location updates synchronously
- Fix GMS interval (was 2x requested) and remove batching delay
- Catch generic exceptions in setupLocationUpdates to prevent silent death
- Load config from DB when OOM-killed service gets a lightweight action
- Report sync failure honestly instead of always showing "Sync complete"
- Show sync failure feedback in red instead of green

Closes #166 