### PR TITLE
feat: add monochrome adaptive icon layer for themed icons

### DIFF
--- a/apps/mobile/android/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,32 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+  <group
+      android:scaleX="0.7088889"
+      android:scaleY="0.7088889"
+      android:translateX="74.524445"
+      android:translateY="74.524445">
+    <!-- Pin shape with inner circle as hole via even-odd fill -->
+    <path
+        android:pathData="M256,120C196,120 152,164 152,224C152,300 256,392 256,392C256,392 360,300 360,224C360,164 316,120 256,120Z M220,224A36,36 0,1,1 292,224A36,36 0,1,1 220,224Z"
+        android:fillColor="#000000"
+        android:fillType="evenOdd"/>
+    <!-- Signal arcs -->
+    <path
+        android:pathData="M256,88a168,168 0,0 1,168 168"
+        android:strokeWidth="16"
+        android:strokeAlpha="0.6"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M256,56a200,200 0,0 1,200 200"
+        android:strokeWidth="12"
+        android:strokeAlpha="0.4"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+  </group>
+</vector>

--- a/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/apps/mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Adds ic_launcher_monochrome.xml. Referenced in both ic_launcher.xml and ic_launcher_round.xml so the icon themes correctly on Pixel Launcher and other compliant launchers.

Closes #233
