### PR TITLE
chore: migrate to @maplibre/maplibre-react-native v11

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -7,7 +7,6 @@ import { NavigationContainer, NavigationContainerRef } from "@react-navigation/n
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { View, StatusBar, Platform, StyleSheet } from "react-native"
-import MapLibreGL from "@maplibre/maplibre-react-native"
 import { ThemeProvider, useTheme } from "./src/hooks/useTheme"
 import { fonts } from "./src/styles/typography"
 import { TrackingProvider } from "./src/contexts/TrackingProvider"
@@ -38,7 +37,6 @@ import {
 } from "./src/screens/"
 import { BottomTabBar } from "./src/components"
 import { loadDisplayPreferences } from "./src/utils/geo"
-MapLibreGL.setAccessToken(null)
 
 // Load display preferences early
 loadDisplayPreferences()

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@colota/shared": "*",
-    "@maplibre/maplibre-react-native": "^10.4.2",
+    "@maplibre/maplibre-react-native": "^11.0.2",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.12",
     "lucide-react-native": "^1.11.0",

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -85,16 +85,18 @@ export function DashboardMap({ tracking, activeZoneName, pauseReason, activeProf
   // override the setCamera zoom from handleCenterMe with a pan-only moveTo).
   useEffect(() => {
     if (!coords || !isCenteredRef.current || !mapRef.current?.camera) return
-    mapRef.current.camera.moveTo([coords.longitude, coords.latitude], MAP_ANIMATION_DURATION_MS)
+    mapRef.current.camera.easeTo({
+      center: [coords.longitude, coords.latitude],
+      duration: MAP_ANIMATION_DURATION_MS
+    })
   }, [coords])
 
   const handleCenterMe = useCallback(() => {
     if (coords && mapRef.current?.camera) {
-      mapRef.current.camera.setCamera({
-        centerCoordinate: [coords.longitude, coords.latitude],
-        zoomLevel: MAX_MAP_ZOOM,
-        animationDuration: MAP_ANIMATION_DURATION_MS,
-        animationMode: "flyTo"
+      mapRef.current.camera.flyTo({
+        center: [coords.longitude, coords.latitude],
+        zoom: MAX_MAP_ZOOM,
+        duration: MAP_ANIMATION_DURATION_MS
       })
       isCenteredRef.current = true
       setIsCentered(true)

--- a/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
@@ -6,15 +6,11 @@ jest.mock("@maplibre/maplibre-react-native", () => {
   const { View } = require("react-native")
   return {
     __esModule: true,
-    default: { setAccessToken: jest.fn() },
-    MapView: (props: any) => R.createElement(View, { testID: "mapview", ...props }),
+    Map: (props: any) => R.createElement(View, { testID: "mapview", ...props }),
     Camera: () => null,
-    ShapeSource: ({ children }: any) => children,
-    FillLayer: () => null,
-    LineLayer: () => null,
-    SymbolLayer: () => null,
-    CircleLayer: () => null,
-    MarkerView: ({ children }: any) => children
+    GeoJSONSource: ({ children }: any) => children,
+    Layer: () => null,
+    Marker: ({ children }: any) => children
   }
 })
 

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -5,7 +5,8 @@
 
 import React, { useRef, useEffect, useMemo, useState, useCallback } from "react"
 import { View, StyleSheet, Text, Pressable } from "react-native"
-import { ShapeSource, LineLayer, CircleLayer } from "@maplibre/maplibre-react-native"
+import { GeoJSONSource, Layer, type PressEventWithFeatures } from "@maplibre/maplibre-react-native"
+import type { NativeSyntheticEvent } from "react-native"
 import { MapPinOff, X } from "lucide-react-native"
 import { ThemeColors, Trip } from "../../../types/global"
 import { getTripColor } from "../../../utils/trips"
@@ -21,18 +22,18 @@ import {
 import { getSpeedUnit } from "../../../utils/geo"
 import { HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS } from "../../../constants"
 
-const trackLineStyle = {
-  lineColor: ["get", "color"] as const,
+const trackLineStyle: any = {
+  lineColor: ["get", "color"],
   lineWidth: 3,
-  lineCap: "round" as const,
-  lineJoin: "round" as const
+  lineCap: "round",
+  lineJoin: "round"
 }
 
-const trackPointStyle = {
+const trackPointStyle: any = {
   circleRadius: 4,
-  circleColor: ["get", "color"] as const,
+  circleColor: ["get", "color"],
   circleOpacity: 0.4,
-  circleStrokeColor: ["get", "color"] as const,
+  circleStrokeColor: ["get", "color"],
   circleStrokeWidth: 1.5
 }
 
@@ -68,7 +69,10 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
     requestAnimationFrame(() => {
       if (!mapRef.current?.camera) return
       fittedVersionRef.current = fitVersion ?? 0
-      mapRef.current.camera.fitBounds(bounds.ne, bounds.sw, [60, 60, 60, 60], MAP_ANIMATION_DURATION_MS)
+      mapRef.current.camera.fitBounds([bounds.sw[0], bounds.sw[1], bounds.ne[0], bounds.ne[1]], {
+        padding: { top: 60, right: 60, bottom: 60, left: 60 },
+        duration: MAP_ANIMATION_DURATION_MS
+      })
     })
   }, [bounds, mapReady, fitVersion])
 
@@ -82,18 +86,20 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
   // Zoom to selected point from table tap
   useEffect(() => {
     if (selectedPoint && mapRef.current?.camera) {
-      mapRef.current.camera.setCamera({
-        centerCoordinate: [selectedPoint.longitude, selectedPoint.latitude],
-        zoomLevel: 17,
-        animationDuration: 500,
-        animationMode: "flyTo"
+      mapRef.current.camera.flyTo({
+        center: [selectedPoint.longitude, selectedPoint.latitude],
+        zoom: 17,
+        duration: 500
       })
     }
   }, [selectedPoint])
 
   const handleFitTrack = useCallback(() => {
     if (bounds && mapRef.current?.camera) {
-      mapRef.current.camera.fitBounds(bounds.ne, bounds.sw, [60, 60, 60, 60], MAP_ANIMATION_DURATION_MS)
+      mapRef.current.camera.fitBounds([bounds.sw[0], bounds.sw[1], bounds.ne[0], bounds.ne[1]], {
+        padding: { top: 60, right: 60, bottom: 60, left: 60 },
+        duration: MAP_ANIMATION_DURATION_MS
+      })
       setIsCentered(true)
     }
   }, [bounds])
@@ -175,8 +181,8 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
 
   const lastPointPressRef = useRef(0)
   const handlePointPress = useCallback(
-    (event: { features: GeoJSON.Feature[]; coordinates: { latitude: number; longitude: number } }) => {
-      const feature = event.features[0]
+    (event: NativeSyntheticEvent<PressEventWithFeatures>) => {
+      const feature = event.nativeEvent.features[0]
       if (!feature?.properties || !feature?.geometry) return
       lastPointPressRef.current = Date.now()
       const geom = feature.geometry as GeoJSON.Point
@@ -214,20 +220,20 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
         onRegionDidChange={handleRegionChange}
         onMapReady={handleMapReady}
       >
-        <ShapeSource id="track-segments" shape={segmentsGeoJSON}>
-          <LineLayer id="track-line" style={trackLineStyle} />
-        </ShapeSource>
-        <ShapeSource
+        <GeoJSONSource id="track-segments" data={segmentsGeoJSON}>
+          <Layer id="track-line" type="line" style={trackLineStyle} />
+        </GeoJSONSource>
+        <GeoJSONSource
           id="track-points"
-          shape={pointsGeoJSON}
+          data={pointsGeoJSON}
           onPress={handlePointPress}
-          hitbox={{ width: 20, height: 20 }}
+          hitbox={{ top: 10, right: 10, bottom: 10, left: 10 }}
         >
-          <CircleLayer id="track-point-circles" style={trackPointStyle} />
-        </ShapeSource>
-        <ShapeSource id="highlight-point" shape={highlightGeoJSON}>
-          <CircleLayer id="highlight-circle" style={highlightStyle} />
-        </ShapeSource>
+          <Layer id="track-point-circles" type="circle" style={trackPointStyle} />
+        </GeoJSONSource>
+        <GeoJSONSource id="highlight-point" data={highlightGeoJSON}>
+          <Layer id="highlight-circle" type="circle" style={highlightStyle} />
+        </GeoJSONSource>
       </ColotaMapView>
     ),
     [

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -32,9 +32,8 @@ jest.mock("@maplibre/maplibre-react-native", () => {
     return Stub
   }
   return {
-    ShapeSource: stub("ShapeSource"),
-    LineLayer: stub("LineLayer"),
-    CircleLayer: stub("CircleLayer")
+    GeoJSONSource: stub("GeoJSONSource"),
+    Layer: stub("Layer")
   }
 })
 

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -5,9 +5,9 @@
 
 import React, { useRef, useImperativeHandle, forwardRef, useState, useEffect, useCallback } from "react"
 import { StyleProp, ViewStyle, View, Text, StyleSheet, Linking, Pressable } from "react-native"
-import { MapView, Camera } from "@maplibre/maplibre-react-native"
-import type { MapViewRef, CameraRef } from "@maplibre/maplibre-react-native"
-import type { RegionPayload } from "@maplibre/maplibre-react-native"
+import { Map, Camera } from "@maplibre/maplibre-react-native"
+import type { MapRef, CameraRef, ViewStateChangeEvent, LngLatBounds } from "@maplibre/maplibre-react-native"
+import type { NativeSyntheticEvent } from "react-native"
 import { Compass } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
@@ -23,14 +23,20 @@ const DEFAULT_ATTRIBUTION_LINKS = [
 
 export interface ColotaMapRef {
   camera: CameraRef | null
-  mapView: MapViewRef | null
+  mapView: MapRef | null
+}
+
+export interface RegionChangePayload {
+  heading: number
+  isUserInteraction: boolean
+  bounds: LngLatBounds
 }
 
 interface Props {
   initialCenter: [number, number] // [lon, lat]
   initialZoom?: number
   onPress?: (coords: { latitude: number; longitude: number }) => void
-  onRegionDidChange?: (payload: RegionPayload & { isUserInteraction: boolean }) => void
+  onRegionDidChange?: (payload: RegionChangePayload) => void
   onMapReady?: () => void
   style?: StyleProp<ViewStyle>
   children?: React.ReactNode
@@ -41,7 +47,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
   ref
 ) {
   const cameraRef = useRef<CameraRef>(null)
-  const mapViewRef = useRef<MapViewRef>(null)
+  const mapViewRef = useRef<MapRef>(null)
   const { colors, mode } = useTheme()
   const isDark = mode === "dark"
 
@@ -81,11 +87,11 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
   const isCustomStyle = mapStyleLight !== MAP_STYLE_URL_LIGHT || mapStyleDark !== MAP_STYLE_URL_DARK
 
   const handleRegionDidChange = useCallback(
-    (feature: GeoJSON.Feature<GeoJSON.Point, RegionPayload>) => {
-      const props = feature.properties as RegionPayload & { isUserInteraction: boolean }
-      setHeading(props.heading ?? 0)
+    (event: NativeSyntheticEvent<ViewStateChangeEvent>) => {
+      const { bearing, userInteraction, bounds } = event.nativeEvent
+      setHeading(bearing ?? 0)
       if (onRegionDidChange) {
-        onRegionDidChange(props)
+        onRegionDidChange({ heading: bearing ?? 0, isUserInteraction: userInteraction, bounds })
       }
     },
     [onRegionDidChange]
@@ -93,18 +99,18 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
 
   const handleCompassPress = useCallback(() => {
     if (cameraRef.current) {
-      cameraRef.current.setCamera({
-        heading: 0,
-        animationDuration: 300,
-        animationMode: "easeTo"
+      cameraRef.current.setStop({
+        bearing: 0,
+        duration: 300,
+        easing: "ease"
       })
     }
   }, [])
 
   const handlePress = useCallback(
-    (feature: GeoJSON.Feature) => {
-      if (onPress && feature.geometry?.type === "Point") {
-        const [lon, lat] = (feature.geometry as GeoJSON.Point).coordinates
+    (event: NativeSyntheticEvent<{ lngLat: [number, number] }>) => {
+      if (onPress) {
+        const [lon, lat] = event.nativeEvent.lngLat
         onPress({ latitude: lat, longitude: lon })
       }
     },
@@ -115,27 +121,27 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
 
   return (
     <View style={[styles.container, style]}>
-      <MapView
+      <Map
         ref={mapViewRef}
         style={styles.map}
         mapStyle={mapStyle}
-        attributionEnabled={isCustomStyle}
-        logoEnabled={false}
-        compassEnabled={false}
+        attribution={isCustomStyle}
+        logo={false}
+        compass={false}
         onDidFinishLoadingMap={onMapReady}
         onPress={onPress ? handlePress : undefined}
         onRegionDidChange={handleRegionDidChange}
       >
         <Camera
           ref={cameraRef}
-          defaultSettings={{
-            centerCoordinate: initialCenter,
-            zoomLevel: initialZoom
+          initialViewState={{
+            center: initialCenter,
+            zoom: initialZoom
           }}
         />
 
         {children}
-      </MapView>
+      </Map>
 
       {/* Custom compass button */}
       {showCompass && (

--- a/apps/mobile/src/components/features/map/CurrentTrackLayers.tsx
+++ b/apps/mobile/src/components/features/map/CurrentTrackLayers.tsx
@@ -4,15 +4,15 @@
  */
 
 import React, { useMemo } from "react"
-import { ShapeSource, LineLayer } from "@maplibre/maplibre-react-native"
+import { GeoJSONSource, Layer } from "@maplibre/maplibre-react-native"
 import { buildTrackSegmentsGeoJSON, type TrackLocation } from "./mapUtils"
 import type { ThemeColors } from "../../../types/global"
 
-const trackLineStyle = {
-  lineColor: ["get", "color"] as const,
+const trackLineStyle: any = {
+  lineColor: ["get", "color"],
   lineWidth: 3,
-  lineCap: "round" as const,
-  lineJoin: "round" as const
+  lineCap: "round",
+  lineJoin: "round"
 }
 
 interface Props {
@@ -33,8 +33,8 @@ export function CurrentTrackLayers({ locations, version, visible, colors }: Prop
   if (!visible || locations.length < 2) return null
 
   return (
-    <ShapeSource id="current-track-segments" shape={geoJSON}>
-      <LineLayer id="current-track-line" style={trackLineStyle} />
-    </ShapeSource>
+    <GeoJSONSource id="current-track-segments" data={geoJSON}>
+      <Layer id="current-track-line" type="line" style={trackLineStyle} />
+    </GeoJSONSource>
   )
 }

--- a/apps/mobile/src/components/features/map/GeofenceLayers.tsx
+++ b/apps/mobile/src/components/features/map/GeofenceLayers.tsx
@@ -4,16 +4,16 @@
  */
 
 import React, { useMemo } from "react"
-import { ShapeSource, FillLayer, LineLayer, SymbolLayer } from "@maplibre/maplibre-react-native"
+import { GeoJSONSource, Layer } from "@maplibre/maplibre-react-native"
 
-const geofenceFillStyle = {
-  fillColor: ["get", "fillColor"] as const,
-  fillOpacity: ["get", "fillOpacity"] as const,
-  fillOutlineColor: ["get", "strokeColor"] as const
+const geofenceFillStyle: any = {
+  fillColor: ["get", "fillColor"],
+  fillOpacity: ["get", "fillOpacity"],
+  fillOutlineColor: ["get", "strokeColor"]
 }
 
-const geofenceStrokeStyle = {
-  lineColor: ["get", "strokeColor"] as const,
+const geofenceStrokeStyle: any = {
+  lineColor: ["get", "strokeColor"],
   lineWidth: 2
 }
 
@@ -24,14 +24,14 @@ interface Props {
 }
 
 export function GeofenceLayers({ fills, labels, haloColor }: Props) {
-  const labelStyle = useMemo(
+  const labelStyle = useMemo<any>(
     () => ({
-      textField: ["get", "name"] as const,
+      textField: ["get", "name"],
       textSize: 12,
-      textColor: ["get", "textColor"] as const,
+      textColor: ["get", "textColor"],
       textHaloColor: haloColor,
       textHaloWidth: 2,
-      textOffset: [0, -1.8] as [number, number],
+      textOffset: [0, -1.8],
       textFont: ["Noto Sans Bold"]
     }),
     [haloColor]
@@ -40,16 +40,16 @@ export function GeofenceLayers({ fills, labels, haloColor }: Props) {
   return (
     <>
       {fills.features.length > 0 && (
-        <ShapeSource id="geofence-fills" shape={fills}>
-          <FillLayer id="geofence-fill" style={geofenceFillStyle} />
-          <LineLayer id="geofence-stroke" style={geofenceStrokeStyle} />
-        </ShapeSource>
+        <GeoJSONSource id="geofence-fills" data={fills}>
+          <Layer id="geofence-fill" type="fill" style={geofenceFillStyle} />
+          <Layer id="geofence-stroke" type="line" style={geofenceStrokeStyle} />
+        </GeoJSONSource>
       )}
 
       {labels.features.length > 0 && (
-        <ShapeSource id="geofence-labels" shape={labels}>
-          <SymbolLayer id="geofence-label-text" style={labelStyle} />
-        </ShapeSource>
+        <GeoJSONSource id="geofence-labels" data={labels}>
+          <Layer id="geofence-label-text" type="symbol" style={labelStyle} />
+        </GeoJSONSource>
       )}
     </>
   )

--- a/apps/mobile/src/components/features/map/OfflinePackManager.ts
+++ b/apps/mobile/src/components/features/map/OfflinePackManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import { OfflineManager } from "@maplibre/maplibre-react-native"
+import { OfflineManager, type OfflinePack } from "@maplibre/maplibre-react-native"
 import { MAP_STYLE_URL_LIGHT as MAP_STYLE_URL } from "../../../constants"
 import NativeLocationService from "../../../services/NativeLocationService"
 
@@ -19,16 +19,15 @@ function bytesPerTile(z: number): number {
   return 50 * 1024
 }
 
-// state values from MapLibre's OfflinePackDownloadState
+// state values from MapLibre's OfflinePackDownloadState (v11 uses string literals)
 export const DOWNLOAD_STATE = {
-  INACTIVE: 0,
-  ACTIVE: 1,
-  COMPLETE: 2,
-  FAILED: 3
+  INACTIVE: "inactive",
+  ACTIVE: "active",
+  COMPLETE: "complete"
 } as const
 
 export interface OfflinePackStatus {
-  state: number
+  state: string
   percentage: number
   completedResourceCount: number
   requiredResourceCount: number
@@ -101,6 +100,12 @@ export function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
+/** Finds a pack by its stored metadata.name (packs are identified by UUID in v11). */
+async function findPackByName(name: string): Promise<OfflinePack | null> {
+  const packs = await OfflineManager.getPacks()
+  return packs.find((p) => (p.metadata as { name?: string })?.name === name) ?? null
+}
+
 export async function createOfflinePack(
   name: string,
   ne: [number, number],
@@ -108,54 +113,61 @@ export async function createOfflinePack(
   onProgress: (status: OfflinePackStatus) => void,
   onError: (err: unknown) => void
 ): Promise<void> {
-  const existing = await OfflineManager.getPack(name)
+  const existing = await findPackByName(name)
   if (existing) throw new Error(`An offline area named "${name}" already exists`)
 
   const customStyleUrl = await NativeLocationService.getSetting("mapStyleUrlLight")
-  const styleURL = customStyleUrl || MAP_STYLE_URL
+  const mapStyle = customStyleUrl || MAP_STYLE_URL
 
   OfflineManager.setTileCountLimit(TILE_COUNT_LIMIT)
 
   await OfflineManager.createPack(
-    { name, styleURL, minZoom: MIN_ZOOM, maxZoom: MAX_ZOOM, bounds: [ne, sw] },
-    (_pack: unknown, status: OfflinePackStatus) => onProgress(status),
-    (_pack: unknown, err: unknown) => onError(err)
+    {
+      mapStyle,
+      minZoom: MIN_ZOOM,
+      maxZoom: MAX_ZOOM,
+      bounds: [sw[0], sw[1], ne[0], ne[1]],
+      metadata: { name }
+    },
+    (_pack, status) => onProgress(status as OfflinePackStatus),
+    (_pack, err) => onError(err)
   )
 }
 
 export async function loadOfflineAreas(): Promise<OfflineAreaInfo[]> {
   const packs = await OfflineManager.getPacks()
 
-  const namedPacks = packs.filter((p): p is typeof p & { name: string } => !!p.name)
-
-  return Promise.all(
-    namedPacks.map(async (pack) => {
+  const results = await Promise.all(
+    packs.map(async (pack): Promise<OfflineAreaInfo | null> => {
+      const name = (pack.metadata as { name?: string })?.name
+      if (!name) return null
       try {
         const status = await pack.status()
         return {
-          name: pack.name,
+          name,
           sizeBytes: status?.completedResourceSize ?? null,
           isComplete: status?.state === DOWNLOAD_STATE.COMPLETE,
           isActive: status?.state === DOWNLOAD_STATE.ACTIVE
-        } satisfies OfflineAreaInfo
+        }
       } catch {
-        return { name: pack.name, sizeBytes: null, isComplete: false, isActive: false } satisfies OfflineAreaInfo
+        return { name, sizeBytes: null, isComplete: false, isActive: false }
       }
     })
   )
+  return results.filter((r): r is OfflineAreaInfo => r !== null)
 }
 
 /** Stops any active download for the pack and removes it and its tiles from disk. */
 export async function deleteOfflineArea(name: string): Promise<void> {
-  OfflineManager.unsubscribe(name)
-  const pack = await OfflineManager.getPack(name)
+  const pack = await findPackByName(name)
   if (pack) {
+    OfflineManager.removeListener(pack.id)
     try {
       await pack.pause()
     } catch {
       // pack may already be inactive - proceed to delete
     }
-    await OfflineManager.deletePack(name)
+    await OfflineManager.deletePack(pack.id)
   }
 
   // SQLite does not shrink the database file when rows are deleted - freed pages
@@ -167,8 +179,9 @@ export async function deleteOfflineArea(name: string): Promise<void> {
   }
 }
 
-export function unsubscribeOfflinePack(name: string): void {
-  OfflineManager.unsubscribe(name)
+export async function unsubscribeOfflinePack(name: string): Promise<void> {
+  const pack = await findPackByName(name)
+  if (pack) OfflineManager.removeListener(pack.id)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
+++ b/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
@@ -5,12 +5,11 @@
 
 import React, { useMemo } from "react"
 import { View, StyleSheet } from "react-native"
-import { ShapeSource, CircleLayer, MarkerView } from "@maplibre/maplibre-react-native"
+import { GeoJSONSource, Layer, Marker } from "@maplibre/maplibre-react-native"
 import type { LocationCoords, ThemeColors } from "../../../types/global"
 
 /** meters-per-pixel at zoom 0 on the equator (Web Mercator constant) */
 const METERS_PER_PX_Z0 = 156543.03
-const MARKER_ANCHOR = { x: 0.5, y: 0.5 }
 
 interface Props {
   coords: LocationCoords
@@ -20,8 +19,8 @@ interface Props {
 
 /**
  * Shared overlay for DashboardMap and GeofenceScreen:
- *  – accuracy circle (CircleLayer with zoom-based radius)
- *  – user position dot (MarkerView)
+ *  - accuracy circle (Layer type="circle" with zoom-based radius)
+ *  - user position dot (Marker)
  */
 export function UserLocationOverlay({ coords, isPaused, colors }: Props) {
   const markerColor = isPaused ? colors.textDisabled : colors.primary
@@ -68,14 +67,14 @@ export function UserLocationOverlay({ coords, isPaused, colors }: Props) {
   return (
     <>
       {accuracyGeoJSON && (
-        <ShapeSource id="user-accuracy" shape={accuracyGeoJSON}>
-          <CircleLayer id="user-accuracy-fill" style={accuracyStyle} />
-        </ShapeSource>
+        <GeoJSONSource id="user-accuracy" data={accuracyGeoJSON}>
+          <Layer id="user-accuracy-fill" type="circle" style={accuracyStyle} />
+        </GeoJSONSource>
       )}
 
-      <MarkerView coordinate={markerCoordinate} anchor={MARKER_ANCHOR} allowOverlap>
+      <Marker lngLat={markerCoordinate} anchor="center">
         <View style={[styles.markerDot, { backgroundColor: markerColor }]} />
-      </MarkerView>
+      </Marker>
     </>
   )
 }

--- a/apps/mobile/src/components/features/map/__tests__/OfflinePackManager.test.ts
+++ b/apps/mobile/src/components/features/map/__tests__/OfflinePackManager.test.ts
@@ -10,7 +10,7 @@ jest.mock("@maplibre/maplibre-react-native", () => ({
     getPack: jest.fn(),
     deletePack: jest.fn(),
     setTileCountLimit: jest.fn(),
-    unsubscribe: jest.fn(),
+    removeListener: jest.fn(),
     resetDatabase: jest.fn()
   }
 }))
@@ -62,10 +62,9 @@ beforeEach(() => {
 
 describe("constants", () => {
   it("DOWNLOAD_STATE has expected values", () => {
-    expect(DOWNLOAD_STATE.INACTIVE).toBe(0)
-    expect(DOWNLOAD_STATE.ACTIVE).toBe(1)
-    expect(DOWNLOAD_STATE.COMPLETE).toBe(2)
-    expect(DOWNLOAD_STATE.FAILED).toBe(3)
+    expect(DOWNLOAD_STATE.INACTIVE).toBe("inactive")
+    expect(DOWNLOAD_STATE.ACTIVE).toBe("active")
+    expect(DOWNLOAD_STATE.COMPLETE).toBe("complete")
   })
 })
 
@@ -205,12 +204,14 @@ describe("estimateSizeLabel", () => {
 
 describe("createOfflinePack", () => {
   beforeEach(() => {
-    mockOfflineManager.getPack.mockResolvedValue(null as never)
+    mockOfflineManager.getPacks.mockResolvedValue([] as never)
     mockGetSetting.mockResolvedValue(null)
   })
 
   it("throws if a pack with the same name already exists", async () => {
-    mockOfflineManager.getPack.mockResolvedValueOnce({ name: "existing" } as never)
+    mockOfflineManager.getPacks.mockResolvedValueOnce([
+      { id: "uuid-existing", metadata: { name: "existing" } }
+    ] as never)
     await expect(createOfflinePack("existing", SMALL_NE, SMALL_SW, jest.fn(), jest.fn())).rejects.toThrow(
       'An offline area named "existing" already exists'
     )
@@ -218,7 +219,7 @@ describe("createOfflinePack", () => {
   })
 
   it("calls OfflineManager.setTileCountLimit before creating pack", async () => {
-    mockOfflineManager.createPack.mockResolvedValueOnce(undefined as never)
+    mockOfflineManager.createPack.mockResolvedValueOnce({} as never)
     await createOfflinePack("test", SMALL_NE, SMALL_SW, jest.fn(), jest.fn())
     expect(mockOfflineManager.setTileCountLimit).toHaveBeenCalledWith(100_000)
     expect((mockOfflineManager.setTileCountLimit as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
@@ -227,12 +228,12 @@ describe("createOfflinePack", () => {
   })
 
   it("uses default style URL when no custom URL is configured", async () => {
-    mockOfflineManager.createPack.mockResolvedValueOnce(undefined as never)
+    mockOfflineManager.createPack.mockResolvedValueOnce({} as never)
     await createOfflinePack("my-area", SMALL_NE, SMALL_SW, jest.fn(), jest.fn())
     expect(mockOfflineManager.createPack).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: "my-area",
-        styleURL: "https://tiles.example.com/style.json",
+        metadata: { name: "my-area" },
+        mapStyle: "https://tiles.example.com/style.json",
         minZoom: 8,
         maxZoom: 14,
         bounds: expect.any(Array)
@@ -244,10 +245,10 @@ describe("createOfflinePack", () => {
 
   it("uses custom style URL from settings when configured", async () => {
     mockGetSetting.mockResolvedValueOnce("https://my-server.com/style.json")
-    mockOfflineManager.createPack.mockResolvedValueOnce(undefined as never)
+    mockOfflineManager.createPack.mockResolvedValueOnce({} as never)
     await createOfflinePack("my-area", SMALL_NE, SMALL_SW, jest.fn(), jest.fn())
     expect(mockOfflineManager.createPack).toHaveBeenCalledWith(
-      expect.objectContaining({ styleURL: "https://my-server.com/style.json" }),
+      expect.objectContaining({ mapStyle: "https://my-server.com/style.json" }),
       expect.any(Function),
       expect.any(Function)
     )
@@ -255,26 +256,30 @@ describe("createOfflinePack", () => {
 
   it("invokes onProgress callback when OfflineManager progress fires", async () => {
     const onProgress = jest.fn()
-    mockOfflineManager.createPack.mockImplementationOnce((_opts: unknown, progressCb: Function) => {
+    mockOfflineManager.createPack.mockImplementationOnce((async (_opts: unknown, progressCb: Function) => {
       progressCb(null, {
-        state: 1,
+        state: "active",
         percentage: 50,
         completedResourceCount: 50,
         requiredResourceCount: 100,
         completedResourceSize: 25600
       })
-      return Promise.resolve()
-    })
+      return {} as never
+    }) as never)
     await createOfflinePack("test", SMALL_NE, SMALL_SW, onProgress, jest.fn())
-    expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({ state: 1, percentage: 50 }))
+    expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({ state: "active", percentage: 50 }))
   })
 
   it("invokes onError callback when OfflineManager error fires", async () => {
     const onError = jest.fn()
-    mockOfflineManager.createPack.mockImplementationOnce((_opts: unknown, _progressCb: Function, errorCb: Function) => {
+    mockOfflineManager.createPack.mockImplementationOnce((async (
+      _opts: unknown,
+      _progressCb: Function,
+      errorCb: Function
+    ) => {
       errorCb(null, new Error("tile limit exceeded"))
-      return Promise.resolve()
-    })
+      return {} as never
+    }) as never)
     await createOfflinePack("test", SMALL_NE, SMALL_SW, jest.fn(), onError)
     expect(onError).toHaveBeenCalledWith(expect.any(Error))
   })
@@ -290,10 +295,13 @@ describe("loadOfflineAreas", () => {
     expect(await loadOfflineAreas()).toEqual([])
   })
 
-  it("filters out packs without a name", async () => {
+  it("filters out packs without a name in metadata", async () => {
     mockOfflineManager.getPacks.mockResolvedValueOnce([
-      { name: undefined, status: jest.fn().mockResolvedValue({ state: 2, completedResourceSize: 1024 }) },
-      { name: "valid-area", status: jest.fn().mockResolvedValue({ state: 2, completedResourceSize: 2048 }) }
+      { metadata: {}, status: jest.fn().mockResolvedValue({ state: "complete", completedResourceSize: 1024 }) },
+      {
+        metadata: { name: "valid-area" },
+        status: jest.fn().mockResolvedValue({ state: "complete", completedResourceSize: 2048 })
+      }
     ] as never)
     const areas = await loadOfflineAreas()
     expect(areas).toHaveLength(1)
@@ -303,7 +311,7 @@ describe("loadOfflineAreas", () => {
   it("maps complete pack status correctly", async () => {
     mockOfflineManager.getPacks.mockResolvedValueOnce([
       {
-        name: "downtown",
+        metadata: { name: "downtown" },
         status: jest.fn().mockResolvedValue({ state: DOWNLOAD_STATE.COMPLETE, completedResourceSize: 5_000_000 })
       }
     ] as never)
@@ -315,7 +323,7 @@ describe("loadOfflineAreas", () => {
   it("maps active pack status correctly", async () => {
     mockOfflineManager.getPacks.mockResolvedValueOnce([
       {
-        name: "in-progress",
+        metadata: { name: "in-progress" },
         status: jest.fn().mockResolvedValue({ state: DOWNLOAD_STATE.ACTIVE, completedResourceSize: 1_000_000 })
       }
     ] as never)
@@ -326,7 +334,7 @@ describe("loadOfflineAreas", () => {
 
   it("handles status() throwing - returns null sizeBytes and false flags", async () => {
     mockOfflineManager.getPacks.mockResolvedValueOnce([
-      { name: "broken-pack", status: jest.fn().mockRejectedValue(new Error("status unavailable")) }
+      { metadata: { name: "broken-pack" }, status: jest.fn().mockRejectedValue(new Error("status unavailable")) }
     ] as never)
     expect(await loadOfflineAreas()).toEqual([
       { name: "broken-pack", sizeBytes: null, isComplete: false, isActive: false }
@@ -335,7 +343,7 @@ describe("loadOfflineAreas", () => {
 
   it("handles null completedResourceSize as null sizeBytes", async () => {
     mockOfflineManager.getPacks.mockResolvedValueOnce([
-      { name: "partial", status: jest.fn().mockResolvedValue({ state: DOWNLOAD_STATE.INACTIVE }) }
+      { metadata: { name: "partial" }, status: jest.fn().mockResolvedValue({ state: DOWNLOAD_STATE.INACTIVE }) }
     ] as never)
     expect((await loadOfflineAreas())[0].sizeBytes).toBeNull()
   })
@@ -348,45 +356,47 @@ describe("loadOfflineAreas", () => {
 describe("deleteOfflineArea", () => {
   it("unsubscribes, pauses, and deletes pack", async () => {
     const mockPause = jest.fn().mockResolvedValue(undefined)
-    mockOfflineManager.getPack.mockResolvedValueOnce({ pause: mockPause } as never)
+    mockOfflineManager.getPacks
+      .mockResolvedValueOnce([{ id: "uuid-1", metadata: { name: "my-area" }, pause: mockPause }] as never)
+      .mockResolvedValueOnce([{ id: "uuid-2", metadata: { name: "other-area" } }] as never)
     mockOfflineManager.deletePack.mockResolvedValueOnce(undefined as never)
-    mockOfflineManager.getPacks.mockResolvedValueOnce([{ name: "other-area" }] as never)
 
     await deleteOfflineArea("my-area")
 
-    expect(mockOfflineManager.unsubscribe).toHaveBeenCalledWith("my-area")
+    expect(mockOfflineManager.removeListener).toHaveBeenCalledWith("uuid-1")
     expect(mockPause).toHaveBeenCalled()
-    expect(mockOfflineManager.deletePack).toHaveBeenCalledWith("my-area")
+    expect(mockOfflineManager.deletePack).toHaveBeenCalledWith("uuid-1")
     expect(mockOfflineManager.resetDatabase).not.toHaveBeenCalled()
   })
 
   it("resets database when last pack is deleted", async () => {
     const mockPause = jest.fn().mockResolvedValue(undefined)
-    mockOfflineManager.getPack.mockResolvedValueOnce({ pause: mockPause } as never)
+    mockOfflineManager.getPacks
+      .mockResolvedValueOnce([{ id: "uuid-last", metadata: { name: "last-area" }, pause: mockPause }] as never)
+      .mockResolvedValueOnce([] as never)
     mockOfflineManager.deletePack.mockResolvedValueOnce(undefined as never)
-    mockOfflineManager.getPacks.mockResolvedValueOnce([] as never)
     mockOfflineManager.resetDatabase.mockResolvedValueOnce(undefined as never)
 
     await deleteOfflineArea("last-area")
 
-    expect(mockOfflineManager.deletePack).toHaveBeenCalledWith("last-area")
+    expect(mockOfflineManager.deletePack).toHaveBeenCalledWith("uuid-last")
     expect(mockOfflineManager.resetDatabase).toHaveBeenCalled()
   })
 
   it("skips pause if pack is already inactive (pause throws) but still deletes", async () => {
     const mockPause = jest.fn().mockRejectedValue(new Error("not active"))
-    mockOfflineManager.getPack.mockResolvedValueOnce({ pause: mockPause } as never)
+    mockOfflineManager.getPacks
+      .mockResolvedValueOnce([{ id: "uuid-x", metadata: { name: "inactive-area" }, pause: mockPause }] as never)
+      .mockResolvedValueOnce([] as never)
     mockOfflineManager.deletePack.mockResolvedValueOnce(undefined as never)
-    mockOfflineManager.getPacks.mockResolvedValueOnce([] as never)
     mockOfflineManager.resetDatabase.mockResolvedValueOnce(undefined as never)
 
     await expect(deleteOfflineArea("inactive-area")).resolves.toBeUndefined()
-    expect(mockOfflineManager.deletePack).toHaveBeenCalledWith("inactive-area")
+    expect(mockOfflineManager.deletePack).toHaveBeenCalledWith("uuid-x")
   })
 
   it("skips delete if pack does not exist", async () => {
-    mockOfflineManager.getPack.mockResolvedValueOnce(null as never)
-    mockOfflineManager.getPacks.mockResolvedValueOnce([] as never)
+    mockOfflineManager.getPacks.mockResolvedValueOnce([] as never).mockResolvedValueOnce([] as never)
     mockOfflineManager.resetDatabase.mockResolvedValueOnce(undefined as never)
 
     await deleteOfflineArea("missing-area")
@@ -400,9 +410,10 @@ describe("deleteOfflineArea", () => {
 // ============================================================================
 
 describe("unsubscribeOfflinePack", () => {
-  it("calls OfflineManager.unsubscribe with the pack name", () => {
-    unsubscribeOfflinePack("some-area")
-    expect(mockOfflineManager.unsubscribe).toHaveBeenCalledWith("some-area")
+  it("calls OfflineManager.removeListener with the pack id", async () => {
+    mockOfflineManager.getPacks.mockResolvedValueOnce([{ id: "uuid-sub", metadata: { name: "some-area" } }] as never)
+    await unsubscribeOfflinePack("some-area")
+    expect(mockOfflineManager.removeListener).toHaveBeenCalledWith("uuid-sub")
   })
 })
 

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -69,7 +69,10 @@ const GeofenceMap = React.memo(function GeofenceMap({
 
   useEffect(() => {
     if (!coords || !isCenteredRef.current || !tracking || !mapRef.current?.camera) return
-    mapRef.current.camera.moveTo([coords.longitude, coords.latitude], MAP_ANIMATION_DURATION_MS)
+    mapRef.current.camera.easeTo({
+      center: [coords.longitude, coords.latitude],
+      duration: MAP_ANIMATION_DURATION_MS
+    })
   }, [coords, tracking])
 
   useEffect(() => {
@@ -78,20 +81,25 @@ const GeofenceMap = React.memo(function GeofenceMap({
     const latDelta = (geofence.radius / 111320) * 1.5
     const lonDelta = (geofence.radius / (111320 * Math.cos((geofence.lat * Math.PI) / 180))) * 1.5
     mapRef.current.camera.fitBounds(
-      [geofence.lon + lonDelta, geofence.lat + latDelta],
-      [geofence.lon - lonDelta, geofence.lat - latDelta],
-      [...GEOFENCE_ZOOM_PADDING],
-      600
+      [geofence.lon - lonDelta, geofence.lat - latDelta, geofence.lon + lonDelta, geofence.lat + latDelta],
+      {
+        padding: {
+          top: GEOFENCE_ZOOM_PADDING[0],
+          right: GEOFENCE_ZOOM_PADDING[1],
+          bottom: GEOFENCE_ZOOM_PADDING[2],
+          left: GEOFENCE_ZOOM_PADDING[3]
+        },
+        duration: 600
+      }
     )
   }, [focusRequest])
 
   const handleCenterMe = useCallback(() => {
     if (coords && mapRef.current?.camera) {
-      mapRef.current.camera.setCamera({
-        centerCoordinate: [coords.longitude, coords.latitude],
-        zoomLevel: MAX_MAP_ZOOM,
-        animationDuration: MAP_ANIMATION_DURATION_MS,
-        animationMode: "flyTo"
+      mapRef.current.camera.flyTo({
+        center: [coords.longitude, coords.latitude],
+        zoom: MAX_MAP_ZOOM,
+        duration: MAP_ANIMATION_DURATION_MS
       })
       isCenteredRef.current = true
       setIsCentered(true)

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -381,8 +381,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
             }
           },
           (err: unknown) => {
-            logger.error("[OfflineMapsScreen] Download failed:", err)
-            onFailure("Download failed. Please try again.")
+            logger.warn("[OfflineMapsScreen] Tile error (may retry):", err)
           }
         ).catch(() => {
           onFailure("Failed to start download. Please try again.")

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -5,7 +5,8 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo, memo } from "react"
 import { View, Text, StyleSheet, TextInput, Pressable, FlatList, ActivityIndicator, AppState } from "react-native"
-import { ShapeSource, FillLayer, LineLayer, type OnPressEvent } from "@maplibre/maplibre-react-native"
+import { GeoJSONSource, Layer, type PressEventWithFeatures } from "@maplibre/maplibre-react-native"
+import type { NativeSyntheticEvent } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { showAlert, showConfirm } from "../services/modalService"
 import { ScreenProps } from "../types/global"
@@ -293,11 +294,10 @@ export function OfflineMapsScreen({}: ScreenProps) {
 
   const handleCenterMe = useCallback(() => {
     if (coords && mapRef.current?.camera) {
-      mapRef.current.camera.setCamera({
-        centerCoordinate: [coords.longitude, coords.latitude],
-        zoomLevel: DEFAULT_MAP_ZOOM,
-        animationDuration: MAP_ANIMATION_DURATION_MS,
-        animationMode: "flyTo"
+      mapRef.current.camera.flyTo({
+        center: [coords.longitude, coords.latitude],
+        zoom: DEFAULT_MAP_ZOOM,
+        duration: MAP_ANIMATION_DURATION_MS
       })
       setIsCentered(true)
     }
@@ -309,13 +309,11 @@ export function OfflineMapsScreen({}: ScreenProps) {
   }, [])
 
   const handleRegionChange = useCallback(
-    (payload: { isUserInteraction: boolean; visibleBounds?: number[][] }) => {
+    (payload: { isUserInteraction: boolean; bounds?: [number, number, number, number] }) => {
       if (payload.isUserInteraction) setIsCentered(false)
-      if (payload.visibleBounds && payload.visibleBounds.length >= 2) {
-        updateBoundsAndEstimate(
-          payload.visibleBounds[0] as [number, number],
-          payload.visibleBounds[1] as [number, number]
-        )
+      if (payload.bounds) {
+        const [west, south, east, north] = payload.bounds
+        updateBoundsAndEstimate([east, north], [west, south])
       }
     },
     [updateBoundsAndEstimate]
@@ -323,8 +321,11 @@ export function OfflineMapsScreen({}: ScreenProps) {
 
   const handleMapReady = useCallback(async () => {
     try {
-      const bounds = await mapRef.current?.mapView?.getVisibleBounds()
-      if (bounds) updateBoundsAndEstimate(bounds[0] as [number, number], bounds[1] as [number, number])
+      const bounds = await mapRef.current?.mapView?.getBounds()
+      if (bounds) {
+        const [west, south, east, north] = bounds
+        updateBoundsAndEstimate([east, north], [west, south])
+      }
     } catch {
       // map not ready yet
     }
@@ -377,13 +378,11 @@ export function OfflineMapsScreen({}: ScreenProps) {
               setDownloadBounds(null)
               onComplete?.()
               loadAreas()
-            } else if (status.state === DOWNLOAD_STATE.FAILED) {
-              logger.error("[OfflineMapsScreen] Download failed via progress callback")
-              onFailure("Download failed. Please try again.")
             }
           },
           (err: unknown) => {
-            logger.warn("[OfflineMapsScreen] Tile error (may retry):", err)
+            logger.error("[OfflineMapsScreen] Download failed:", err)
+            onFailure("Download failed. Please try again.")
           }
         ).catch(() => {
           onFailure("Failed to start download. Please try again.")
@@ -582,15 +581,18 @@ export function OfflineMapsScreen({}: ScreenProps) {
     (name: string) => {
       const entry = areaBounds.find((b) => b.name === name)
       if (!entry || !mapRef.current?.camera) return
-      mapRef.current.camera.fitBounds(entry.ne, entry.sw, 40, MAP_ANIMATION_DURATION_MS)
+      mapRef.current.camera.fitBounds([entry.sw[0], entry.sw[1], entry.ne[0], entry.ne[1]], {
+        padding: { top: 40, right: 40, bottom: 40, left: 40 },
+        duration: MAP_ANIMATION_DURATION_MS
+      })
     },
     [areaBounds]
   )
 
   const handleAreaPress = useCallback(
-    (event: OnPressEvent) => {
+    (event: NativeSyntheticEvent<PressEventWithFeatures>) => {
       if (downloading) return
-      const name: string | undefined = event.features?.[0]?.properties?.name
+      const name: string | undefined = event.nativeEvent.features?.[0]?.properties?.name
       if (name) fitToArea(name)
     },
     [downloading, fitToArea]
@@ -819,16 +821,16 @@ export function OfflineMapsScreen({}: ScreenProps) {
             onMapReady={handleMapReady}
           >
             {savedAreasGeoJSON.features.length > 0 && (
-              <ShapeSource id="saved-areas" shape={savedAreasGeoJSON} onPress={handleAreaPress}>
-                <FillLayer id="saved-areas-fill" style={savedAreasFillStyle} />
-                <LineLayer id="saved-areas-border" style={savedAreasBorderStyle} />
-              </ShapeSource>
+              <GeoJSONSource id="saved-areas" data={savedAreasGeoJSON} onPress={handleAreaPress}>
+                <Layer id="saved-areas-fill" type="fill" style={savedAreasFillStyle} />
+                <Layer id="saved-areas-border" type="line" style={savedAreasBorderStyle} />
+              </GeoJSONSource>
             )}
             {downloadAreaGeoJSON && (
-              <ShapeSource id="offline-area" shape={downloadAreaGeoJSON}>
-                <FillLayer id="offline-area-fill" style={downloadAreaFillStyle} />
-                <LineLayer id="offline-area-border" style={downloadAreaBorderStyle} />
-              </ShapeSource>
+              <GeoJSONSource id="offline-area" data={downloadAreaGeoJSON}>
+                <Layer id="offline-area-fill" type="fill" style={downloadAreaFillStyle} />
+                <Layer id="offline-area-border" type="line" style={downloadAreaBorderStyle} />
+              </GeoJSONSource>
             )}
           </ColotaMapView>
         ) : null}

--- a/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
@@ -9,15 +9,11 @@ jest.mock("@maplibre/maplibre-react-native", () => {
   const { View } = require("react-native")
   return {
     __esModule: true,
-    default: { setAccessToken: jest.fn() },
-    MapView: (props: any) => R.createElement(View, { testID: "mapview", ...props }),
+    Map: (props: any) => R.createElement(View, { testID: "mapview", ...props }),
     Camera: () => null,
-    ShapeSource: ({ children }: any) => children,
-    FillLayer: () => null,
-    LineLayer: () => null,
-    SymbolLayer: () => null,
-    CircleLayer: () => null,
-    MarkerView: ({ children }: any) => children
+    GeoJSONSource: ({ children }: any) => children,
+    Layer: () => null,
+    Marker: ({ children }: any) => children
   }
 })
 

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -9,9 +9,8 @@ import { OfflineMapsScreen } from "../OfflineMapsScreen"
 
 // --- MapLibre ---
 jest.mock("@maplibre/maplibre-react-native", () => ({
-  ShapeSource: () => null,
-  FillLayer: () => null,
-  LineLayer: () => null
+  GeoJSONSource: () => null,
+  Layer: () => null
 }))
 
 // --- Navigation ---
@@ -95,7 +94,7 @@ const mockEstimateSizeBytes = jest.fn()
 const mockWillExceedTileLimit = jest.fn()
 
 jest.mock("../../components/features/map/OfflinePackManager", () => ({
-  DOWNLOAD_STATE: { INACTIVE: 0, ACTIVE: 1, COMPLETE: 2, FAILED: 3 },
+  DOWNLOAD_STATE: { INACTIVE: "inactive", ACTIVE: "active", COMPLETE: "complete" },
   formatBytes: jest.fn().mockReturnValue("5.0 MB"),
   loadOfflineAreas: (...args: any[]) => mockLoadOfflineAreas(...args),
   loadOfflineAreaBounds: (...args: any[]) => mockLoadOfflineAreaBounds(...args),
@@ -118,10 +117,7 @@ jest.mock("../../components/features/map/ColotaMapView", () => {
       R.useEffect(() => {
         onRegionDidChange?.({
           isUserInteraction: false,
-          visibleBounds: [
-            [13.5, 52.6],
-            [13.4, 52.5]
-          ]
+          bounds: [13.4, 52.5, 13.5, 52.6]
         })
       }, [])
       return R.createElement(View, { testID: "map-view" }, children)

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
       "name": "@colota/mobile",
       "dependencies": {
         "@colota/shared": "*",
-        "@maplibre/maplibre-react-native": "^10.4.2",
+        "@maplibre/maplibre-react-native": "^11.0.2",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.12",
         "lucide-react-native": "^1.11.0",
@@ -5309,26 +5309,58 @@
       "version": "2.0.5",
       "license": "MIT"
     },
-    "node_modules/@maplibre/maplibre-react-native": {
-      "version": "10.4.2",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "examples/*"
-      ],
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
+      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "license": "ISC",
       "dependencies": {
-        "@turf/distance": "^7.1.0",
-        "@turf/helpers": "^7.1.0",
-        "@turf/length": "^7.1.0",
-        "@turf/nearest-point-on-line": "^7.1.0",
-        "debounce": "^2.2.0"
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-react-native": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-11.0.2.tgz",
+      "integrity": "sha512-aL+eD0OD2wBqBVS8G/oyykzGbH2npYOkx9HokayvXjYlj0rIz4uvMreQganPcdO3dkmtY9bVx35BnV+WQ8f/5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "24.8.1",
+        "@turf/distance": "^7.3.5",
+        "@turf/helpers": "^7.3.5",
+        "@turf/length": "^7.3.5",
+        "@turf/nearest-point-on-line": "^7.3.5"
       },
       "peerDependencies": {
-        "@expo/config-plugins": ">=7",
+        "@expo/config-plugins": ">=54.0.0",
         "@types/geojson": "^7946.0.0",
-        "@types/react": ">=16.6.1",
-        "react": ">=16.6.1",
-        "react-native": ">=0.59.9"
+        "@types/react": ">=19.1.0",
+        "react": ">=19.1.0",
+        "react-native": ">=0.80.0"
       },
       "peerDependenciesMeta": {
         "@expo/config-plugins": {
@@ -7192,11 +7224,13 @@
       "license": "MIT"
     },
     "node_modules/@turf/distance": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -7205,7 +7239,9 @@
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
@@ -7216,10 +7252,12 @@
       }
     },
     "node_modules/@turf/invariant": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -7228,12 +7266,14 @@
       }
     },
     "node_modules/@turf/length": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.5.tgz",
+      "integrity": "sha512-Bi+vEP54wt1ly3BRcCOP0nd2kGTYEhGk6haQxTpkrqr3XtmqDh8c3NowSgseN2cegIZRjwCOEC8eSsZ0JemJdA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/distance": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -7242,10 +7282,12 @@
       }
     },
     "node_modules/@turf/meta": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -7254,13 +7296,15 @@
       }
     },
     "node_modules/@turf/nearest-point-on-line": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/distance": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -7391,6 +7435,8 @@
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -10306,16 +10352,6 @@
       "version": "1.11.20",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/debounce": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -15156,6 +15192,12 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -20866,6 +20908,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "license": "MIT",
@@ -21878,6 +21926,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -23394,6 +23448,12 @@
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",


### PR DESCRIPTION
Bumps `@maplibre/maplibre-react-native` from 10.4.2 to 11.0.2 and updates all call sites to the new API.