### PR TITLE
chore: clean up Kotlin imports, constants, and redundant annotations

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/BuildConfigModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/BuildConfigModule.kt
@@ -8,9 +8,6 @@
 import com.facebook.react.bridge.ReactApplicationContext
 import com.Colota.BuildConfig
 import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.Promise
-import android.os.Build
 
 class BuildConfigModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/PayloadBuilder.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/PayloadBuilder.kt
@@ -8,7 +8,7 @@ package com.Colota.sync
 import android.location.Location
 import com.Colota.util.AppLogger
 import org.json.JSONObject
-import kotlin.math.*
+import kotlin.math.roundToInt
 
 /**
  * Builds and parses location payloads with dynamic field mapping.

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
@@ -23,6 +23,7 @@ class SyncManager(
 ) {
     companion object {
         private const val TAG = "SyncManager"
+        private const val MAX_BATCHES_PER_SYNC = 10
     }
 
     @Volatile private var endpoint: String = ""
@@ -42,8 +43,6 @@ class SyncManager(
     @Volatile private var consecutiveFailures = 0
 
     private val queueCountCache = TimedCache(5000L) { dbHelper.getQueuedCount() }
-
-    private val MAX_BATCHES_PER_SYNC = 10
 
     fun updateConfig(
         endpoint: String,

--- a/apps/mobile/android/app/src/main/java/com/colota/util/FileOperations.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/util/FileOperations.kt
@@ -11,11 +11,15 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.core.content.FileProvider
-import com.facebook.react.bridge.*
+import com.facebook.react.bridge.ReactApplicationContext
 import java.io.File
 
 class FileOperations(private val context: ReactApplicationContext) {
-    
+
+    companion object {
+        private const val TAG = "FileOperations"
+    }
+
     /**
      * Writes content to a file in the app's cache directory
      * @param fileName Name of the file to create
@@ -67,10 +71,10 @@ class FileOperations(private val context: ReactApplicationContext) {
             try {
                 if (file.exists()) {
                     file.delete()
-                    AppLogger.d("FileOperations", "Cleaned up export file: ${file.name}")
+                    AppLogger.d(TAG, "Cleaned up export file: ${file.name}")
                 }
             } catch (e: Exception) {
-                AppLogger.w("FileOperations", "Failed to cleanup file")
+                AppLogger.w(TAG, "Failed to cleanup file")
             }
         }, 60000)
         

--- a/apps/mobile/android/app/src/main/java/com/colota/util/SecureStorageHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/util/SecureStorageHelper.kt
@@ -8,7 +8,6 @@ package com.Colota.util
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Base64
-import com.Colota.util.AppLogger
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import org.json.JSONObject

--- a/apps/mobile/android/app/src/main/java/com/colota/util/TimedCache.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/util/TimedCache.kt
@@ -6,7 +6,7 @@ package com.Colota.util
 
 /**
  * Generic time-based cache that reloads its value after a configurable TTL.
- * Thread-safe via @Volatile annotations.
+ * Thread-safe via @Synchronized access.
  *
  * @param ttlMs Time-to-live in milliseconds before the cached value is refreshed
  * @param loader Function that produces a fresh value when the cache is stale
@@ -15,8 +15,8 @@ class TimedCache<T>(
     private val ttlMs: Long,
     private val loader: () -> T
 ) {
-    @Volatile private var value: T? = null
-    @Volatile private var lastCheck: Long = 0
+    private var value: T? = null
+    private var lastCheck: Long = 0
 
     @Synchronized
     fun get(): T {


### PR DESCRIPTION
- Replace wildcard imports with explicit imports across 4 files
- Remove unused and redundant same-package imports
- Move MAX_BATCHES_PER_SYNC to companion const val
- Remove redundant @Volatile where @Synchronized suffices
- Add companion TAG constant to FileOperations
- Refactor checkCurrentPauseZone to use inline coroutine