### PR TITLE
Extract shared settings UI components (SettingRow, RadioDot, FormatSelector)

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -11,6 +11,7 @@ import NativeLocationService from "../../../services/NativeLocationService"
 import { isPrivateHost, isEndpointAllowed } from "../../../utils/settingsValidation"
 import { ensureLocalNetworkPermission } from "../../../services/LocationServicePermission"
 import { fonts } from "../../../styles/typography"
+import { SettingRow } from "../../ui/SettingRow"
 import { useTimeout } from "../../../hooks/useTimeout"
 import { CONNECTION_TEST_TIMEOUT, TEST_RESULT_DISPLAY_MS } from "../../../constants"
 import { logger } from "../../../utils/logger"
@@ -141,11 +142,7 @@ export function ConnectionSettings({
     <View style={styles.section}>
       <SectionTitle>Connection</SectionTitle>
       <Card>
-        <View style={styles.settingRow}>
-          <View style={styles.settingContent}>
-            <Text style={[styles.settingLabel, { color: colors.text }]}>Offline Mode</Text>
-            <Text style={[styles.settingHint, { color: colors.textSecondary }]}>Save locally, no network sync</Text>
-          </View>
+        <SettingRow label="Offline Mode" hint="Save locally, no network sync">
           <Switch
             value={settings.isOfflineMode}
             onValueChange={handleOfflineModeChange}
@@ -155,7 +152,7 @@ export function ConnectionSettings({
             }}
             thumbColor={settings.isOfflineMode ? colors.primary : colors.border}
           />
-        </View>
+        </SettingRow>
 
         {!settings.isOfflineMode && (
           <>
@@ -273,26 +270,6 @@ export function ConnectionSettings({
 const styles = StyleSheet.create({
   section: {
     marginBottom: 24
-  },
-  settingRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: 4
-  },
-  settingContent: {
-    flex: 1,
-    marginRight: 16
-  },
-  settingLabel: {
-    fontSize: 16,
-    ...fonts.semiBold,
-    marginBottom: 2
-  },
-  settingHint: {
-    fontSize: 13,
-    ...fonts.regular,
-    lineHeight: 18
   },
   inputGroup: {
     marginBottom: 12

--- a/apps/mobile/src/components/features/settings/PresetOption.tsx
+++ b/apps/mobile/src/components/features/settings/PresetOption.tsx
@@ -2,55 +2,44 @@
  * Copyright (C) 2026 Max Dietrich
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
-import React from "react"
 import { View, Text, StyleSheet, Pressable } from "react-native"
 import { Zap, Check } from "lucide-react-native"
-import { ThemeColors, SelectablePreset, TRACKING_PRESETS } from "../../../types/global"
+import { SelectablePreset, TRACKING_PRESETS } from "../../../types/global"
 import { fonts } from "../../../styles/typography"
+import { useTheme } from "../../../hooks/useTheme"
+import { RadioDot } from "../../ui/RadioDot"
 
 interface PresetOptionProps {
   preset: SelectablePreset
   isSelected: boolean
   onSelect: (preset: SelectablePreset) => void
-  colors: ThemeColors
 }
 
-/**
- * PresetOption Component - Improved Design
- *
- * Enhanced with:
- * - Better visual hierarchy
- * - Cleaner badge placement
- * - Improved selection states
- * - More accessible touch targets
- */
-export function PresetOption({ preset, isSelected, onSelect, colors }: PresetOptionProps) {
+export function PresetOption({ preset, isSelected, onSelect }: PresetOptionProps) {
+  const { colors } = useTheme()
   const config = TRACKING_PRESETS[preset]
   const showRecommendedBadge = preset === "balanced"
   const showWarningBadge = config.batteryImpact === "High"
 
-  const radioBgColor = isSelected ? colors.primary + "20" : "transparent"
-
   return (
     <Pressable
-      style={({ pressed }) => [
-        styles.container,
-        {
-          backgroundColor: isSelected ? colors.primary + "12" : colors.background
-        },
-        pressed && { opacity: 0.7 }
-      ]}
+      style={({ pressed }) => [pressed && { opacity: 0.7 }]}
       onPress={() => onSelect(preset)}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: isSelected }}
     >
-      {/* Selection indicator bar */}
-      {isSelected && <View style={[styles.selectionBar, { backgroundColor: colors.primary }]} />}
-
       <View style={styles.content}>
-        {/* Left side - Icon and text */}
         <View style={styles.leftContent}>
           <View style={styles.textContent}>
             <View style={styles.titleRow}>
-              <Text style={[styles.label, { color: colors.text }]}>{config.label}</Text>
+              <Text
+                style={[
+                  styles.label,
+                  isSelected ? { color: colors.primaryDark, ...fonts.bold } : { color: colors.text }
+                ]}
+              >
+                {config.label}
+              </Text>
               {showRecommendedBadge && (
                 <View
                   style={[
@@ -88,54 +77,23 @@ export function PresetOption({ preset, isSelected, onSelect, colors }: PresetOpt
           </View>
         </View>
 
-        {/* Right side - Radio button */}
-        <View
-          style={[
-            styles.radio,
-            {
-              borderColor: isSelected ? colors.primary : colors.border,
-              backgroundColor: radioBgColor
-            }
-          ]}
-        >
-          {isSelected && <View style={[styles.radioInner, { backgroundColor: colors.primary }]} />}
-        </View>
+        <RadioDot selected={isSelected} />
       </View>
     </Pressable>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    borderRadius: 14,
-    overflow: "hidden",
-    position: "relative",
-    marginBottom: 8
-  },
-  selectionBar: {
-    position: "absolute",
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: 4
-  },
   content: {
     flexDirection: "row",
     alignItems: "center",
-    padding: 16,
-    paddingLeft: 20
+    padding: 12
   },
   leftContent: {
     flex: 1,
     flexDirection: "row",
     alignItems: "center",
     gap: 14
-  },
-  iconContainer: {
-    width: 28,
-    height: 28,
-    justifyContent: "center",
-    alignItems: "center"
   },
   textContent: {
     flex: 1
@@ -172,19 +130,5 @@ const styles = StyleSheet.create({
     fontSize: 13,
     ...fonts.regular,
     lineHeight: 18
-  },
-  radio: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    borderWidth: 2,
-    justifyContent: "center",
-    alignItems: "center",
-    marginLeft: 12
-  },
-  radioInner: {
-    width: 12,
-    height: 12,
-    borderRadius: 6
   }
 })

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -118,16 +118,19 @@ export function StatsCard({ queueCount, sentCount, interval, isOfflineMode, onMa
 
       {/* Warning Banner */}
       {showWarning && onManageClick && (
-        <View style={styles.warningBanner}>
+        <View style={styles.warningWrapper}>
           <Pressable
-            style={({ pressed }) => [
-              styles.warningBanner,
-              {
-                backgroundColor: warningLevel === "critical" ? colors.error + "15" : colors.warning + "15",
-                borderTopColor: colors.border
-              },
-              pressed && { opacity: 0.7 }
-            ]}
+            style={({ pressed }) => {
+              const accent = warningLevel === "critical" ? colors.error : colors.warning
+              return [
+                styles.warningButton,
+                {
+                  backgroundColor: accent + "15",
+                  borderColor: accent + "40"
+                },
+                pressed && { opacity: 0.7 }
+              ]
+            }}
             onPress={onManageClick}
           >
             <View style={styles.warningContent}>
@@ -202,21 +205,23 @@ const styles = StyleSheet.create({
     marginHorizontal: 12,
     opacity: 0.3
   },
-  warningBanner: {
+  warningWrapper: {
+    paddingHorizontal: 12,
+    paddingBottom: 12
+  },
+  warningButton: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: 20,
-    paddingVertical: 14,
-    borderTopWidth: 1
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1.5
   },
   warningContent: {
     flexDirection: "row",
     alignItems: "center",
     flex: 1
-  },
-  warningIcon: {
-    marginRight: 12
   },
   warningText: {
     flex: 1,

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -8,10 +8,9 @@ import { Text, StyleSheet, Switch, View, Pressable } from "react-native"
 import { Lightbulb } from "lucide-react-native"
 import { Settings, TRACKING_PRESETS, SyncPreset, SelectablePreset, ThemeColors } from "../../../types/global"
 import { fonts, fontSizes } from "../../../styles/typography"
-import { SectionTitle, Card, Divider, NumericInput } from "../../index"
+import { SYNC_INTERVAL_PRESETS, SYNC_INTERVAL_LABELS } from "../../../constants"
+import { SectionTitle, Card, Divider, NumericInput, SettingRow } from "../../index"
 import { PresetOption } from "./PresetOption"
-
-const SYNC_PRESETS: readonly number[] = [0, 60, 300, 900]
 
 interface SyncStrategySettingsProps {
   settings: Settings
@@ -34,7 +33,7 @@ export function SyncStrategySettings({
   const [syncIntervalInput, setSyncIntervalInput] = useState(settings.syncInterval.toString())
   const [showAdvanced, setShowAdvanced] = useState(false)
 
-  const isCustomSyncInterval = !SYNC_PRESETS.includes(settings.syncInterval)
+  const isCustomSyncInterval = !SYNC_INTERVAL_PRESETS.includes(settings.syncInterval)
 
   // Sync inputs with settings changes (e.g. preset selection)
   useEffect(() => {
@@ -121,16 +120,11 @@ export function SyncStrategySettings({
     <View style={styles.section}>
       <SectionTitle>Tracking Configuration</SectionTitle>
       <Card>
-        <View style={styles.presetsContainer}>
+        <View accessibilityRole="radiogroup">
           {(Object.keys(TRACKING_PRESETS) as SelectablePreset[]).map((preset, index) => (
             <View key={preset}>
-              <PresetOption
-                preset={preset}
-                isSelected={settings.syncPreset === preset}
-                onSelect={handlePresetSelect}
-                colors={colors}
-              />
-              {index < Object.keys(TRACKING_PRESETS).length - 1 && <View style={styles.presetSpacer} />}
+              {index > 0 && <View style={styles.presetSpacer} />}
+              <PresetOption preset={preset} isSelected={settings.syncPreset === preset} onSelect={handlePresetSelect} />
             </View>
           ))}
         </View>
@@ -138,7 +132,6 @@ export function SyncStrategySettings({
         <Pressable
           style={({ pressed }) => [
             styles.advancedToggle,
-            showAdvanced ? styles.advancedToggleActive : styles.advancedToggleInactive,
             { borderColor: showAdvanced ? colors.primary : colors.border },
             pressed && { opacity: 0.7 }
           ]}
@@ -211,15 +204,8 @@ export function SyncStrategySettings({
                 </Text>
 
                 <View style={styles.optionsGrid}>
-                  {SYNC_PRESETS.map((sec) => {
-                    const labels: Record<number, string> = {
-                      0: "Instant",
-                      60: "1 min",
-                      300: "5 min",
-                      900: "15 min"
-                    }
+                  {SYNC_INTERVAL_PRESETS.map((sec) => {
                     const isSelected = settings.syncInterval === sec && !isCustomSyncInterval
-
                     return (
                       <Pressable
                         key={sec}
@@ -238,7 +224,7 @@ export function SyncStrategySettings({
                         onPress={() => handleGridSelect("syncInterval", sec)}
                       >
                         <Text style={[styles.gridLabel, { color: isSelected ? colors.primary : colors.text }]}>
-                          {labels[sec]}
+                          {SYNC_INTERVAL_LABELS[sec]}
                         </Text>
                       </Pressable>
                     )
@@ -269,49 +255,48 @@ export function SyncStrategySettings({
                     </Text>
                   </Pressable>
                 </View>
-
-                {isCustomSyncInterval && (
-                  <View style={styles.customSyncInput}>
-                    <NumericInput
-                      label="Custom Sync Interval"
-                      value={syncIntervalInput}
-                      onChange={(val) => {
-                        setSyncIntervalInput(val)
-                        const num = Number(val)
-                        if (!isNaN(num) && num >= 1) {
-                          const next = { ...settings, syncInterval: num, syncPreset: "custom" as const }
-                          onDebouncedSave(next)
-                        }
-                      }}
-                      onBlur={() => {
-                        let val = Number(syncIntervalInput)
-                        if (isNaN(val) || val < 1) {
-                          val = 1
-                          setSyncIntervalInput("1")
-                          const next = { ...settings, syncInterval: val, syncPreset: "custom" as const }
-                          onSettingsChange(next)
-                          onImmediateSave(next)
-                        }
-                      }}
-                      unit="seconds"
-                      placeholder="1800"
-                      hint="Custom interval in seconds"
-                      colors={colors}
-                    />
-                  </View>
-                )}
               </View>
 
-              {/* Retry Forever Toggle */}
-              <View style={styles.settingRow}>
-                <View style={styles.settingContent}>
-                  <Text style={[styles.settingLabel, { color: colors.text }]}>Retry Failed Uploads</Text>
-                  <Text style={[styles.settingHint, { color: colors.textSecondary }]}>
-                    {settings.maxRetries === 0
-                      ? "Failed uploads stay in the queue until they succeed"
-                      : "Failed uploads are permanently deleted after 5 failed send attempts"}
-                  </Text>
+              {isCustomSyncInterval && (
+                <View style={styles.customSyncInput}>
+                  <NumericInput
+                    label="Custom Sync Interval"
+                    value={syncIntervalInput}
+                    onChange={(val) => {
+                      setSyncIntervalInput(val)
+                      const num = Number(val)
+                      if (!isNaN(num) && num >= 1) {
+                        const next = { ...settings, syncInterval: num, syncPreset: "custom" as const }
+                        onDebouncedSave(next)
+                      }
+                    }}
+                    onBlur={() => {
+                      let val = Number(syncIntervalInput)
+                      if (isNaN(val) || val < 1) {
+                        val = 1
+                        setSyncIntervalInput("1")
+                        const next = { ...settings, syncInterval: val, syncPreset: "custom" as const }
+                        onSettingsChange(next)
+                        onImmediateSave(next)
+                      }
+                    }}
+                    unit="seconds"
+                    placeholder="1800"
+                    hint="Custom interval in seconds"
+                    colors={colors}
+                  />
                 </View>
+              )}
+
+              {/* Retry Forever Toggle */}
+              <SettingRow
+                label="Retry Failed Uploads"
+                hint={
+                  settings.maxRetries === 0
+                    ? "Failed uploads stay in the queue until they succeed"
+                    : "Failed uploads are permanently deleted after 5 failed send attempts"
+                }
+              >
                 <Switch
                   value={settings.maxRetries === 0}
                   onValueChange={(retryForever) => {
@@ -329,16 +314,14 @@ export function SyncStrategySettings({
                   }}
                   thumbColor={settings.maxRetries === 0 ? colors.primary : colors.border}
                 />
-              </View>
+              </SettingRow>
 
               {/* Wi-Fi Only Sync Toggle */}
-              <View style={[styles.settingRow, styles.settingRowSpaced]}>
-                <View style={styles.settingContent}>
-                  <Text style={[styles.settingLabel, { color: colors.text }]}>Wi-Fi Only Sync</Text>
-                  <Text style={[styles.settingHint, { color: colors.textSecondary }]}>
-                    Only upload when connected to Wi-Fi
-                  </Text>
-                </View>
+              <SettingRow
+                label="Wi-Fi Only Sync"
+                hint="Only upload when connected to Wi-Fi"
+                style={styles.settingRowSpaced}
+              >
                 <Switch
                   value={settings.isWifiOnlySync}
                   onValueChange={(value) => {
@@ -356,7 +339,7 @@ export function SyncStrategySettings({
                   }}
                   thumbColor={settings.isWifiOnlySync ? colors.primary : colors.border}
                 />
-              </View>
+              </SettingRow>
             </View>
 
             <Divider />
@@ -365,13 +348,7 @@ export function SyncStrategySettings({
             <View style={styles.paramGroup}>
               <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Quality Filters</Text>
 
-              <View style={styles.settingRow}>
-                <View style={styles.settingContent}>
-                  <Text style={[styles.settingLabel, { color: colors.text }]}>Filter Inaccurate Locations</Text>
-                  <Text style={[styles.settingHint, { color: colors.textSecondary }]}>
-                    Reject low-accuracy GPS readings
-                  </Text>
-                </View>
+              <SettingRow label="Filter Inaccurate Locations" hint="Reject low-accuracy GPS readings">
                 <Switch
                   value={settings.filterInaccurateLocations}
                   onValueChange={(value) =>
@@ -386,7 +363,7 @@ export function SyncStrategySettings({
                   }}
                   thumbColor={settings.filterInaccurateLocations ? colors.primary : colors.border}
                 />
-              </View>
+              </SettingRow>
 
               {settings.filterInaccurateLocations && (
                 <View style={[styles.nestedSetting, { borderLeftColor: colors.border }]}>
@@ -414,9 +391,6 @@ const styles = StyleSheet.create({
   section: {
     marginBottom: 24
   },
-  presetsContainer: {
-    marginBottom: 16
-  },
   presetSpacer: {
     height: 8
   },
@@ -426,13 +400,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     borderRadius: 12,
     borderWidth: 1.5,
-    marginTop: 8
-  },
-  advancedToggleActive: {
-    backgroundColor: "transparent"
-  },
-  advancedToggleInactive: {
-    backgroundColor: "transparent"
+    marginTop: 16
   },
   advancedText: {
     fontSize: 15,
@@ -487,7 +455,7 @@ const styles = StyleSheet.create({
     flexWrap: "wrap"
   },
   gridOption: {
-    flex: 1,
+    width: "31%", // ~3 per row with gap in a flexWrap container
     borderWidth: 2,
     borderRadius: 10,
     paddingVertical: 14,
@@ -496,26 +464,6 @@ const styles = StyleSheet.create({
   gridLabel: {
     fontSize: 14,
     ...fonts.semiBold
-  },
-  settingRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: 4
-  },
-  settingContent: {
-    flex: 1,
-    marginRight: 16
-  },
-  settingLabel: {
-    fontSize: 16,
-    ...fonts.semiBold,
-    marginBottom: 2
-  },
-  settingHint: {
-    fontSize: 13,
-    ...fonts.regular,
-    lineHeight: 18
   },
   settingRowSpaced: {
     marginTop: 16

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -24,6 +24,14 @@ jest.mock("../../../index", () => {
           keyboardType: "numeric"
         }),
         R.createElement(Text, null, unit)
+      ),
+    SettingRow: ({ label, hint, children }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        hint && R.createElement(Text, null, hint),
+        children
       )
   }
 })
@@ -84,9 +92,10 @@ describe("SyncStrategySettings", () => {
   }
 
   describe("presets", () => {
-    it("renders all three presets", () => {
+    it("renders all three presets inline", () => {
       const { getByTestId } = renderComponent()
 
+      // Presets are rendered inline (no picker to open)
       expect(getByTestId("preset-instant")).toBeTruthy()
       expect(getByTestId("preset-balanced")).toBeTruthy()
       expect(getByTestId("preset-powersaver")).toBeTruthy()
@@ -95,6 +104,7 @@ describe("SyncStrategySettings", () => {
     it("selecting a preset applies its config via onImmediateSave", () => {
       const { getByTestId } = renderComponent()
 
+      // Select balanced directly (inline)
       fireEvent.press(getByTestId("preset-balanced"))
 
       expect(mockOnSettingsChange).toHaveBeenCalledWith(
@@ -157,16 +167,17 @@ describe("SyncStrategySettings", () => {
     })
   })
 
-  describe("sync interval grid", () => {
-    it("renders all sync interval options", () => {
-      const { getByText } = renderComponent()
+  describe("sync interval chips", () => {
+    it("renders all sync interval options inline", () => {
+      const { getByText, getAllByText } = renderComponent()
 
       fireEvent.press(getByText("+ Show Advanced Settings"))
 
-      expect(getByText("Instant")).toBeTruthy()
+      expect(getAllByText("Instant").length).toBeGreaterThan(0)
       expect(getByText("1 min")).toBeTruthy()
       expect(getByText("5 min")).toBeTruthy()
       expect(getByText("15 min")).toBeTruthy()
+      expect(getByText("Custom")).toBeTruthy()
     })
 
     it("selecting a sync interval sets preset to custom", () => {
@@ -323,7 +334,7 @@ describe("SyncStrategySettings", () => {
       fireEvent.changeText(intervalInput, "10")
       fireEvent(intervalInput, "blur")
 
-      // Valid value — onSettingsChange should only have been called from changeText (debounced save),
+      // Valid value - onSettingsChange should only have been called from changeText (debounced save),
       // not from blur (no clamping needed)
       expect(mockOnImmediateSave).not.toHaveBeenCalled()
     })

--- a/apps/mobile/src/components/index.ts
+++ b/apps/mobile/src/components/index.ts
@@ -26,6 +26,10 @@ export { LocationDisclosureModal } from "./ui/LocationDisclosureModal"
 export { LocalNetworkDisclosureModal } from "./ui/LocalNetworkDisclosureModal"
 export { AppModal } from "./ui/AppModal"
 export { ChipGroup } from "./ui/ChipGroup"
+export { FormatOption } from "./ui/FormatOption"
+export { FormatSelector } from "./ui/FormatSelector"
+export { RadioDot } from "./ui/RadioDot"
+export { SettingRow } from "./ui/SettingRow"
 
 // ============================================================================
 // Feature Components - Dashboard

--- a/apps/mobile/src/components/ui/FormatOption.tsx
+++ b/apps/mobile/src/components/ui/FormatOption.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import React from "react"
+import { Text, StyleSheet, View, Pressable } from "react-native"
+import type { LucideIcon } from "lucide-react-native"
+import { fonts } from "../../styles/typography"
+import { useTheme } from "../../hooks/useTheme"
+import { RadioDot } from "./RadioDot"
+
+export const FormatOption = ({
+  icon: Icon,
+  title,
+  subtitle,
+  description,
+  extension,
+  selected,
+  onPress
+}: {
+  icon: LucideIcon
+  title: string
+  subtitle: string
+  description: string
+  extension: string
+  selected: boolean
+  onPress: () => void
+}) => {
+  const { colors } = useTheme()
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.formatOption, pressed && { opacity: 0.7 }]}
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected }}
+    >
+      <View style={styles.formatContent}>
+        <View style={styles.leftContent}>
+          <Icon size={28} color={colors.primaryDark} />
+          <View style={styles.textContent}>
+            <View style={styles.titleRow}>
+              <Text
+                style={[
+                  styles.formatTitle,
+                  selected ? { color: colors.primaryDark, ...fonts.bold } : { color: colors.text }
+                ]}
+              >
+                {title}
+              </Text>
+              <View
+                style={[
+                  styles.extensionBadge,
+                  {
+                    backgroundColor: selected ? colors.primary + "20" : colors.primary + "15",
+                    borderColor: selected ? colors.primary + "60" : colors.primary + "30"
+                  }
+                ]}
+              >
+                <Text style={[styles.extensionText, { color: colors.primaryDark }]}>{extension}</Text>
+              </View>
+            </View>
+            <Text style={[styles.formatSubtitle, { color: colors.textSecondary }]}>{subtitle}</Text>
+            <Text style={[styles.formatDescription, { color: colors.textLight }]}>{description}</Text>
+          </View>
+        </View>
+
+        <RadioDot selected={selected} />
+      </View>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  formatOption: {
+    paddingVertical: 8,
+    paddingHorizontal: 12
+  },
+  formatContent: {
+    flexDirection: "row",
+    alignItems: "center"
+  },
+  leftContent: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14
+  },
+  textContent: {
+    flex: 1
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 2
+  },
+  formatTitle: {
+    fontSize: 16,
+    ...fonts.semiBold,
+    letterSpacing: -0.2
+  },
+  extensionBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    borderWidth: 1
+  },
+  extensionText: {
+    fontSize: 10,
+    ...fonts.bold,
+    letterSpacing: 0.3
+  },
+  formatSubtitle: {
+    fontSize: 13,
+    marginBottom: 2
+  },
+  formatDescription: {
+    fontSize: 12,
+    lineHeight: 16
+  }
+})

--- a/apps/mobile/src/components/ui/FormatSelector.tsx
+++ b/apps/mobile/src/components/ui/FormatSelector.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import React from "react"
+import { View } from "react-native"
+import { ExportFormat, EXPORT_FORMATS } from "../../utils/exportConverters"
+import { Divider } from "./Divider"
+import { FormatOption } from "./FormatOption"
+
+export const FormatSelector = ({
+  selectedFormat,
+  onSelectFormat
+}: {
+  selectedFormat: ExportFormat | null
+  onSelectFormat: (format: ExportFormat) => void
+}) => (
+  <View accessibilityRole="radiogroup">
+    {(Object.entries(EXPORT_FORMATS) as [ExportFormat, (typeof EXPORT_FORMATS)[ExportFormat]][]).map(
+      ([key, config], index) => (
+        <React.Fragment key={key}>
+          {index > 0 && <Divider />}
+          <FormatOption
+            icon={config.icon}
+            title={config.label}
+            subtitle={config.subtitle}
+            description={config.description}
+            extension={config.extension}
+            selected={selectedFormat === key}
+            onPress={() => onSelectFormat(key)}
+          />
+        </React.Fragment>
+      )
+    )}
+  </View>
+)

--- a/apps/mobile/src/components/ui/RadioDot.tsx
+++ b/apps/mobile/src/components/ui/RadioDot.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import React from "react"
+import { View, StyleSheet } from "react-native"
+import { useTheme } from "../../hooks/useTheme"
+
+export function RadioDot({ selected }: { selected: boolean }) {
+  const { colors } = useTheme()
+  return (
+    <View
+      style={[styles.radio, { borderColor: selected ? colors.primary : colors.border }]}
+      importantForAccessibility="no"
+      accessibilityElementsHidden
+    >
+      {selected && <View style={[styles.inner, { backgroundColor: colors.primary }]} />}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  radio: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 2,
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  inner: {
+    width: 12,
+    height: 12,
+    borderRadius: 6
+  }
+})

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import React from "react"
+import { View, Text, StyleSheet, type StyleProp, type ViewStyle } from "react-native"
+import { fonts } from "../../styles/typography"
+import { useTheme } from "../../hooks/useTheme"
+
+interface SettingRowProps {
+  label: string
+  hint?: string
+  children: React.ReactNode
+  style?: StyleProp<ViewStyle>
+}
+
+export function SettingRow({ label, hint, children, style }: SettingRowProps) {
+  const { colors } = useTheme()
+  return (
+    <View style={[styles.settingRow, style]}>
+      <View style={styles.settingContent}>
+        <Text style={[styles.settingLabel, { color: colors.text }]}>{label}</Text>
+        {hint && <Text style={[styles.settingHint, { color: colors.textSecondary }]}>{hint}</Text>}
+      </View>
+      {children}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  settingRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 4
+  },
+  settingContent: {
+    flex: 1,
+    marginRight: 16
+  },
+  settingLabel: {
+    fontSize: 16,
+    ...fonts.semiBold,
+    marginBottom: 2
+  },
+  settingHint: {
+    fontSize: 13,
+    ...fonts.regular,
+    lineHeight: 18
+  }
+})

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -60,6 +60,16 @@ export const PROFILE_CONDITIONS: {
   }
 ]
 
+// Sync Interval
+export const SYNC_INTERVAL_PRESETS: readonly number[] = [0, 60, 300, 900]
+
+export const SYNC_INTERVAL_LABELS: Record<number, string> = {
+  0: "Instant",
+  60: "1 min",
+  300: "5 min",
+  900: "15 min"
+}
+
 // Thresholds
 export const HIGH_QUEUE_THRESHOLD = 50
 export const CRITICAL_QUEUE_THRESHOLD = 100

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useCallback, useMemo, useRef } from "react"
+import { useState, useCallback, useMemo, useRef } from "react"
 import { Text, StyleSheet, TextInput, View, ScrollView, Pressable } from "react-native"
 import {
   FieldMap,
@@ -40,11 +40,10 @@ const FIELD_DESCRIPTIONS: Record<keyof FieldMap, string> = {
 
 const TEMPLATE_OPTIONS: { value: ApiTemplateName; label: string }[] = [
   { value: "custom", label: "Custom" },
-  { value: "dawarich", label: "Dawarich" },
-  { value: "owntracks", label: "OwnTracks" },
-  { value: "phonetrack", label: "PhoneTrack" },
-  { value: "reitti", label: "Reitti" },
-  { value: "traccar", label: "Traccar" }
+  ...Object.entries(API_TEMPLATES).map(([key, tmpl]) => ({
+    value: key as ApiTemplateName,
+    label: tmpl.label
+  }))
 ]
 
 const HTTP_METHOD_OPTIONS: { value: HttpMethod; label: string }[] = [

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -15,7 +15,7 @@ import NativeLocationService from "../services/NativeLocationService"
 import { logger } from "../utils/logger"
 import { findDuplicates } from "../utils/settingsValidation"
 
-const AUTH_TYPES: { value: AuthType; label: string }[] = [
+const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
   { value: "none", label: "None" },
   { value: "basic", label: "Basic Auth" },
   { value: "bearer", label: "Bearer Token" }
@@ -162,7 +162,7 @@ export function AuthSettingsScreen({}: ScreenProps) {
           <SectionTitle>Authentication</SectionTitle>
           <Card>
             <ChipGroup
-              options={AUTH_TYPES}
+              options={AUTH_TYPE_OPTIONS}
               selected={config.authType}
               onSelect={handleAuthTypeChange}
               colors={colors}

--- a/apps/mobile/src/screens/ExportDataScreen.tsx
+++ b/apps/mobile/src/screens/ExportDataScreen.tsx
@@ -3,13 +3,13 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useEffect, useCallback, useRef } from "react"
-import { Text, StyleSheet, View, ActivityIndicator, ScrollView, Pressable } from "react-native"
+import { useState, useEffect, useCallback, useRef } from "react"
+import { Text, StyleSheet, View, ActivityIndicator, ScrollView } from "react-native"
 import { fonts } from "../styles/typography"
-import { Download, MapPinOff, type LucideIcon } from "lucide-react-native"
-import { Container, Card, SectionTitle, Divider, Button } from "../components"
+import { Download, MapPinOff } from "lucide-react-native"
+import { Container, Card, SectionTitle, Button, FormatSelector } from "../components"
 import { useTheme } from "../hooks/useTheme"
-import { ThemeColors, LocationCoords } from "../types/global"
+import { LocationCoords } from "../types/global"
 import NativeLocationService from "../services/NativeLocationService"
 import { LARGE_FILE_THRESHOLD, formatBytes, getByteSize, EXPORT_FORMATS, ExportFormat } from "../utils/exportConverters"
 import { logger } from "../utils/logger"
@@ -177,25 +177,8 @@ export function ExportDataScreen() {
             {/* Format Selection */}
             <View style={styles.section}>
               <SectionTitle>Select Format</SectionTitle>
-
               <Card>
-                {(Object.entries(EXPORT_FORMATS) as [ExportFormat, (typeof EXPORT_FORMATS)[ExportFormat]][]).map(
-                  ([key, config], index, arr) => (
-                    <React.Fragment key={key}>
-                      <FormatOption
-                        icon={config.icon}
-                        title={config.label}
-                        subtitle={config.subtitle}
-                        description={config.description}
-                        extension={config.extension}
-                        selected={selectedFormat === key}
-                        onPress={() => setSelectedFormat(key)}
-                        colors={colors}
-                      />
-                      {index < arr.length - 1 && <Divider />}
-                    </React.Fragment>
-                  )
-                )}
+                <FormatSelector selectedFormat={selectedFormat} onSelectFormat={setSelectedFormat} />
               </Card>
             </View>
 
@@ -223,76 +206,6 @@ export function ExportDataScreen() {
         </View>
       )}
     </Container>
-  )
-}
-
-// --- Format Option Component ---
-
-const FormatOption = ({
-  icon: Icon,
-  title,
-  subtitle,
-  description,
-  extension,
-  selected,
-  onPress,
-  colors
-}: {
-  icon: LucideIcon
-  title: string
-  subtitle: string
-  description: string
-  extension: string
-  selected: boolean
-  onPress: () => void
-  colors: ThemeColors
-}) => {
-  const backgroundColor = selected ? colors.primary + "12" : "transparent"
-  const radioBgColor = selected ? colors.primary + "20" : "transparent"
-
-  return (
-    <Pressable
-      style={({ pressed }) => [styles.formatOption, { backgroundColor }, pressed && { opacity: 0.7 }]}
-      onPress={onPress}
-    >
-      {selected && <View style={[styles.selectionBar, { backgroundColor: colors.primary }]} />}
-
-      <View style={styles.formatContent}>
-        <View style={styles.leftContent}>
-          <Icon size={28} color={colors.primaryDark} />
-          <View style={styles.textContent}>
-            <View style={styles.titleRow}>
-              <Text style={[styles.formatTitle, { color: colors.text }]}>{title}</Text>
-              <View
-                style={[
-                  styles.extensionBadge,
-                  {
-                    backgroundColor: selected ? colors.primary + "20" : colors.primary + "15",
-                    borderColor: selected ? colors.primary + "60" : colors.primary + "30"
-                  }
-                ]}
-              >
-                <Text style={[styles.extensionText, { color: colors.primaryDark }]}>{extension}</Text>
-              </View>
-            </View>
-            <Text style={[styles.formatSubtitle, { color: colors.textSecondary }]}>{subtitle}</Text>
-            <Text style={[styles.formatDescription, { color: colors.textLight }]}>{description}</Text>
-          </View>
-        </View>
-
-        <View
-          style={[
-            styles.radio,
-            {
-              borderColor: selected ? colors.primary : colors.border,
-              backgroundColor: radioBgColor
-            }
-          ]}
-        >
-          {selected && <View style={[styles.radioInner, { backgroundColor: colors.primary }]} />}
-        </View>
-      </View>
-    </Pressable>
   )
 }
 
@@ -359,76 +272,6 @@ const styles = StyleSheet.create({
   },
   section: {
     marginBottom: 24
-  },
-  formatOption: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    marginHorizontal: -16,
-    position: "relative"
-  },
-  selectionBar: {
-    position: "absolute",
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: 4
-  },
-  formatContent: {
-    flexDirection: "row",
-    alignItems: "center"
-  },
-  leftContent: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 14
-  },
-  textContent: {
-    flex: 1
-  },
-  titleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    marginBottom: 2
-  },
-  formatTitle: {
-    fontSize: 16,
-    ...fonts.semiBold,
-    letterSpacing: -0.2
-  },
-  extensionBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 6,
-    borderWidth: 1
-  },
-  extensionText: {
-    fontSize: 10,
-    ...fonts.bold,
-    letterSpacing: 0.3
-  },
-  formatSubtitle: {
-    fontSize: 13,
-    marginBottom: 2
-  },
-  formatDescription: {
-    fontSize: 12,
-    lineHeight: 16
-  },
-  radio: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    borderWidth: 2,
-    justifyContent: "center",
-    alignItems: "center",
-    marginLeft: 12
-  },
-  radioInner: {
-    width: 12,
-    height: 12,
-    borderRadius: 6
   },
   loader: {
     position: "absolute",

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -10,17 +10,10 @@ import { ProfileService } from "../services/ProfileService"
 import { showAlert } from "../services/modalService"
 import { TrackingProfile, ProfileConditionType } from "../types/global"
 import { fonts } from "../styles/typography"
-import { Container, SectionTitle, Card, Divider } from "../components"
+import { Container, SectionTitle, Card, Divider, SettingRow, NumericInput } from "../components"
 import { Check } from "lucide-react-native"
 import { logger } from "../utils/logger"
-import { MS_TO_KMH, PROFILE_CONDITIONS } from "../constants"
-
-const SYNC_OPTIONS = [
-  { label: "Instant", value: 0 },
-  { label: "1 min", value: 60 },
-  { label: "5 min", value: 300 },
-  { label: "15 min", value: 900 }
-]
+import { MS_TO_KMH, PROFILE_CONDITIONS, SYNC_INTERVAL_PRESETS, SYNC_INTERVAL_LABELS } from "../constants"
 
 const DEFAULT_PROFILE: Omit<TrackingProfile, "id" | "createdAt"> = {
   name: "",
@@ -47,6 +40,7 @@ export function ProfileEditorScreen({ navigation, route }: any) {
   const [distanceStr, setDistanceStr] = useState("0")
   const [priorityStr, setPriorityStr] = useState("10")
   const [delayStr, setDelayStr] = useState("60")
+  const [syncIntervalStr, setSyncIntervalStr] = useState("0")
 
   useEffect(() => {
     if (!profileId) return
@@ -69,6 +63,7 @@ export function ProfileEditorScreen({ navigation, route }: any) {
           setDistanceStr(String(existing.distance))
           setPriorityStr(String(existing.priority))
           setDelayStr(String(existing.deactivationDelay))
+          setSyncIntervalStr(String(existing.syncInterval))
           if (existing.condition.speedThreshold) {
             setSpeedKmh((existing.condition.speedThreshold * MS_TO_KMH).toFixed(0))
           }
@@ -149,6 +144,7 @@ export function ProfileEditorScreen({ navigation, route }: any) {
   }, [profile, isEditing, profileId, navigation])
 
   const isSpeed = profile.condition.type === "speed_above" || profile.condition.type === "speed_below"
+  const isCustomSyncInterval = !SYNC_INTERVAL_PRESETS.includes(profile.syncInterval)
 
   const inputStyle = [
     styles.numInput,
@@ -185,13 +181,7 @@ export function ProfileEditorScreen({ navigation, route }: any) {
 
           <Divider />
 
-          <View style={styles.settingRow}>
-            <View style={styles.settingContent}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>Priority</Text>
-              <Text style={[styles.settingHint, { color: colors.textLight }]}>
-                Higher number wins when multiple profiles match
-              </Text>
-            </View>
+          <SettingRow label="Priority" hint="Higher number wins when multiple profiles match">
             <TextInput
               style={inputStyle}
               keyboardType="numeric"
@@ -200,7 +190,7 @@ export function ProfileEditorScreen({ navigation, route }: any) {
               placeholder="10"
               placeholderTextColor={colors.placeholder}
             />
-          </View>
+          </SettingRow>
         </Card>
 
         {/* Condition */}
@@ -257,10 +247,7 @@ export function ProfileEditorScreen({ navigation, route }: any) {
         {/* Tracking Settings */}
         <SectionTitle style={styles.sectionGap}>Tracking Settings</SectionTitle>
         <Card>
-          <View style={styles.settingRow}>
-            <View style={styles.settingContent}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>Tracking Interval</Text>
-            </View>
+          <SettingRow label="Tracking Interval">
             <View style={styles.inputWithUnit}>
               <TextInput
                 style={inputStyle}
@@ -272,14 +259,11 @@ export function ProfileEditorScreen({ navigation, route }: any) {
               />
               <Text style={[styles.unit, { color: colors.textSecondary }]}>sec</Text>
             </View>
-          </View>
+          </SettingRow>
 
           <Divider />
 
-          <View style={styles.settingRow}>
-            <View style={styles.settingContent}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>Movement Threshold</Text>
-            </View>
+          <SettingRow label="Movement Threshold">
             <View style={styles.inputWithUnit}>
               <TextInput
                 style={inputStyle}
@@ -291,46 +275,91 @@ export function ProfileEditorScreen({ navigation, route }: any) {
               />
               <Text style={[styles.unit, { color: colors.textSecondary }]}>m</Text>
             </View>
-          </View>
+          </SettingRow>
 
           <Divider />
 
-          <Text style={[styles.label, styles.syncSectionLabel, { color: colors.textSecondary }]}>Sync Interval</Text>
+          <Text style={[styles.syncLabel, { color: colors.textSecondary }]}>Sync Interval</Text>
           <View style={styles.syncGrid}>
-            {SYNC_OPTIONS.map((opt) => {
-              const selected = profile.syncInterval === opt.value
+            {SYNC_INTERVAL_PRESETS.map((sec) => {
+              const isSelected = profile.syncInterval === sec && SYNC_INTERVAL_PRESETS.includes(profile.syncInterval)
               return (
                 <Pressable
-                  key={opt.value}
+                  key={sec}
                   style={({ pressed }) => [
                     styles.syncOption,
                     {
-                      backgroundColor: selected ? colors.primary + "15" : colors.background,
-                      borderColor: selected ? colors.primary : colors.border
+                      backgroundColor: isSelected ? colors.primary + "15" : colors.background,
+                      borderColor: isSelected ? colors.primary : colors.border
                     },
                     pressed && { opacity: 0.7 }
                   ]}
-                  onPress={() => setProfile((prev) => ({ ...prev, syncInterval: opt.value }))}
+                  onPress={() => setProfile((prev) => ({ ...prev, syncInterval: sec }))}
                 >
-                  <Text style={[styles.syncLabel, { color: selected ? colors.primary : colors.text }]}>
-                    {opt.label}
+                  <Text style={[styles.syncOptionLabel, { color: isSelected ? colors.primary : colors.text }]}>
+                    {SYNC_INTERVAL_LABELS[sec]}
                   </Text>
                 </Pressable>
               )
             })}
+            <Pressable
+              style={({ pressed }) => [
+                styles.syncOption,
+                {
+                  backgroundColor: isCustomSyncInterval ? colors.primary + "15" : colors.background,
+                  borderColor: isCustomSyncInterval ? colors.primary : colors.border
+                },
+                pressed && { opacity: 0.7 }
+              ]}
+              onPress={() => {
+                if (!isCustomSyncInterval) {
+                  const customValue = 1800
+                  setSyncIntervalStr(customValue.toString())
+                  setProfile((prev) => ({ ...prev, syncInterval: customValue }))
+                }
+              }}
+            >
+              <Text style={[styles.syncOptionLabel, { color: isCustomSyncInterval ? colors.primary : colors.text }]}>
+                Custom
+              </Text>
+            </Pressable>
           </View>
+
+          {isCustomSyncInterval && (
+            <View style={styles.customSyncInput}>
+              <NumericInput
+                label="Custom Sync Interval"
+                value={syncIntervalStr}
+                onChange={(val) => {
+                  setSyncIntervalStr(val)
+                  const num = Number(val)
+                  if (!isNaN(num) && num >= 0) {
+                    setProfile((prev) => ({ ...prev, syncInterval: num }))
+                  }
+                }}
+                onBlur={() => {
+                  const num = Number(syncIntervalStr)
+                  if (isNaN(num) || num < 0) {
+                    setSyncIntervalStr("0")
+                    setProfile((prev) => ({ ...prev, syncInterval: 0 }))
+                  }
+                }}
+                unit="seconds"
+                placeholder="1800"
+                hint="Custom interval in seconds"
+                colors={colors}
+              />
+            </View>
+          )}
         </Card>
 
         {/* Deactivation Delay */}
         <SectionTitle style={styles.sectionGap}>Deactivation</SectionTitle>
         <Card>
-          <View style={styles.settingRow}>
-            <View style={styles.settingContent}>
-              <Text style={[styles.settingLabel, { color: colors.text }]}>Deactivation Delay</Text>
-              <Text style={[styles.settingHint, { color: colors.textLight }]}>
-                Wait before reverting to default settings after the condition stops matching. Prevents rapid switching.
-              </Text>
-            </View>
+          <SettingRow
+            label="Deactivation Delay"
+            hint="Wait before reverting to default settings after the condition stops matching. Prevents rapid switching."
+          >
             <View style={styles.inputWithUnit}>
               <TextInput
                 style={inputStyle}
@@ -342,7 +371,7 @@ export function ProfileEditorScreen({ navigation, route }: any) {
               />
               <Text style={[styles.unit, { color: colors.textSecondary }]}>sec</Text>
             </View>
-          </View>
+          </SettingRow>
         </Card>
 
         {/* Save Button */}
@@ -390,15 +419,6 @@ const styles = StyleSheet.create({
   },
   inputWithUnit: { flexDirection: "row", alignItems: "center", gap: 6 },
   unit: { fontSize: 14, ...fonts.medium, minWidth: 28 },
-  settingRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: 4
-  },
-  settingContent: { flex: 1, marginRight: 16 },
-  settingLabel: { fontSize: 15, ...fonts.semiBold, marginBottom: 2 },
-  settingHint: { fontSize: 12, ...fonts.regular, lineHeight: 16 },
   conditionGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
@@ -414,15 +434,11 @@ const styles = StyleSheet.create({
   },
   conditionLabel: { fontSize: 13, ...fonts.semiBold },
   conditionDesc: { fontSize: 11, ...fonts.regular, textAlign: "center" },
-  syncGrid: { flexDirection: "row", gap: 8 },
-  syncOption: {
-    flex: 1,
-    padding: 12,
-    borderRadius: 10,
-    borderWidth: 1.5,
-    alignItems: "center"
-  },
-  syncLabel: { fontSize: 13, ...fonts.semiBold },
+  syncLabel: { fontSize: 12, ...fonts.semiBold, marginBottom: 8, textTransform: "uppercase", letterSpacing: 0.5 },
+  syncGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  syncOption: { width: "31%", padding: 12, borderRadius: 10, borderWidth: 1.5, alignItems: "center" }, // ~3 per row with gap
+  syncOptionLabel: { fontSize: 13, ...fonts.semiBold },
+  customSyncInput: { marginTop: 12 },
   saveBtn: {
     flexDirection: "row",
     alignItems: "center",
@@ -434,6 +450,5 @@ const styles = StyleSheet.create({
   },
   saveBtnText: { fontSize: 16, ...fonts.semiBold },
   saveBtnDisabled: { opacity: 0.6 },
-  syncSectionLabel: { marginBottom: 8 },
   sectionGap: { marginTop: 24 }
 })

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -65,7 +65,7 @@ jest.mock("../../components", () => {
     FloatingSaveIndicator: () => null,
     Container: ({ children }: any) => R.createElement(View, null, children),
     Divider: () => R.createElement(View, null),
-    ChipGroup: ({ options, onSelect }: any) =>
+    ChipGroup: ({ options, selected, onSelect }: any) =>
       R.createElement(
         View,
         null,
@@ -73,7 +73,7 @@ jest.mock("../../components", () => {
           R.createElement(
             Pressable,
             { key: opt.value, onPress: () => onSelect(opt.value) },
-            R.createElement(Text, null, opt.label)
+            R.createElement(Text, null, opt.label, selected === opt.value ? " (selected)" : "")
           )
         )
       )
@@ -97,12 +97,12 @@ describe("ApiSettingsScreen", () => {
 
   describe("template switching", () => {
     it("renders all template options", () => {
-      const { getByText } = renderScreen()
+      const { getByText, getAllByText } = renderScreen()
 
-      expect(getByText("Custom")).toBeTruthy()
+      expect(getAllByText(/Custom/).length).toBeGreaterThan(0)
       expect(getByText("Dawarich")).toBeTruthy()
       expect(getByText("OwnTracks")).toBeTruthy()
-      expect(getByText("PhoneTrack")).toBeTruthy()
+      expect(getByText(/PhoneTrack/)).toBeTruthy()
       expect(getByText("Reitti")).toBeTruthy()
       expect(getByText("Traccar")).toBeTruthy()
     })
@@ -134,7 +134,7 @@ describe("ApiSettingsScreen", () => {
     it("selecting PhoneTrack template applies its unique field names", () => {
       const { getByText, getByDisplayValue } = renderScreen()
 
-      fireEvent.press(getByText("PhoneTrack"))
+      fireEvent.press(getByText(/PhoneTrack/))
 
       // PhoneTrack uses different field names
       expect(getByDisplayValue("speed")).toBeTruthy() // vel -> speed
@@ -155,10 +155,10 @@ describe("ApiSettingsScreen", () => {
       const { getByText, getByDisplayValue } = renderScreen()
 
       // First switch to PhoneTrack
-      fireEvent.press(getByText("PhoneTrack"))
+      fireEvent.press(getByText(/PhoneTrack/))
       expect(getByDisplayValue("speed")).toBeTruthy()
 
-      // Switch to Custom — field map stays as PhoneTrack's
+      // Switch to Custom - field map stays as PhoneTrack's
       fireEvent.press(getByText("Custom"))
       expect(getByDisplayValue("speed")).toBeTruthy()
     })
@@ -191,17 +191,18 @@ describe("ApiSettingsScreen", () => {
   })
 
   describe("HTTP method switching", () => {
-    it("renders POST and GET options", () => {
-      const { getByText } = renderScreen()
+    it("renders POST and GET options inline", () => {
+      const { getAllByText, getByText } = renderScreen()
 
-      expect(getByText("POST")).toBeTruthy()
-      expect(getByText("GET")).toBeTruthy()
+      // ChipGroup renders both options inline (no picker to open)
+      expect(getAllByText(/POST/).length).toBeGreaterThan(0)
+      expect(getByText(/GET/)).toBeTruthy()
     })
 
     it("switching to GET shows query parameter hint", () => {
       const { getByText } = renderScreen()
 
-      fireEvent.press(getByText("GET"))
+      fireEvent.press(getByText(/^GET$/))
 
       expect(getByText("Fields sent as URL query parameters instead of JSON body")).toBeTruthy()
     })
@@ -209,7 +210,7 @@ describe("ApiSettingsScreen", () => {
     it("switching method triggers immediate save", () => {
       const { getByText } = renderScreen()
 
-      fireEvent.press(getByText("GET"))
+      fireEvent.press(getByText(/^GET$/))
 
       expect(mockImmediateSaveAndRestart).toHaveBeenCalled()
     })
@@ -217,7 +218,7 @@ describe("ApiSettingsScreen", () => {
     it("example payload changes format for GET method", () => {
       const { getByText } = renderScreen()
 
-      fireEvent.press(getByText("GET"))
+      fireEvent.press(getByText(/^GET$/))
 
       expect(getByText("EXAMPLE REQUEST")).toBeTruthy()
     })

--- a/apps/mobile/src/screens/__tests__/ExportDataScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ExportDataScreen.test.tsx
@@ -137,6 +137,7 @@ jest.mock("../../utils/logger", () => ({
 jest.mock("../../components", () => {
   const R = require("react")
   const RN = require("react-native")
+  const { EXPORT_FORMATS } = require("../../utils/exportConverters")
   return {
     Container: function (props: any) {
       return R.createElement(RN.View, null, props.children)
@@ -155,6 +156,24 @@ jest.mock("../../components", () => {
         RN.Pressable,
         { onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
         R.createElement(RN.Text, null, props.title)
+      )
+    },
+    FormatSelector: function ({ onSelectFormat }: any) {
+      return R.createElement(
+        RN.View,
+        null,
+        Object.entries(EXPORT_FORMATS).map(function ([key, config]: any) {
+          return R.createElement(
+            RN.Pressable,
+            {
+              key: key,
+              onPress: function () {
+                onSelectFormat(key)
+              }
+            },
+            R.createElement(RN.Text, null, config.label)
+          )
+        })
       )
     }
   }

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -63,7 +63,15 @@ jest.mock("../../components", () => {
     Container: ({ children }: any) => R.createElement(View, null, children),
     SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
     Card: ({ children }: any) => R.createElement(View, null, children),
-    Divider: () => R.createElement(View, null)
+    Divider: () => R.createElement(View, null),
+    SettingRow: ({ label, hint, children }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        hint && R.createElement(Text, null, hint),
+        children
+      )
   }
 })
 
@@ -110,10 +118,10 @@ describe("ProfileEditorScreen", () => {
     expect(getByText("Speed Below")).toBeTruthy()
   })
 
-  it("shows all sync interval options", () => {
-    const { getByText } = renderNewProfile()
+  it("shows all sync interval options inline", () => {
+    const { getByText, getAllByText } = renderNewProfile()
 
-    expect(getByText("Instant")).toBeTruthy()
+    expect(getAllByText("Instant").length).toBeGreaterThan(0)
     expect(getByText("1 min")).toBeTruthy()
     expect(getByText("5 min")).toBeTruthy()
     expect(getByText("15 min")).toBeTruthy()
@@ -146,7 +154,7 @@ describe("ProfileEditorScreen", () => {
     const nameInput = getByDisplayValue("")
     fireEvent.changeText(nameInput, "Speed Test")
 
-    // Select speed_above condition — defaults to 30 km/h threshold
+    // Select speed_above condition - defaults to 30 km/h threshold
     fireEvent.press(getByText("Speed Above"))
 
     fireEvent.press(getByText("Create Profile"))
@@ -269,7 +277,7 @@ describe("ProfileEditorScreen", () => {
   it("shows speed threshold input only for speed conditions", () => {
     const { getByText, queryByText } = renderNewProfile()
 
-    // Default is charging — no speed input
+    // Default is charging - no speed input
     expect(queryByText("Speed Threshold (km/h)")).toBeNull()
 
     // Select Speed Above


### PR DESCRIPTION
- Extract SettingRow, RadioDot, FormatOption, FormatSelector into reusable ui/ components
- Deduplicate settingRow/settingContent/settingLabel styles across 4 files
- Move SYNC_INTERVAL_PRESETS/LABELS to constants (single source of truth)
- Derive API template options from API_TEMPLATES instead of hand-maintained list
- Add accessibility roles (radio, radiogroup) to preset and format selectors
- Add custom sync interval input to ProfileEditorScreen