### PR TITLE
feat(trip-detail): match track color to title + prev/next trip nav

### DIFF
--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -41,10 +41,11 @@ interface Props {
   locations: TrackLocation[]
   colors: ThemeColors
   trips?: Trip[]
+  trackColor: string
   fitVersion?: number
 }
 
-export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
+export function TrackMap({ locations, colors, trips, trackColor, fitVersion }: Props) {
   const mapRef = useRef<ColotaMapRef>(null)
   const [isCentered, setIsCentered] = useState(true)
   const [selectedPoint, setSelectedPoint] = useState<{
@@ -126,14 +127,13 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
           arr.push(tripColor)
         }
       }
-      // Fill remaining points with default color
       while (arr.length < locations.length) {
-        arr.push(colors.primary)
+        arr.push(trackColor)
       }
       return arr
     }
-    return locations.map(() => colors.primary)
-  }, [trips, locations, colors.primary])
+    return locations.map(() => trackColor)
+  }, [trips, locations, trackColor])
 
   // GeoJSON data
   const segmentsGeoJSON = useMemo(
@@ -148,7 +148,7 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
   // Highlight GeoJSON for selected point
   const highlightGeoJSON = useMemo(() => {
     const coord = selectedPoint ? [selectedPoint.longitude, selectedPoint.latitude] : null
-    const color = selectedPoint?.color ?? colors.primary
+    const color = selectedPoint?.color ?? trackColor
     return {
       type: "FeatureCollection" as const,
       features: [
@@ -159,7 +159,7 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
         }
       ]
     }
-  }, [selectedPoint, colors.primary])
+  }, [selectedPoint, trackColor])
 
   const highlightStyle = useMemo(
     () => ({
@@ -182,7 +182,7 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
       lastPointPressRef.current = Date.now()
       const geom = feature.geometry as GeoJSON.Point
       const coord = geom.coordinates as [number, number]
-      const color = feature.properties.color ?? colors.primary
+      const color = feature.properties.color ?? trackColor
       setSelectedPoint({ longitude: coord[0], latitude: coord[1], color })
       setPopup({
         coordinate: coord,
@@ -193,7 +193,7 @@ export function TrackMap({ locations, colors, trips, fitVersion }: Props) {
         color
       })
     },
-    [colors.primary]
+    [trackColor]
   )
 
   const handleMapPress = useCallback(() => {

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -92,18 +92,18 @@ describe("TrackMap auto-fit", () => {
     const locsA = [loc(48.1, 11.5), loc(48.2, 11.6)]
     const locsB = [loc(52.5, 13.4), loc(52.6, 13.5)]
 
-    const { rerender } = render(<TrackMap locations={locsA} colors={colors} fitVersion={1} />)
+    const { rerender } = render(<TrackMap locations={locsA} colors={colors} trackColor="#000" fitVersion={1} />)
     expect(mockFitBounds).toHaveBeenCalledTimes(1)
 
     // Switch to empty day
     act(() => {
-      rerender(<TrackMap locations={[]} colors={colors} fitVersion={2} />)
+      rerender(<TrackMap locations={[]} colors={colors} trackColor="#000" fitVersion={2} />)
     })
     expect(mockFitBounds).toHaveBeenCalledTimes(1) // no new fit on empty
 
     // Switch to another non-empty day - the regression target
     act(() => {
-      rerender(<TrackMap locations={locsB} colors={colors} fitVersion={3} />)
+      rerender(<TrackMap locations={locsB} colors={colors} trackColor="#000" fitVersion={3} />)
     })
     expect(mockFitBounds).toHaveBeenCalledTimes(2)
   })

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -168,9 +168,9 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
   /** Tap a trip card -> open detail screen */
   const handleTripSelect = useCallback(
     (trip: Trip) => {
-      navigation.navigate("Trip Detail", { trip })
+      navigation.navigate("Trip Detail", { trip, trips })
     },
-    [navigation]
+    [navigation, trips]
   )
 
   /** Export trips (all or single) */
@@ -265,6 +265,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
             locations={mapLocations}
             colors={colors}
             trips={selectedTrip ? undefined : trips}
+            trackColor={colors.primary}
             fitVersion={fitVersion}
           />
           {selectedTrip && (

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useMemo, useState, useCallback, useLayoutEffect } from "react"
+import React, { useMemo, useState, useCallback, useLayoutEffect, useEffect } from "react"
 import { View, Text, StyleSheet, ScrollView, Pressable } from "react-native"
 import {
   Route,
@@ -14,6 +14,8 @@ import {
   MapPin,
   Share,
   Trash2,
+  ChevronLeft,
+  ChevronRight,
   type LucideIcon
 } from "lucide-react-native"
 import { useTheme } from "../hooks/useTheme"
@@ -25,6 +27,7 @@ import { InteractiveLineChart } from "../components/features/inspector/Interacti
 import { getTripColor, computeTripStats } from "../utils/trips"
 import { formatDate, formatDistance, formatDuration, formatSpeed, formatTime } from "../utils/geo"
 import { TRIP_CONVERTERS, EXPORT_FORMATS, EXPORT_FORMAT_KEYS, type ExportFormat } from "../utils/exportConverters"
+import { HIT_SLOP_LG } from "../constants"
 import { showAlert, showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
 import NativeLocationService from "../services/NativeLocationService"
@@ -51,6 +54,7 @@ function downsample(values: number[], maxBars: number): number[] {
 export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip Detail">) {
   const { colors } = useTheme()
   const trip: Trip = route.params.trip
+  const trips: Trip[] = route.params.trips
   const tripColor = getTripColor(trip.index)
   const [deleting, setDeleting] = useState(false)
 
@@ -60,6 +64,24 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
 
   const [showExport, setShowExport] = useState(false)
   const [chartActiveIndex, setChartActiveIndex] = useState<number | null>(null)
+
+  const currentIdx = trips.findIndex((t) => t.index === trip.index)
+  const prevTrip = currentIdx > 0 ? trips[currentIdx - 1] : null
+  const nextTrip = currentIdx >= 0 && currentIdx < trips.length - 1 ? trips[currentIdx + 1] : null
+
+  // Reset transient UI state when switching to a different trip.
+  useEffect(() => {
+    setChartActiveIndex(null)
+    setShowExport(false)
+  }, [trip.index])
+
+  const goToTrip = useCallback(
+    (target: Trip | null) => {
+      if (!target) return
+      navigation.setParams({ trip: target })
+    },
+    [navigation]
+  )
 
   const handleExport = useCallback(
     async (format: ExportFormat) => {
@@ -145,14 +167,32 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
   return (
     <Container>
       <View style={styles.mapContainer}>
-        <TrackMap locations={trip.locations} colors={colors} fitVersion={1} />
+        <TrackMap locations={trip.locations} colors={colors} trackColor={tripColor} fitVersion={trip.index} />
       </View>
       <ScrollView contentContainerStyle={styles.content}>
         {/* Header */}
         <View style={styles.section}>
           <View style={styles.headerTitleRow}>
-            <View style={[styles.dot, { backgroundColor: tripColor }]} />
-            <Text style={[styles.title, { color: colors.text }]}>{displayName}</Text>
+            <Pressable
+              onPress={() => goToTrip(prevTrip)}
+              disabled={!prevTrip}
+              hitSlop={HIT_SLOP_LG}
+              style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
+            >
+              <ChevronLeft size={24} color={prevTrip ? colors.primary : colors.textDisabled} />
+            </Pressable>
+            <View style={styles.headerTitleCenter}>
+              <View style={[styles.dot, { backgroundColor: tripColor }]} />
+              <Text style={[styles.title, { color: colors.text }]}>{displayName}</Text>
+            </View>
+            <Pressable
+              onPress={() => goToTrip(nextTrip)}
+              disabled={!nextTrip}
+              hitSlop={HIT_SLOP_LG}
+              style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
+            >
+              <ChevronRight size={24} color={nextTrip ? colors.primary : colors.textDisabled} />
+            </Pressable>
           </View>
           <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
             {formatDate(trip.startTime)} · {formatTime(trip.startTime, true)} - {formatTime(trip.endTime, true)}
@@ -312,8 +352,18 @@ const styles = StyleSheet.create({
   headerTitleRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
+    justifyContent: "space-between",
     marginBottom: 4
+  },
+  headerTitleCenter: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    flex: 1,
+    justifyContent: "center"
+  },
+  navBtn: {
+    padding: 4
   },
   dot: {
     width: 12,
@@ -327,7 +377,7 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 13,
     ...fonts.regular,
-    marginLeft: 22
+    textAlign: "center"
   },
   statsGrid: {
     flexDirection: "row",

--- a/apps/mobile/src/types/navigation.ts
+++ b/apps/mobile/src/types/navigation.ts
@@ -29,7 +29,7 @@ export type RootStackParamList = {
   "Profile Editor": { profileId?: number } | undefined
   "About Colota": undefined
   "Setup Import": undefined
-  "Trip Detail": { trip: Trip }
+  "Trip Detail": { trip: Trip; trips: Trip[] }
   "Offline Maps": undefined
   "Activity Log": undefined
   "Backup & Restore": undefined

--- a/fastlane/metadata/android/en-US/changelogs/39.txt
+++ b/fastlane/metadata/android/en-US/changelogs/39.txt
@@ -2,3 +2,6 @@
 - Tasker support: start/stop tracking via broadcast intent.
 - Battery charging status now shows correctly in the Data tab.
 - Backup password field switched to hold-to-reveal.
+- Fixed app freezes on slower devices caused by motion detection.
+- Trip detail: track on the map now matches the trip's title color.
+- Trip detail: switch between trips with prev/next arrows next to the title.


### PR DESCRIPTION
The track polyline now uses the trip's identity color (matching the dot next to "Trip N") instead of the theme primary.

Adds prev/next chevrons next to the title that swap trips in place.

References #413 