### PR TITLE
fix: bypass OS distance filter for location-dependent profiles

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -60,6 +60,9 @@ class LocationForegroundService : Service() {
     @Volatile private var motionDetector: MotionDetector? = null
     @Volatile private var lastKnownLocation: Location? = null
 
+    /** Whether the currently-registered location request bypasses the OS-level distance filter. */
+    @Volatile private var lastRequestedBypassOsFilter: Boolean = false
+
     /**
      * Pause-zone state. Threading contract:
      * - Mutated ONLY on the Main thread. Call sites: onStartCommand, enter/exitPauseZone,
@@ -253,6 +256,14 @@ class LocationForegroundService : Service() {
         profileManager.invalidateProfiles()
         conditionMonitor.start()
         profileManager.evaluate()
+        // evaluate() may have triggered a profile switch, which already restarts the
+        // location request. Compare what is currently registered with what is now needed;
+        // only restart when they differ (eg user enabled a speed profile while no profile
+        // matches yet, so evaluate() didn't switch anything).
+        if (isLocationUpdatesRegistered() && needsLocationStreamForProfiles() != lastRequestedBypassOsFilter) {
+            stopLocationUpdates()
+            setupLocationUpdates()
+        }
     }
 
     private fun handleManualFlush() {
@@ -326,15 +337,19 @@ class LocationForegroundService : Service() {
             return
         }
 
-        AppLogger.d(TAG, "Requesting location updates: interval=${config.interval}ms, distance=${config.minUpdateDistance}m")
+        val bypassOsFilter = needsLocationStreamForProfiles()
+        val osMinDistance = if (bypassOsFilter) 0f else config.minUpdateDistance
+        
+        AppLogger.d(TAG, "Requesting location updates: interval=${config.interval}ms, distance=${config.minUpdateDistance}m, osFilter=${osMinDistance}m")
 
         try {
             locationProvider.requestLocationUpdates(
                 intervalMs = config.interval,
-                minDistanceMeters = config.minUpdateDistance,
+                minDistanceMeters = osMinDistance,
                 looper = Looper.getMainLooper(),
                 callback = callback
             )
+            lastRequestedBypassOsFilter = bypassOsFilter
 
             locationProvider.getLastLocation(
                 onSuccess = { location ->
@@ -365,6 +380,17 @@ class LocationForegroundService : Service() {
         locationUpdateCallback?.let { locationProvider.removeLocationUpdates(it) }
         locationUpdateCallback = null
     }
+
+    /**
+     * True when at least one enabled profile's condition depends on the location stream
+     * (speed or stationary). When true, [setupLocationUpdates] passes 0m to the OS provider
+     * so fixes keep arriving within the configured movement threshold; the software-side
+     * filter in [handleLocationUpdate] still enforces it before DB writes and sync.
+     */
+    private fun needsLocationStreamForProfiles(): Boolean =
+        profileManager.getNeededConditionTypes().any { it in ProfileConstants.LOCATION_DEPENDENT_CONDITIONS }
+
+    private fun isLocationUpdatesRegistered(): Boolean = locationUpdateCallback != null
 
     /**
      * Diagnostic-only periodic logger. Records "time since last GPS fix" every 5 minutes
@@ -541,8 +567,9 @@ class LocationForegroundService : Service() {
         // Before distance filter so stationary locations still update the speed buffer
         profileManager.onLocationUpdate(location)
 
-        // Software-side distance filter (FLP bypasses the OS-level distance filter for some fixes)
-        // Bypassed during geofence entry delay so stationary arrival points are logged
+        // Software-side distance filter. Enforces config.minUpdateDistance for DB/sync
+        // regardless of the OS filter (which passes 0m to when a location-dependent
+        // profile is enabled). Bypassed during entry delay so arrival points get logged.
         if (pendingPauseZone == null && config.minUpdateDistance > 0f && prev != null) {
             val distance = prev.distanceTo(location)
             if (distance < config.minUpdateDistance) {

--- a/apps/mobile/android/app/src/main/java/com/colota/service/ProfileConstants.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/ProfileConstants.kt
@@ -12,6 +12,18 @@ object ProfileConstants {
     const val CONDITION_SPEED_BELOW = "speed_below"
     const val CONDITION_STATIONARY = "stationary"
 
+    /**
+     * Conditions whose re-evaluation depends on a fresh stream of location fixes.
+     * When any enabled profile uses one of these, the OS-level distance filter
+     * must be bypassed so fixes continue to arrive even within the configured
+     * movement threshold.
+     */
+    val LOCATION_DEPENDENT_CONDITIONS: Set<String> = setOf(
+        CONDITION_SPEED_ABOVE,
+        CONDITION_SPEED_BELOW,
+        CONDITION_STATIONARY,
+    )
+
     const val CACHE_TTL_MS = 30_000L
     const val SPEED_BUFFER_SIZE = 5
     const val MIN_INTERVAL_MS = 1000L

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -1236,6 +1236,121 @@ class LocationForegroundServiceTest {
     }
 
     // =========================================================================
+    // OS-level distance filter bypass for location-dependent profiles
+    // =========================================================================
+
+    @Test
+    fun `setupLocationUpdates passes configured distance when no location-dependent profile enabled`() {
+        setField("config", ServiceConfig(
+            endpoint = "https://example.com",
+            interval = 5000L,
+            minUpdateDistance = 50f,
+            filterInaccurateLocations = false
+        ))
+        every { profileManager.getNeededConditionTypes() } returns setOf(ProfileConstants.CONDITION_CHARGING)
+
+        invokeSetupLocationUpdates()
+
+        verify { locationProvider.requestLocationUpdates(5000L, 50f, any(), any()) }
+        assertFalse(getField("lastRequestedBypassOsFilter"))
+    }
+
+    @Test
+    fun `setupLocationUpdates passes zero when a speed_above profile is enabled`() {
+        setField("config", ServiceConfig(
+            endpoint = "https://example.com",
+            interval = 5000L,
+            minUpdateDistance = 50f,
+            filterInaccurateLocations = false
+        ))
+        every { profileManager.getNeededConditionTypes() } returns setOf(ProfileConstants.CONDITION_SPEED_ABOVE)
+
+        invokeSetupLocationUpdates()
+
+        verify { locationProvider.requestLocationUpdates(5000L, 0f, any(), any()) }
+        assertTrue(getField("lastRequestedBypassOsFilter"))
+    }
+
+    @Test
+    fun `setupLocationUpdates passes zero when a speed_below profile is enabled`() {
+        setField("config", ServiceConfig(
+            endpoint = "https://example.com",
+            interval = 5000L,
+            minUpdateDistance = 50f,
+            filterInaccurateLocations = false
+        ))
+        every { profileManager.getNeededConditionTypes() } returns setOf(ProfileConstants.CONDITION_SPEED_BELOW)
+
+        invokeSetupLocationUpdates()
+
+        verify { locationProvider.requestLocationUpdates(5000L, 0f, any(), any()) }
+    }
+
+    @Test
+    fun `setupLocationUpdates passes zero when a stationary profile is enabled`() {
+        setField("config", ServiceConfig(
+            endpoint = "https://example.com",
+            interval = 5000L,
+            minUpdateDistance = 50f,
+            filterInaccurateLocations = false
+        ))
+        every { profileManager.getNeededConditionTypes() } returns setOf(ProfileConstants.CONDITION_STATIONARY)
+
+        invokeSetupLocationUpdates()
+
+        verify { locationProvider.requestLocationUpdates(5000L, 0f, any(), any()) }
+    }
+
+    @Test
+    fun `handleRecheckProfiles restarts updates when effective OS filter flips to bypassed`() = runServiceTest {
+        setField("config", ServiceConfig(
+            endpoint = "https://example.com",
+            interval = 5000L,
+            minUpdateDistance = 50f,
+            filterInaccurateLocations = false
+        ))
+        val existingCallback = mockk<LocationUpdateCallback>(relaxed = true)
+        setField("locationUpdateCallback", existingCallback)
+        setField("lastRequestedBypassOsFilter", false)
+        every { profileManager.getNeededConditionTypes() } returns setOf(ProfileConstants.CONDITION_SPEED_ABOVE)
+
+        invokeHandleRecheckProfiles()
+
+        verify { locationProvider.removeLocationUpdates(existingCallback) }
+        verify { locationProvider.requestLocationUpdates(5000L, 0f, any(), any()) }
+    }
+
+    @Test
+    fun `handleRecheckProfiles does not restart when effective OS filter unchanged`() {
+        setField("config", ServiceConfig(
+            endpoint = "https://example.com",
+            interval = 5000L,
+            minUpdateDistance = 50f,
+            filterInaccurateLocations = false
+        ))
+        val existingCallback = mockk<LocationUpdateCallback>(relaxed = true)
+        setField("locationUpdateCallback", existingCallback)
+        setField("lastRequestedBypassOsFilter", false)
+        every { profileManager.getNeededConditionTypes() } returns setOf(ProfileConstants.CONDITION_CHARGING)
+
+        invokeHandleRecheckProfiles()
+
+        verify(exactly = 0) { locationProvider.removeLocationUpdates(any()) }
+        verify(exactly = 0) { locationProvider.requestLocationUpdates(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `handleRecheckProfiles does not restart when not tracking`() {
+        setField("locationUpdateCallback", null)
+        setField("lastRequestedBypassOsFilter", false)
+        every { profileManager.getNeededConditionTypes() } returns setOf(ProfileConstants.CONDITION_SPEED_ABOVE)
+
+        invokeHandleRecheckProfiles()
+
+        verify(exactly = 0) { locationProvider.requestLocationUpdates(any(), any(), any(), any()) }
+    }
+
+    // =========================================================================
     // onDestroy - cleanup
     // =========================================================================
 
@@ -1768,6 +1883,13 @@ class LocationForegroundServiceTest {
     private fun invokeSetupLocationUpdates() {
         val method = LocationForegroundService::class.java
             .getDeclaredMethod("setupLocationUpdates")
+        method.isAccessible = true
+        method.invoke(service)
+    }
+
+    private fun invokeHandleRecheckProfiles() {
+        val method = LocationForegroundService::class.java
+            .getDeclaredMethod("handleRecheckProfiles")
         method.isAccessible = true
         method.invoke(service)
     }


### PR DESCRIPTION
Pass 0m to the OS provider when any enabled profile uses speed or
stationary conditions so the speed buffer stays fresh and profile
switching works within the configured movement threshold. Software
filter still enforces minUpdateDistance for DB writes and sync.

Closes #304
