### PR TITLE
fix: prevent MapLibre crash on tracking stop, show newest locations first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ test-output.txt
 
 # Misc
 testers
+apps/mobile/test-checklist.md

--- a/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
@@ -538,8 +538,14 @@ class DatabaseHelperSQLiteTest {
 
         assertEquals(3, page1.size)
         assertEquals(3, page2.size)
-        // Locations ordered by timestamp DESC — page 1 has newest
-        assertNotEquals(page1[0]["timestamp"], page2[0]["timestamp"])
+        // Locations ordered by timestamp DESC — newest first
+        val t1 = page1[0]["timestamp"] as Long
+        val t2 = page1[1]["timestamp"] as Long
+        val t3 = page1[2]["timestamp"] as Long
+        assertTrue("Page 1 should be sorted newest-first", t1 > t2 && t2 > t3)
+        // Page 2 starts after page 1
+        val t4 = page2[0]["timestamp"] as Long
+        assertTrue("Page 2 should continue after page 1", t3 > t4)
     }
 
     @Test

--- a/apps/mobile/src/components/features/inspector/LocationTable.tsx
+++ b/apps/mobile/src/components/features/inspector/LocationTable.tsx
@@ -89,17 +89,17 @@ const getItemLayout = (_: any, index: number) => ({
 export function LocationTable({ locations, colors }: Props) {
   const speedUnit = useMemo(() => getSpeedUnit(), [])
 
-  const data = useMemo<TableRow[]>(
-    () =>
-      locations.map((loc, i) => ({
-        ...loc,
-        delta:
-          i > 0 && loc.timestamp && locations[i - 1].timestamp
-            ? Math.round(loc.timestamp - locations[i - 1].timestamp!)
-            : null
-      })),
-    [locations]
-  )
+  const data = useMemo<TableRow[]>(() => {
+    // Compute deltas in chronological order, then reverse for newest-first display
+    const rows = locations.map((loc, i) => ({
+      ...loc,
+      delta:
+        i > 0 && loc.timestamp && locations[i - 1].timestamp
+          ? Math.round(loc.timestamp - locations[i - 1].timestamp!)
+          : null
+    }))
+    return rows.reverse()
+  }, [locations])
 
   const renderItem = useCallback(
     ({ item }: { item: TableRow }) => <LocationRow item={item} speedUnit={speedUnit} colors={colors} />,

--- a/apps/mobile/src/hooks/useLocationTracking.ts
+++ b/apps/mobile/src/hooks/useLocationTracking.ts
@@ -155,7 +155,6 @@ export function useLocationTracking(settings: Settings): LocationTrackingResult 
         listenerRef.current = null
       }
       setTracking(false)
-      setCoords(null)
     })
     return () => sub.remove()
   }, [])
@@ -221,7 +220,6 @@ export function useLocationTracking(settings: Settings): LocationTrackingResult 
 
     NativeLocationService.stop()
     setTracking(false)
-    setCoords(null)
   }, [])
 
   /**


### PR DESCRIPTION
Keep map and overlay layers mounted (hidden) when tracking stops to avoid MapLibre/Fabric unmount race condition (IndexOutOfBoundsException). Retain last coords instead of nulling them on stop. Reverse location table order to show newest entries at the top. Add sort order assertion to getTableData test.