### PR TITLE
Replace NEARBY_WIFI_DEVICES with ACCESS_LOCAL_NETWORK for Android 17+

### DIFF
--- a/apps/docs/docs/development/permissions.md
+++ b/apps/docs/docs/development/permissions.md
@@ -18,7 +18,7 @@ These are the permissions Colota uses and why. None are related to analytics, ad
 | Network State                  | Yes         | Check connectivity before syncing                 |
 | Boot Completed                 | Yes         | Auto-restart tracking after device reboot         |
 | Notifications                  | Android 13+ | Display the foreground service notification       |
-| Nearby Wi-Fi Devices           | Android 17+ | Access local network servers (self-hosted)        |
+| Local Network Access           | Android 17+ | Access local network servers (self-hosted)        |
 | Battery Optimization Exemption | Optional    | Prevent Android from killing the tracking service |
 
 ## Permission Request Flow
@@ -80,13 +80,15 @@ android.permission.POST_NOTIFICATIONS
 
 Starting with Android 13, apps must request notification permission explicitly. Colota needs this for the foreground service notification. If denied, the service may still run but with reduced reliability depending on the Android version.
 
-### Local Network (Nearby Wi-Fi Devices)
+### Local Network Access
 
 ```
-android.permission.NEARBY_WIFI_DEVICES
+android.permission.ACCESS_LOCAL_NETWORK
 ```
 
-Starting with Android 17, apps need this permission to connect to other devices on the local network. Colota requests it when you use **Test Connection** with a private/local IP endpoint (e.g. `192.168.x.x`, `10.x.x.x`, `172.16-31.x.x`, or `100.64.x.x`). Loopback addresses (`localhost` / `127.0.0.1`) do not require this permission. The `neverForLocation` flag is set, indicating this permission is not used to derive location, only for network access. If your server is a public HTTPS endpoint, this permission is never requested.
+Starting with Android 17, apps need this permission to connect to devices on the local network. Colota requests it when you use **Test Connection** with a private/local IP endpoint (e.g. `192.168.x.x`, `10.x.x.x`, `172.16-31.x.x`, or `100.64.x.x`). Loopback addresses (`localhost` / `127.0.0.1`) do not require this permission. If your server is a public HTTPS endpoint, this permission is never requested.
+
+:::note Android 16 On some Android 16 devices, local network access may be enforced early via security patches. In this case, Android uses the **Nearby Wi-Fi Devices** (`NEARBY_WIFI_DEVICES`) permission instead. If your local server is unreachable on Android 16, go to **Android Settings > Apps > Colota > Permissions** and enable **Nearby devices** manually. :::
 
 ### Battery Optimization
 

--- a/apps/docs/docs/faq.md
+++ b/apps/docs/docs/faq.md
@@ -48,6 +48,6 @@ Depends on your settings. With the **Balanced** preset (30s interval, batch sync
 
 Colota requires Android 8.0 (API 26) or higher.
 
-### Why does Colota ask for "Nearby devices" permission?
+### Why does Colota ask for "Local network access" permission?
 
-On Android 17+, apps need the Nearby Wi-Fi Devices permission to connect to local network addresses. Colota only requests this when your server is on a private/local IP (e.g. `192.168.x.x`). It is not used for device scanning or discovery, only to reach your self-hosted server.
+On Android 17+, apps need the Local Network Access permission to connect to local network addresses. Colota only requests this when your server is on a private/local IP (e.g. `192.168.x.x`). It is not used for device scanning or discovery, only to reach your self-hosted server. On some Android 16 devices, this may be enforced early via security patches under the "Nearby devices" permission name.

--- a/apps/docs/docs/guides/troubleshooting.md
+++ b/apps/docs/docs/guides/troubleshooting.md
@@ -25,7 +25,7 @@ sidebar_position: 4
 4. Verify network connectivity
 5. Check the queue count in **Data Management**
 
-**Common causes**: Wrong URL, HTTPS required for non-localhost, expired SSL certificate, incorrect authentication, mismatched field mapping, self-signed certificate (not supported), **Wi-Fi Only Sync** enabled while on cellular data, missing local network permission on Android 17+.
+**Common causes**: Wrong URL, HTTPS required for non-localhost, expired SSL certificate, incorrect authentication, mismatched field mapping, self-signed certificate (not supported), **Wi-Fi Only Sync** enabled while on cellular data, missing local network permission on Android 16+.
 
 ## Exporting app logs
 
@@ -58,15 +58,18 @@ Key log tags:
 
 You can also use the **Location History** screen in the app to see recorded locations on a track map or as a list with their accuracy and timestamps.
 
-## Local server not reachable (Android 17+)
+## Local server not reachable (Android 16+)
 
-On Android 17 and later, connecting to local/private network addresses requires the **Nearby Wi-Fi Devices** permission. Colota requests this automatically when you test a local endpoint.
+Starting with Android 17, connecting to local/private network addresses requires the **Local Network Access** permission. Colota requests this automatically when you test a local endpoint.
+
+On some Android 16 devices, this may already be enforced via security patches using the **Nearby Wi-Fi Devices** permission instead.
 
 If sync to a local server stopped working after an Android update:
 
 1. Go to **Android Settings > Apps > Colota > Permissions**
-2. Grant the **Nearby devices** permission
-3. Use the **Test Connection** button to verify
+2. On Android 17+: Grant the **Local network access** permission
+3. On Android 16: Grant the **Nearby devices** permission
+4. Use the **Test Connection** button to verify
 
 If you denied the permission and the system no longer shows the dialog, reset it from Android Settings.
 

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/NetworkManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/NetworkManager.kt
@@ -134,7 +134,7 @@ class NetworkManager(private val context: Context) {
             }
         } catch (e: java.net.SocketException) {
             if (isPrivateHost(url.host ?: "") && e.message?.contains("EPERM") == true) {
-                AppLogger.e(TAG, "Local network access denied - grant Nearby Devices permission", e)
+                AppLogger.e(TAG, "Local network access denied - grant Local Network Access permission", e)
             } else {
                 AppLogger.e(TAG, "Network error: ${e.message}", e)
             }

--- a/apps/mobile/src/components/ui/LocalNetworkDisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/LocalNetworkDisclosureModal.tsx
@@ -10,8 +10,8 @@ import { registerLocalNetworkDisclosureCallback } from "../../services/LocationS
 import { DisclosureModal } from "./DisclosureModal"
 
 /**
- * Disclosure modal for the local network (Nearby Devices) permission.
- * Shown before requesting NEARBY_WIFI_DEVICES on Android 17+.
+ * Disclosure modal for the local network permission.
+ * Shown before requesting ACCESS_LOCAL_NETWORK on Android 16+.
  */
 export function LocalNetworkDisclosureModal() {
   const { colors } = useTheme()
@@ -21,7 +21,7 @@ export function LocalNetworkDisclosureModal() {
       icon={<Wifi size={28} color={colors.primary} />}
       title="Local Network Access"
       paragraphs={[
-        "Your server is on the local network. Colota needs the nearby devices permission to reach it.",
+        "Your server is on the local network. Colota needs local network access permission to reach it.",
         "This permission is only used to connect to your self-hosted server. No device scanning or discovery is performed."
       ]}
       confirmLabel="Continue"

--- a/apps/mobile/src/services/LocationServicePermission.ts
+++ b/apps/mobile/src/services/LocationServicePermission.ts
@@ -25,7 +25,7 @@ const ANDROID_10 = 29
 /** Android version for notifications (Android 13) */
 const ANDROID_13 = 33
 
-/** Android version for local network permission enforcement (expected Android 17) */
+/** Android 17 (API 37) - local network enforced via ACCESS_LOCAL_NETWORK */
 const ANDROID_LOCAL_NETWORK = 37
 
 /**
@@ -195,12 +195,12 @@ async function checkBatteryOptimization(): Promise<boolean> {
 
 async function checkLocalNetwork(): Promise<boolean> {
   if (getAndroidVersion() < ANDROID_LOCAL_NETWORK) return true
-  return await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES)
+  return await PermissionsAndroid.check("android.permission.ACCESS_LOCAL_NETWORK" as any)
 }
 
 /**
  * Requests the local network permission for accessing private/local IP endpoints.
- * Only needed on Android 17+ and only when the sync endpoint is a local address.
+ * Needed on Android 16+ when the sync endpoint is a local address.
  *
  * @returns True if permission is granted (or not needed)
  */
@@ -218,7 +218,7 @@ export async function ensureLocalNetworkPermission(): Promise<boolean> {
       : await fallbackLocalNetworkDisclosure()
     if (!consented) return false
 
-    const result = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES)
+    const result = await PermissionsAndroid.request("android.permission.ACCESS_LOCAL_NETWORK" as any)
     return result === PermissionsAndroid.RESULTS.GRANTED
   } catch (err) {
     logger.error("[PermissionService] Local network permission request failed:", err)
@@ -233,7 +233,7 @@ function fallbackLocalNetworkDisclosure(): Promise<boolean> {
   return new Promise((resolve) => {
     Alert.alert(
       "Local Network Access",
-      "Your server is on the local network. Colota needs the nearby devices permission to reach it.",
+      "Your server is on the local network. Colota needs local network access permission to reach it.",
       [
         { text: "Not Now", style: "cancel", onPress: () => resolve(false) },
         { text: "Continue", onPress: () => resolve(true) }

--- a/apps/mobile/src/services/__tests__/LocationServicePermission.test.ts
+++ b/apps/mobile/src/services/__tests__/LocationServicePermission.test.ts
@@ -323,10 +323,10 @@ describe("checkPermissions", () => {
     expect(result.localNetwork).toBe(true)
   })
 
-  it("checks NEARBY_WIFI_DEVICES on Android 37+", async () => {
+  it("checks ACCESS_LOCAL_NETWORK on Android 37+", async () => {
     setPlatform("android", 37)
     checkSpy.mockImplementation((permission: string) => {
-      if (permission === PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES) {
+      if (permission === "android.permission.ACCESS_LOCAL_NETWORK") {
         return Promise.resolve(false)
       }
       return Promise.resolve(true)
@@ -376,7 +376,7 @@ describe("ensureLocalNetworkPermission", () => {
     await ensureLocalNetworkPermission()
 
     expect(disclosureSpy).toHaveBeenCalledTimes(1)
-    expect(requestSpy).toHaveBeenCalledWith(PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES)
+    expect(requestSpy).toHaveBeenCalledWith("android.permission.ACCESS_LOCAL_NETWORK")
   })
 
   it("returns false if user denies disclosure", async () => {


### PR DESCRIPTION
NEARBY_WIFI_DEVICES was misleading - it implies device scanning, but Colota only needs local network access for self-hosted servers. Use the dedicated ACCESS_LOCAL_NETWORK permission (Android 17+) instead.

Android 16 users with early enforcement via security patches can enable "Nearby devices" manually in app settings (documented).

- Gate permission request behind API 37 (Android 17)
- Update disclosure modal and fallback alert text
- Update tests, docs, FAQ, and troubleshooting
- Update NetworkManager.kt error log message

see #198 
