### PR TITLE
chore: update dependencies to latest compatible versions

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -186,6 +186,6 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.14.9'
     testImplementation 'org.json:json:20240303'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
-    testImplementation 'org.robolectric:robolectric:4.14.1'
+    testImplementation 'org.robolectric:robolectric:4.16.1'
     testImplementation 'androidx.test:core:1.6.1'
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,13 +22,13 @@
   "dependencies": {
     "@colota/shared": "*",
     "@maplibre/maplibre-react-native": "^10.4.2",
-    "@react-navigation/native": "^7.1.28",
-    "@react-navigation/native-stack": "^7.12.0",
+    "@react-navigation/native": "^7.1.31",
+    "@react-navigation/native-stack": "^7.14.2",
     "lucide-react-native": "^0.564.0",
     "react": "19.2.0",
     "react-native": "0.83.1",
-    "react-native-safe-area-context": "^5.6.2",
-    "react-native-screens": "^4.23.0",
+    "react-native-safe-area-context": "^5.7.0",
+    "react-native-screens": "^4.24.0",
     "react-native-svg": "^15.15.3"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colota",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colota",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -752,13 +752,13 @@
       "dependencies": {
         "@colota/shared": "*",
         "@maplibre/maplibre-react-native": "^10.4.2",
-        "@react-navigation/native": "^7.1.28",
-        "@react-navigation/native-stack": "^7.12.0",
+        "@react-navigation/native": "^7.1.31",
+        "@react-navigation/native-stack": "^7.14.2",
         "lucide-react-native": "^0.564.0",
         "react": "19.2.0",
         "react-native": "0.83.1",
-        "react-native-safe-area-context": "^5.6.2",
-        "react-native-screens": "^4.23.0",
+        "react-native-safe-area-context": "^5.7.0",
+        "react-native-screens": "^4.24.0",
         "react-native-svg": "^15.15.3"
       },
       "devDependencies": {
@@ -7784,9 +7784,9 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.14.0.tgz",
-      "integrity": "sha512-tMpzskBzVp0E7CRNdNtJIdXjk54Kwe/TF9ViXAef+YFM1kSfGv4e/B2ozfXE+YyYgmh4WavTv8fkdJz1CNyu+g==",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.15.1.tgz",
+      "integrity": "sha512-Fqr6qxfZJIC4ewho7LtTa9zz6hcOzohX7D1lcDfrkGaYkS5xBwEZViGNxCJK/czUc74ua8NThyrObQFjB6Q/RQ==",
       "license": "MIT",
       "dependencies": {
         "@react-navigation/routers": "^7.5.3",
@@ -7803,9 +7803,9 @@
       }
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.5.tgz",
-      "integrity": "sha512-iHZU8rRN1014Upz73AqNVXDvSMZDh5/ktQ1CMe21rdgnOY79RWtHHBp9qOS3VtqlUVYGkuX5GEw5mDt4tKdl0g==",
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.8.tgz",
+      "integrity": "sha512-3gpwUmVnDJYvK9nFmAA/YXw0hmT/C/lZx8RkRMK+ux9l1T+32EWnQFnn34Wa1BMDX8HN2r64yrlW93DIzKI7Uw==",
       "license": "MIT",
       "dependencies": {
         "color": "^4.2.3",
@@ -7814,7 +7814,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.28",
+        "@react-navigation/native": "^7.1.31",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -7826,13 +7826,13 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "7.1.28",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
-      "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
+      "version": "7.1.31",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.31.tgz",
+      "integrity": "sha512-+YCUwtfDgsux59Q0LDHc3Zid9ih93ecUCFWZOH6/+eNoUGnWx77wjS6ZfvBO/7E+EiIup11IVShDzCHR4of8hw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-navigation/core": "^7.14.0",
+        "@react-navigation/core": "^7.15.1",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
@@ -7844,18 +7844,18 @@
       }
     },
     "node_modules/@react-navigation/native-stack": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.12.0.tgz",
-      "integrity": "sha512-XmNJsPshjkNsahgbxNgGWQUq4s1l6HqH/Fei4QsjBNn/0mTvVrRVZwJ1XrY9YhWYvyiYkAN6/OmarWQaQJ0otQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.2.tgz",
+      "integrity": "sha512-/nKxFAFSUSGV+NSXrXXcWEcGAHdyp8RyWjoGMDzVPdBhjCLblVSgHWx5y4mm+k0de9V1pkjsftUaroP7rQckzw==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.5",
+        "@react-navigation/elements": "^2.9.8",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0",
         "warn-once": "^0.1.1"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.28",
+        "@react-navigation/native": "^7.1.31",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -23558,9 +23558,9 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
-      "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
+      "integrity": "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -23569,9 +23569,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz",
-      "integrity": "sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.24.0.tgz",
+      "integrity": "sha512-SyoiGaDofiyGPFrUkn1oGsAzkRuX1JUvTD9YQQK3G1JGQ5VWkvHgYSsc1K9OrLsDQxN7NmV71O0sHCAh8cBetA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27854,7 +27854,6 @@
     },
     "packages/shared": {
       "name": "@colota/shared",
-      "version": "1.0.0",
       "devDependencies": {
         "sharp": "^0.34.5"
       }


### PR DESCRIPTION
- react-navigation/native ^7.1.31, native-stack ^7.14.2
- react-native-safe-area-context ^5.7.0, screens ^4.24.0
- robolectric 4.14.1 -> 4.16.1 (adds SDK 36 support)