### PR TITLE
feat: filter GPS position-jump outliers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,11 @@ test-output.txt
 testers
 apps/mobile/test-checklist.md
 gitnote.md
+
+# Server
+apps/server/.env
+apps/server/config/users.toml
+apps/server/data/
+apps/server/dist
+apps/server/web/dist
+

--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -128,6 +128,14 @@ class LocationForegroundService : Service() {
         private const val WIFI_RESUME_DEBOUNCE_MS = 2_000L
         /** Cadence at which the tracking heartbeat logs time-since-last-fix for diagnostics. */
         private const val TRACKING_HEARTBEAT_INTERVAL_MS = 5 * 60_000L
+
+        /** Stationary-jitter floor for the position-jump filter. */
+        private const val POSITION_JUMP_FILTER_MIN_IMPLIED_MPS = 20f
+        /** Implied speed must exceed chip-Doppler by this factor to count as a jump. */
+        private const val POSITION_JUMP_FILTER_RATIO = 5f
+        /** Gaps above this bypass the filter so post-resume fixes aren't dropped. */
+        private const val POSITION_JUMP_FILTER_WINDOW_MS = 300_000L
+
         const val ACTION_MANUAL_FLUSH = "com.Colota.ACTION_MANUAL_FLUSH"
         const val ACTION_RECHECK_ZONE = "com.Colota.RECHECK_PAUSE_ZONE"
         const val ACTION_REFRESH_NOTIFICATION = "com.Colota.REFRESH_NOTIFICATION"
@@ -610,6 +618,20 @@ class LocationForegroundService : Service() {
             && location.longitude == prev.longitude) {
             AppLogger.d(TAG, "Duplicate location skipped (same timestamp and coords)")
             return
+        }
+
+        // Position-jump filter: chip-reported and implied speed are independent signals; large disagreement means the chip hallucinated position.
+        if (prev != null && location.hasSpeed()) {
+            val dt = location.time - prev.time
+            if (dt in 1000..POSITION_JUMP_FILTER_WINDOW_MS) {
+                val distance = prev.distanceTo(location)
+                val implied = distance / (dt / 1000f)
+                if (implied > POSITION_JUMP_FILTER_MIN_IMPLIED_MPS
+                    && implied > location.speed * POSITION_JUMP_FILTER_RATIO) {
+                    AppLogger.w(TAG, "Location filtered: implied ${String.format(Locale.US, "%.1f", implied)}m/s vs chip ${String.format(Locale.US, "%.1f", location.speed)}m/s (dist ${String.format(Locale.US, "%.1f", distance)}m, dt ${dt}ms)")
+                    return
+                }
+            }
         }
 
         applySpeedFallback(location)

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -334,6 +334,122 @@ class LocationForegroundServiceTest {
     }
 
     // =========================================================================
+    // Position-jump filter (#382) - implied-speed vs chip-Doppler-speed disagreement
+    // =========================================================================
+
+    @Test
+    fun `position-jump filter drops fix when implied speed far exceeds chip speed`() = testScope.runTest {
+        // Bug signature: chip reports 0 m/s but position jumps 1670m in 10s (implied 167 m/s).
+        val now = System.currentTimeMillis()
+        val prev = mockLocation(time = now - 10_000, distanceTo = 1670f)
+        setField("lastKnownLocation", prev)
+
+        val jump = mockLocation(hasSpeed = true, speed = 0f, time = now)
+        invokeHandleLocationUpdate(jump)
+
+        verify(exactly = 0) { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        // Anchor must stay on prev so the next good fix is judged against a trusted point.
+        assertEquals(prev, getField<Location?>("lastKnownLocation"))
+    }
+
+    @Test
+    fun `position-jump filter keeps flight cruise where chip and implied agree`() = testScope.runTest {
+        // ~250 m/s (900 km/h) cruise. Both measurements agree -> ratio check passes.
+        val now = System.currentTimeMillis()
+        val prev = mockLocation(time = now - 5_000, distanceTo = 1250f)  // 1250m in 5s = 250 m/s
+        setField("lastKnownLocation", prev)
+        every { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns 1L
+
+        val cruise = mockLocation(hasSpeed = true, speed = 250f, time = now)
+        invokeHandleLocationUpdate(cruise)
+
+        verify { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `position-jump filter keeps highway driving`() = testScope.runTest {
+        val now = System.currentTimeMillis()
+        val prev = mockLocation(time = now - 2_000, distanceTo = 60f)  // 60m in 2s = 30 m/s
+        setField("lastKnownLocation", prev)
+        every { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns 1L
+
+        val driving = mockLocation(hasSpeed = true, speed = 30f, time = now)
+        invokeHandleLocationUpdate(driving)
+
+        verify { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `position-jump filter keeps stationary GPS jitter below floor`() = testScope.runTest {
+        // chip=0, implied=0.5 m/s. Implied is below the 20 m/s floor -> not flagged.
+        val now = System.currentTimeMillis()
+        val prev = mockLocation(time = now - 10_000, distanceTo = 5f)
+        setField("lastKnownLocation", prev)
+        every { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns 1L
+
+        val jitter = mockLocation(hasSpeed = true, speed = 0f, time = now)
+        invokeHandleLocationUpdate(jitter)
+
+        verify { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `position-jump filter bypassed when gap exceeds window`() = testScope.runTest {
+        // 10-minute gap (e.g. post-airplane-mode, deep sleep resume). Implied is huge but
+        // we cannot judge it, so the first fix after a long pause is accepted unconditionally.
+        val now = System.currentTimeMillis()
+        val prev = mockLocation(time = now - 600_000, distanceTo = 50_000f)
+        setField("lastKnownLocation", prev)
+        every { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns 1L
+
+        val resume = mockLocation(hasSpeed = true, speed = 0f, time = now)
+        invokeHandleLocationUpdate(resume)
+
+        verify { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `position-jump filter skipped when chip omits speed`() = testScope.runTest {
+        // Without chip-Doppler speed there's nothing to compare against, so we can't tell
+        // a jump from a legitimate fast fix - accept rather than false-drop flight fixes.
+        val now = System.currentTimeMillis()
+        val prev = mockLocation(time = now - 10_000, distanceTo = 1670f)
+        setField("lastKnownLocation", prev)
+        every { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns 1L
+
+        val noSpeed = mockLocation(hasSpeed = false, time = now)
+        invokeHandleLocationUpdate(noSpeed)
+
+        verify { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `position-jump filter not applied on first fix without previous anchor`() = testScope.runTest {
+        // No lastKnownLocation -> nothing to compare against; first fix is always accepted.
+        every { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns 1L
+
+        val firstFix = mockLocation(hasSpeed = true, speed = 0f)
+        invokeHandleLocationUpdate(firstFix)
+
+        verify { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `consecutive position-jumps both dropped with anchor stuck on last good fix`() = testScope.runTest {
+        val t0 = System.currentTimeMillis()
+        val anchor = mockLocation(time = t0, distanceTo = 1670f)
+        setField("lastKnownLocation", anchor)
+
+        val jump1 = mockLocation(hasSpeed = true, speed = 0f, time = t0 + 10_000)
+        invokeHandleLocationUpdate(jump1)
+        val jump2 = mockLocation(hasSpeed = true, speed = 0f, time = t0 + 20_000)
+        invokeHandleLocationUpdate(jump2)
+
+        verify(exactly = 0) { dbHelper.saveLocation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertEquals(anchor, getField<Location?>("lastKnownLocation"))
+    }
+
+    // =========================================================================
     // applySpeedFallback
     // =========================================================================
 

--- a/fastlane/metadata/android/en-US/changelogs/38.txt
+++ b/fastlane/metadata/android/en-US/changelogs/38.txt
@@ -1,5 +1,7 @@
 - Encrypted backup and restore: bundle your locations, settings and credentials into a single password-encrypted .colota file you can store anywhere. Restore on the same device or migrate to a new one. There is no password recovery, so use one you won't forget.
+- Import location history from external files: read GeoJSON, Google Timeline, GPX, KML or CSV from your device, dedupe against existing data and optionally push the new rows to your sync backend.
 - mTLS client certificate support: configure a client certificate in the new mTLS Settings screen, either by picking one already installed on the device (key stays in the OS keystore) or by importing a .p12 / .pfx file. Required if your server enforces mutual TLS.
 - Self-signed / private CA support: import a Trusted Server CA in the same screen for self-hosted servers without publicly-trusted certificates.
 - Stricter TLS trust (breaking): user-installed CAs from Android Settings -> Encryption & credentials are no longer trusted by Colota. If you relied on one, re-import via the new mTLS Settings screen.
 - Removed the "Delete Queue" button from the offline-mode switch dialog.
+- Filter occasional GPS teleport outliers


### PR DESCRIPTION
Drop fixes where position-implied speed wildly exceeds reported speed. The two are independent signals, so disagreement catches single-fix chip position hallucinations without affecting normal travel.

Closes #382