### PR TITLE
feat: add home screen shortcuts for start/stop tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Colota sends your location to your own server over HTTP(S). It works offline, su
 - **Tracking Profiles** - Automatically adjust GPS interval, distance filter and sync settings based on conditions like charging, car mode or speed.
 - **Flexible Sync** - Instant, batch, Wi-Fi only or offline modes.
 - **Display Settings** - Choose between metric and imperial units, 12h or 24h time format. Auto-detected from device locale on first use.
+- **App Shortcuts** - Long-press the app icon to start or stop tracking directly from the home screen, compatible with automation apps like Tasker and Samsung Routines.
 - **Quick Setup** - Configure devices via `colota://setup` deep links or QR codes.
 - **Authentication** - Basic Auth, Bearer Token or custom headers with AES-256-GCM encryption.
 - **Dark Mode** - Full light and dark theme support.

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -172,6 +172,7 @@ Wraps Android's `EncryptedSharedPreferences` for encrypted credential storage (A
 | `AutoExportScheduler` | Schedules a daily (24h) check worker via WorkManager with battery-not-low constraint - frequency logic (daily/weekly/monthly) is handled at runtime by the worker |
 | `AutoExportConfig` | Typed data class wrapping auto-export settings from the SQLite settings table with validation, `isExportDue()`, and `nextExportTimestamp()` |
 | `ExportConverters` | Native Kotlin export converters (CSV, GeoJSON, GPX, KML) with in-memory, streaming, and file-based (`exportToFile`) interfaces |
+| `ShortcutHandlerActivity` | Handles app shortcut intents (start/stop tracking) without showing UI - reads config from DB via `ServiceConfig.fromDatabase()` and dispatches to `LocationForegroundService` |
 
 ## React Native Layer
 

--- a/apps/docs/docs/guides/app-shortcuts.md
+++ b/apps/docs/docs/guides/app-shortcuts.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 3
+---
+
+# App Shortcuts
+
+Long-press the Colota icon on your home screen to access shortcuts for starting and stopping tracking without opening the app.
+
+## Available Shortcuts
+
+| Shortcut           | Action                                                |
+| ------------------ | ----------------------------------------------------- |
+| **Start Tracking** | Starts the tracking service using your saved settings |
+| **Stop Tracking**  | Stops the tracking service                            |
+
+## Requirements
+
+Shortcuts use your saved settings directly - no UI interaction needed. Before using shortcuts, make sure you have:
+
+- Granted location permissions (fine + background)
+- Exempted Colota from battery optimization
+- Configured an endpoint (if syncing to a server)
+
+If permissions have not been granted, the start shortcut will not work. Open the app first to complete setup.
+
+## Automations
+
+Shortcuts can be triggered by automation apps, making hands-free tracking possible while driving.
+
+**Samsung Routines** (One UI):
+
+1. Open the **Routines** app
+2. Create a new routine
+3. Add a trigger (e.g. connected to car Bluetooth)
+4. Add action → **App shortcuts** → select Colota → **Start Tracking**
+
+**Tasker**:
+
+1. Create a new Task
+2. Add action → **App** → **Shortcut**
+3. Select the Colota start or stop shortcut

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -44,6 +44,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "guides/geofencing",
         "guides/tracking-profiles",
+        "guides/app-shortcuts",
         "guides/data-export",
         "guides/data-management",
         "guides/deep-link-setup",

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -60,7 +60,17 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="colota" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
+
+        <!-- Handles app shortcut intents without showing UI -->
+        <activity
+            android:name=".service.ShortcutHandlerActivity"
+            android:theme="@android:style/Theme.NoDisplay"
+            android:exported="true"
+            android:excludeFromRecents="true" />
 
         <!-- Foreground location service -->
         <service

--- a/apps/mobile/android/app/src/main/java/com/colota/service/ShortcutHandlerActivity.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/ShortcutHandlerActivity.kt
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+package com.Colota.service
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import com.Colota.data.DatabaseHelper
+import com.Colota.util.AppLogger
+
+/**
+ * Transparent activity that handles app shortcut intents for starting and stopping
+ * the tracking service. Finishes immediately after dispatching the action - no UI is shown.
+ */
+class ShortcutHandlerActivity : Activity() {
+
+    companion object {
+        private const val TAG = "ShortcutHandlerActivity"
+        const val ACTION_START = "com.Colota.ACTION_SHORTCUT_START"
+        const val ACTION_STOP = "com.Colota.ACTION_SHORTCUT_STOP"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val dbHelper = DatabaseHelper.getInstance(this)
+
+        when (intent?.action) {
+            ACTION_START -> {
+                AppLogger.d(TAG, "Shortcut: start tracking")
+                val config = ServiceConfig.fromDatabase(dbHelper)
+                val serviceIntent = config.toIntent(
+                    Intent(this, LocationForegroundService::class.java)
+                )
+                startForegroundService(serviceIntent)
+            }
+            ACTION_STOP -> {
+                AppLogger.d(TAG, "Shortcut: stop tracking")
+                dbHelper.saveSetting("tracking_enabled", "false")
+                dbHelper.saveSetting("pause_zone_name", "")
+                stopService(Intent(this, LocationForegroundService::class.java))
+            }
+        }
+
+        finish()
+    }
+}

--- a/apps/mobile/android/app/src/main/res/drawable/ic_shortcut_start.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/ic_shortcut_start.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <!-- Background circle -->
+    <path
+        android:pathData="M24,24m-24,0a24,24 0,1,0 48,0a24,24 0,1,0 -48,0"
+        android:fillColor="#FFFFFF"/>
+    <!-- Play triangle pointing right -->
+    <path
+        android:pathData="M14,14L14,34L34,24Z"
+        android:fillColor="#0D9387"/>
+</vector>

--- a/apps/mobile/android/app/src/main/res/drawable/ic_shortcut_stop.xml
+++ b/apps/mobile/android/app/src/main/res/drawable/ic_shortcut_stop.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <!-- Background circle -->
+    <path
+        android:pathData="M24,24m-24,0a24,24 0,1,0 48,0a24,24 0,1,0 -48,0"
+        android:fillColor="#FFFFFF"/>
+    <!-- Stop square -->
+    <path
+        android:pathData="M13,13h22v22H13z"
+        android:fillColor="#E53935"/>
+</vector>

--- a/apps/mobile/android/app/src/main/res/values/strings.xml
+++ b/apps/mobile/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">Colota</string>
+    <string name="shortcut_start_short">Start</string>
+    <string name="shortcut_start_long">Start Tracking</string>
+    <string name="shortcut_stop_short">Stop</string>
+    <string name="shortcut_stop_long">Stop Tracking</string>
 </resources>

--- a/apps/mobile/android/app/src/main/res/xml/shortcuts.xml
+++ b/apps/mobile/android/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut
+        android:shortcutId="start_tracking"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_start"
+        android:shortcutShortLabel="@string/shortcut_start_short"
+        android:shortcutLongLabel="@string/shortcut_start_long">
+        <intent
+            android:action="com.Colota.ACTION_SHORTCUT_START"
+            android:targetPackage="com.Colota"
+            android:targetClass="com.Colota.service.ShortcutHandlerActivity" />
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="stop_tracking"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_stop"
+        android:shortcutShortLabel="@string/shortcut_stop_short"
+        android:shortcutLongLabel="@string/shortcut_stop_long">
+        <intent
+            android:action="com.Colota.ACTION_SHORTCUT_STOP"
+            android:targetPackage="com.Colota"
+            android:targetClass="com.Colota.service.ShortcutHandlerActivity" />
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+
+</shortcuts>

--- a/apps/mobile/src/hooks/__tests__/useLocationTracking.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useLocationTracking.test.ts
@@ -11,11 +11,13 @@ jest.mock("../../services/modalService", () => ({
 const mockStart = jest.fn().mockResolvedValue(undefined)
 const mockStop = jest.fn()
 const mockGetMostRecentLocation = jest.fn().mockResolvedValue(null)
+const mockIsTrackingActive = jest.fn().mockResolvedValue(false)
 
 jest.mock("../../services/NativeLocationService", () => ({
   start: (...args: any[]) => mockStart(...args),
   stop: (...args: any[]) => mockStop(...args),
-  getMostRecentLocation: (...args: any[]) => mockGetMostRecentLocation(...args)
+  getMostRecentLocation: (...args: any[]) => mockGetMostRecentLocation(...args),
+  isTrackingActive: (...args: any[]) => mockIsTrackingActive(...args)
 }))
 
 // Mock permissions
@@ -238,6 +240,90 @@ describe("useLocationTracking", () => {
       })
 
       expect(result.current.tracking).toBe(true)
+    })
+  })
+
+  describe("AppState foreground sync", () => {
+    let appStateCallback: (state: string) => void
+
+    beforeEach(() => {
+      const { AppState } = require("react-native")
+      ;(AppState.addEventListener as jest.Mock).mockImplementation((_event: string, cb: (state: string) => void) => {
+        appStateCallback = cb
+        return { remove: jest.fn() }
+      })
+    })
+
+    it("reconnects when service was started externally while app was backgrounded", async () => {
+      mockIsTrackingActive.mockResolvedValue(true)
+      mockGetMostRecentLocation.mockResolvedValue(null)
+
+      const { result } = renderHook(() => useLocationTracking(DEFAULT_SETTINGS))
+
+      // App is not tracking in UI, but service is active
+      await act(async () => {
+        await appStateCallback("active")
+      })
+
+      expect(mockIsTrackingActive).toHaveBeenCalled()
+      expect(result.current.tracking).toBe(true)
+    })
+
+    it("updates UI to stopped when service was stopped externally", async () => {
+      mockIsTrackingActive.mockResolvedValue(false)
+
+      const { result } = renderHook(() => useLocationTracking(DEFAULT_SETTINGS))
+
+      // Start tracking in UI first
+      await act(async () => {
+        await result.current.startTracking(DEFAULT_SETTINGS)
+      })
+      expect(result.current.tracking).toBe(true)
+
+      // Service was stopped externally
+      await act(async () => {
+        await appStateCallback("active")
+      })
+
+      expect(result.current.tracking).toBe(false)
+    })
+
+    it("refreshes coords when already in sync on foreground", async () => {
+      mockIsTrackingActive.mockResolvedValue(true)
+      mockGetMostRecentLocation.mockResolvedValue({
+        latitude: 48.1,
+        longitude: 11.5,
+        accuracy: 10,
+        altitude: 500,
+        speed: 0,
+        bearing: 0,
+        timestamp: 1700000000,
+        battery: 80,
+        batteryStatus: 2
+      })
+
+      const { result } = renderHook(() => useLocationTracking(DEFAULT_SETTINGS))
+
+      await act(async () => {
+        await result.current.startTracking(DEFAULT_SETTINGS)
+      })
+
+      await act(async () => {
+        await appStateCallback("active")
+      })
+
+      expect(result.current.coords?.latitude).toBe(48.1)
+    })
+
+    it("does nothing when transitioning to background", async () => {
+      const { result } = renderHook(() => useLocationTracking(DEFAULT_SETTINGS))
+
+      await act(async () => {
+        await appStateCallback("background")
+      })
+
+      expect(mockIsTrackingActive).not.toHaveBeenCalled()
+      expect(result.current.tracking).toBe(false)
     })
   })
 

--- a/apps/mobile/src/hooks/useLocationTracking.ts
+++ b/apps/mobile/src/hooks/useLocationTracking.ts
@@ -83,38 +83,6 @@ export function useLocationTracking(settings: Settings): LocationTrackingResult 
   }, [tracking, isRestarting, coords])
 
   /**
-   * Fetches latest location from DB when app returns to foreground.
-   * Native events are suppressed while backgrounded, so coords go stale.
-   */
-  useEffect(() => {
-    const subscription = AppState.addEventListener("change", (nextState) => {
-      if (nextState === "active" && isTrackingRef.current) {
-        NativeLocationService.getMostRecentLocation()
-          .then((latest) => {
-            if (latest) {
-              setCoords({
-                latitude: latest.latitude,
-                longitude: latest.longitude,
-                accuracy: latest.accuracy,
-                altitude: latest.altitude ?? 0,
-                speed: latest.speed ?? 0,
-                bearing: latest.bearing ?? 0,
-                timestamp: latest.timestamp ?? Date.now(),
-                battery: latest.battery,
-                battery_status: latest.batteryStatus
-              })
-            }
-          })
-          .catch((err) => {
-            logger.error("[useLocationTracking] Failed to fetch location on resume:", err)
-          })
-      }
-    })
-
-    return () => subscription.remove()
-  }, [])
-
-  /**
    * Subscribes to real-time location updates from native service
    */
   useEffect(() => {
@@ -301,6 +269,57 @@ export function useLocationTracking(settings: Settings): LocationTrackingResult 
       logger.error("[useLocationTracking] Failed to fetch location on reconnect:", err)
     }
   }, [])
+
+  /**
+   * Syncs tracking state and coords when app returns to foreground.
+   * Detects external start/stop (e.g. app shortcuts) by comparing UI state
+   * against the DB's tracking_enabled flag.
+   */
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", async (nextState) => {
+      if (nextState !== "active") return
+
+      const serviceActive = await NativeLocationService.isTrackingActive().catch(() => null)
+      if (serviceActive === null) return
+
+      if (!isTrackingRef.current && serviceActive) {
+        // Service was started externally (e.g. start shortcut) - reconnect UI
+        logger.debug("[useLocationTracking] External start detected, reconnecting")
+        reconnect()
+      } else if (isTrackingRef.current && !serviceActive) {
+        // Service was stopped externally (e.g. stop shortcut) - update UI
+        logger.debug("[useLocationTracking] External stop detected, updating UI")
+        if (listenerRef.current) {
+          listenerRef.current.remove()
+          listenerRef.current = null
+        }
+        setTracking(false)
+      } else if (isTrackingRef.current && serviceActive) {
+        // Already in sync - refresh coords since events are suppressed while backgrounded
+        NativeLocationService.getMostRecentLocation()
+          .then((latest) => {
+            if (latest) {
+              setCoords({
+                latitude: latest.latitude,
+                longitude: latest.longitude,
+                accuracy: latest.accuracy,
+                altitude: latest.altitude ?? 0,
+                speed: latest.speed ?? 0,
+                bearing: latest.bearing ?? 0,
+                timestamp: latest.timestamp ?? Date.now(),
+                battery: latest.battery,
+                battery_status: latest.batteryStatus
+              })
+            }
+          })
+          .catch((err) => {
+            logger.error("[useLocationTracking] Failed to fetch location on resume:", err)
+          })
+      }
+    })
+
+    return () => subscription.remove()
+  }, [reconnect])
 
   /**
    * Cleanup on unmount


### PR DESCRIPTION
Long-pressing the app icon now shows Start Tracking and Stop Tracking shortcuts. Shortcuts use a transparent handler activity that reads config from the DB and dispatches directly to the foreground service - no UI required.

When the app returns to foreground, AppState detects any mismatch between UI state and the running service and reconnects or clears tracking state accordingly.

- Add ShortcutHandlerActivity with Theme.NoDisplay
- Add shortcuts.xml with static shortcut definitions
- Add teal/red shortcut icons (start/stop)
- Register shortcuts meta-data and activity in AndroidManifest
- Add AppState foreground sync to useLocationTracking
- Add AppState tests to useLocationTracking test suite
- Add app shortcuts guide to docs
- Update architecture.md and README

Closes #229