### PR TITLE
fix: remove "Delete Queue" option from offline-mode switch dialog

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -64,7 +64,6 @@ export function ConnectionSettings({
             const buttons = [
               ...(hasEndpoint ? [{ text: "Sync First", style: "primary" as const }] : []),
               { text: "Keep in Queue", style: "secondary" as const },
-              { text: "Delete Queue", style: "destructive" as const },
               { text: "Cancel", style: "secondary" as const }
             ]
             const choice = await showChoice({
@@ -72,10 +71,9 @@ export function ConnectionSettings({
               message: `You have ${stats.queued} locations waiting to sync. What would you like to do?`,
               buttons
             })
-            // Normalize index: with endpoint [Sync, Keep, Delete, Cancel], without [Keep, Delete, Cancel]
             const action = hasEndpoint
-              ? (["sync", "keep", "delete", "cancel"] as const)[choice]
-              : (["keep", "delete", "cancel"] as const)[choice]
+              ? (["sync", "keep", "cancel"] as const)[choice]
+              : (["keep", "cancel"] as const)[choice]
             if (action === "sync") {
               try {
                 await NativeLocationService.manualFlush()
@@ -84,9 +82,6 @@ export function ConnectionSettings({
               }
               onSettingsChange({ ...settings, isOfflineMode: true })
             } else if (action === "keep") {
-              onSettingsChange({ ...settings, isOfflineMode: true })
-            } else if (action === "delete") {
-              await NativeLocationService.clearQueue()
               onSettingsChange({ ...settings, isOfflineMode: true })
             }
             return

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -208,7 +208,7 @@ describe("ConnectionSettings", () => {
 
     it("shows choice dialog when queue has items", async () => {
       mockGetStats.mockResolvedValue({ queued: 10, sent: 50, total: 60, today: 5, databaseSizeMB: 1 })
-      mockShowChoice.mockResolvedValue(3) // Cancel
+      mockShowChoice.mockResolvedValue(2) // Cancel
       const { getAllByRole } = renderComponent({ endpoint: "https://example.com/api" })
 
       const toggle = getAllByRole("switch")[0]
@@ -253,23 +253,9 @@ describe("ConnectionSettings", () => {
       })
     })
 
-    it("deletes queue and enables offline when Delete chosen", async () => {
-      mockGetStats.mockResolvedValue({ queued: 10, sent: 50, total: 60, today: 5, databaseSizeMB: 1 })
-      mockShowChoice.mockResolvedValue(2) // Delete Queue (with endpoint)
-      const { getAllByRole } = renderComponent({ endpoint: "https://example.com/api" })
-
-      const toggle = getAllByRole("switch")[0]
-      fireEvent(toggle, "valueChange", true)
-
-      await waitFor(() => {
-        expect(mockClearQueue).toHaveBeenCalled()
-        expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ isOfflineMode: true }))
-      })
-    })
-
     it("does not enable offline when Cancel chosen", async () => {
       mockGetStats.mockResolvedValue({ queued: 10, sent: 50, total: 60, today: 5, databaseSizeMB: 1 })
-      mockShowChoice.mockResolvedValue(3) // Cancel (with endpoint)
+      mockShowChoice.mockResolvedValue(2) // Cancel (with endpoint)
       const { getAllByRole } = renderComponent({ endpoint: "https://example.com/api" })
 
       const toggle = getAllByRole("switch")[0]

--- a/fastlane/metadata/android/en-US/changelogs/38.txt
+++ b/fastlane/metadata/android/en-US/changelogs/38.txt
@@ -2,3 +2,4 @@
 - mTLS client certificate support: configure a client certificate in the new mTLS Settings screen, either by picking one already installed on the device (key stays in the OS keystore) or by importing a .p12 / .pfx file. Required if your server enforces mutual TLS.
 - Self-signed / private CA support: import a Trusted Server CA in the same screen for self-hosted servers without publicly-trusted certificates.
 - Stricter TLS trust (breaking): user-installed CAs from Android Settings -> Encryption & credentials are no longer trusted by Colota. If you relied on one, re-import via the new mTLS Settings screen.
+- Removed the "Delete Queue" button from the offline-mode switch dialog.


### PR DESCRIPTION
Queue can be still deleted from Data Management screen

Related to #377 