### PR TITLE
Release/1.7.1

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -4,3 +4,8 @@ paths-ignore:
   - '**/*.test.ts'
   - '**/*.test.tsx'
   - '**/src/test/**'
+
+query-filters:
+  - exclude:
+      id:
+        - java/missing-override-annotation

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
         applicationId "com.Colota"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 34
-        versionName "1.7.0"
+        versionCode 35
+        versionName "1.7.1"
 
         // Strip Build IDs for reproducible builds (IzzyOnDroid/F-Droid)
         externalNativeBuild {

--- a/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
@@ -318,11 +318,18 @@ class AutoExportWorker(
                     setDataAndType(docUri, DocumentsContract.Document.MIME_TYPE_DIR)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
-                val pendingIntent = PendingIntent.getActivity(
-                    appContext, 0, intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-                builder.setContentIntent(pendingIntent)
+                val resolved = appContext.packageManager.resolveActivity(intent, 0)
+                if (resolved != null) {
+                    intent.setClassName(
+                        resolved.activityInfo.packageName,
+                        resolved.activityInfo.name
+                    )
+                    val pendingIntent = PendingIntent.getActivity(
+                        appContext, 0, intent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    )
+                    builder.setContentIntent(pendingIntent)
+                }
             } catch (e: Exception) {
                 AppLogger.w(TAG, "Could not create directory open intent: ${e.message}")
             }

--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -937,8 +937,6 @@ class LocationForegroundService : Service() {
             accuracy = 0f
             time = System.currentTimeMillis()
         }
-        lastKnownLocation = location
-
         val (battery, batteryStatus) = deviceInfoHelper.getCachedBatteryStatus()
         val timestampSec = location.time / 1000
 

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -2060,6 +2060,23 @@ class LocationForegroundServiceTest {
         coVerify(exactly = 0) { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) }
     }
 
+    @Test
+    fun `sendHeartbeatLocation must not overwrite lastKnownLocation`() = testScope.runTest {
+        val realPreviousFix = mockLocation(lat = 52.50, lon = 13.40,
+            time = System.currentTimeMillis() - 60_000)
+        setField("currentZoneGeofence", homeGeofence)
+        setField("lastKnownLocation", realPreviousFix)
+        every { syncManager.isSyncAllowed() } returns true
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } returns true
+        every { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(),
+            any(), any(), any(), any()) } returns 1L
+
+        invokeSendHeartbeatLocation()
+
+        assertSame(realPreviousFix, getField<Location?>("lastKnownLocation"))
+    }
+
+
     // =========================================================================
     // Reflection helpers
     // =========================================================================

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -47,7 +47,11 @@ interface Props {
 export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
   const mapRef = useRef<ColotaMapRef>(null)
   const [isCentered, setIsCentered] = useState(true)
-  const [selectedPoint, setSelectedPoint] = useState<{ latitude: number; longitude: number } | null>(null)
+  const [selectedPoint, setSelectedPoint] = useState<{
+    latitude: number
+    longitude: number
+    color: string
+  } | null>(null)
   const [popup, setPopup] = useState<{
     coordinate: [number, number]
     speed: number
@@ -144,12 +148,13 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
   // Highlight GeoJSON for selected point
   const highlightGeoJSON = useMemo(() => {
     const coord = selectedPoint ? [selectedPoint.longitude, selectedPoint.latitude] : null
+    const color = selectedPoint?.color ?? colors.primary
     return {
       type: "FeatureCollection" as const,
       features: [
         {
           type: "Feature" as const,
-          properties: { color: colors.primary, visible: coord ? 1 : 0 },
+          properties: { color, visible: coord ? 1 : 0 },
           geometry: { type: "Point" as const, coordinates: coord ?? [0, 0] }
         }
       ]
@@ -161,10 +166,10 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
       circleRadius: 8,
       circleColor: ["get", "color"] as any,
       circleOpacity: ["get", "visible"] as any,
-      circleStrokeColor: "#ffffff",
+      circleStrokeColor: colors.cardElevated,
       circleStrokeWidth: ["*", 2.5, ["get", "visible"]] as any
     }),
-    []
+    [colors.cardElevated]
   )
 
   const { factor: speedFactor, unit: speedUnit } = getSpeedUnit()
@@ -177,14 +182,15 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
       lastPointPressRef.current = Date.now()
       const geom = feature.geometry as GeoJSON.Point
       const coord = geom.coordinates as [number, number]
-      setSelectedPoint({ longitude: coord[0], latitude: coord[1] })
+      const color = feature.properties.color ?? colors.primary
+      setSelectedPoint({ longitude: coord[0], latitude: coord[1], color })
       setPopup({
         coordinate: coord,
         speed: feature.properties.speed,
         timestamp: feature.properties.timestamp,
         accuracy: feature.properties.accuracy,
         altitude: feature.properties.altitude,
-        color: feature.properties.color ?? colors.primary
+        color
       })
     },
     [colors.primary]

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -39,15 +39,15 @@ const trackPointStyle: any = {
 
 interface Props {
   locations: TrackLocation[]
-  selectedPoint: { latitude: number; longitude: number } | null
   colors: ThemeColors
   trips?: Trip[]
   fitVersion?: number
 }
 
-export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }: Props) {
+export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
   const mapRef = useRef<ColotaMapRef>(null)
   const [isCentered, setIsCentered] = useState(true)
+  const [selectedPoint, setSelectedPoint] = useState<{ latitude: number; longitude: number } | null>(null)
   const [popup, setPopup] = useState<{
     coordinate: [number, number]
     speed: number
@@ -78,21 +78,11 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
 
   const handleMapReady = useCallback(() => setMapReady(true), [])
 
-  // Clear popup when underlying locations change (new day / different trip)
+  // Clear popup and highlight when underlying locations change (new day / different trip)
   useEffect(() => {
     setPopup(null)
+    setSelectedPoint(null)
   }, [locations])
-
-  // Zoom to selected point from table tap
-  useEffect(() => {
-    if (selectedPoint && mapRef.current?.camera) {
-      mapRef.current.camera.flyTo({
-        center: [selectedPoint.longitude, selectedPoint.latitude],
-        zoom: 17,
-        duration: 500
-      })
-    }
-  }, [selectedPoint])
 
   const handleFitTrack = useCallback(() => {
     if (bounds && mapRef.current?.camera) {
@@ -187,6 +177,7 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
       lastPointPressRef.current = Date.now()
       const geom = feature.geometry as GeoJSON.Point
       const coord = geom.coordinates as [number, number]
+      setSelectedPoint({ longitude: coord[0], latitude: coord[1] })
       setPopup({
         coordinate: coord,
         speed: feature.properties.speed,
@@ -202,6 +193,7 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
   const handleMapPress = useCallback(() => {
     if (Date.now() - lastPointPressRef.current < 200) return
     setPopup(null)
+    setSelectedPoint(null)
   }, [])
 
   const initialCenter = useMemo(
@@ -272,7 +264,10 @@ export function TrackMap({ locations, selectedPoint, colors, trips, fitVersion }
               {popup.timestamp ? new Date(popup.timestamp * 1000).toLocaleTimeString() : "-"}
             </Text>
             <Pressable
-              onPress={() => setPopup(null)}
+              onPress={() => {
+                setPopup(null)
+                setSelectedPoint(null)
+              }}
               hitSlop={HIT_SLOP_MD}
               style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
             >

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -92,18 +92,18 @@ describe("TrackMap auto-fit", () => {
     const locsA = [loc(48.1, 11.5), loc(48.2, 11.6)]
     const locsB = [loc(52.5, 13.4), loc(52.6, 13.5)]
 
-    const { rerender } = render(<TrackMap locations={locsA} selectedPoint={null} colors={colors} fitVersion={1} />)
+    const { rerender } = render(<TrackMap locations={locsA} colors={colors} fitVersion={1} />)
     expect(mockFitBounds).toHaveBeenCalledTimes(1)
 
     // Switch to empty day
     act(() => {
-      rerender(<TrackMap locations={[]} selectedPoint={null} colors={colors} fitVersion={2} />)
+      rerender(<TrackMap locations={[]} colors={colors} fitVersion={2} />)
     })
     expect(mockFitBounds).toHaveBeenCalledTimes(1) // no new fit on empty
 
     // Switch to another non-empty day - the regression target
     act(() => {
-      rerender(<TrackMap locations={locsB} selectedPoint={null} colors={colors} fitVersion={3} />)
+      rerender(<TrackMap locations={locsB} colors={colors} fitVersion={3} />)
     })
     expect(mockFitBounds).toHaveBeenCalledTimes(2)
   })

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -239,7 +239,6 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
           {calendarPicker}
           <TrackMap
             locations={mapLocations}
-            selectedPoint={null}
             colors={colors}
             trips={selectedTrip ? undefined : trips}
             fitVersion={fitVersion}

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -147,7 +147,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
       <ScrollView contentContainerStyle={styles.content}>
         {/* Map */}
         <View style={styles.mapContainer}>
-          <TrackMap locations={trip.locations} selectedPoint={null} colors={colors} fitVersion={1} />
+          <TrackMap locations={trip.locations} colors={colors} fitVersion={1} />
         </View>
 
         {/* Header */}

--- a/fastlane/metadata/android/en-US/changelogs/35.txt
+++ b/fastlane/metadata/android/en-US/changelogs/35.txt
@@ -1,0 +1,3 @@
+- Fixed tracking getting stuck inside a geofence after physically leaving it. Open the app once after updating to resume tracking; if still stuck, toggle tracking off and on from the dashboard.
+- Tapping a point on the location history map now highlights it
+- Hardened auto-export notification PendingIntent against implicit-intent hijacking

--- a/fastlane/metadata/android/en-US/changelogs/35.txt
+++ b/fastlane/metadata/android/en-US/changelogs/35.txt
@@ -1,3 +1,2 @@
 - Fixed tracking getting stuck inside a geofence after physically leaving it. Open the app once after updating to resume tracking; if still stuck, toggle tracking off and on from the dashboard.
-- Tapping a point on the location history map now highlights it
 - Hardened auto-export notification PendingIntent against implicit-intent hijacking


### PR DESCRIPTION
- Fixed tracking getting stuck inside a geofence after physically leaving it. Open the app once after updating to resume tracking; if still stuck, toggle tracking off and on from the dashboard.
- Tapping a point on the location history map now highlights it
- Hardened auto-export notification PendingIntent against implicit-intent hijacking
