### PR TITLE
fix(import): stop duplicating sniff buffer

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/importer/LocationImporter.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/importer/LocationImporter.kt
@@ -37,15 +37,12 @@ object LocationImporter {
         nowSec: Long = System.currentTimeMillis() / 1000,
     ): PreviewResult {
         val parseStart = System.currentTimeMillis()
-        val (sniffBytes, sniffString) = readSniff(contentResolver, uri)
-        val format = detectFormat(sniffString)
-            ?: throw UnsupportedFormatException("Could not detect file format")
-
-        // Prepend the sniff buffer back so the parser sees the full document without a
-        // second SAF open - some cloud providers charge a network round-trip per open.
-        val parse = openStream(contentResolver, uri).use { rest ->
-            val combined = SequenceInputStream(ByteArrayInputStream(sniffBytes), rest)
-            when (format) {
+        val (format, parse) = openStream(contentResolver, uri).use { stream ->
+            val (sniffBytes, sniffString) = readSniff(stream)
+            val detected = detectFormat(sniffString)
+                ?: throw UnsupportedFormatException("Could not detect file format")
+            val combined = SequenceInputStream(ByteArrayInputStream(sniffBytes), stream)
+            val result = when (detected) {
                 ImportFormat.GEOJSON -> GeoJsonParser.parse(combined, cancelled, nowSec)
                 ImportFormat.GOOGLE_TIMELINE_LEGACY,
                 ImportFormat.GOOGLE_TIMELINE_NEW -> GoogleTimelineParser.parse(combined, cancelled, nowSec)
@@ -53,6 +50,7 @@ object LocationImporter {
                 ImportFormat.KML -> KmlParser.parse(combined, cancelled, nowSec)
                 ImportFormat.CSV -> CsvParser.parse(combined, cancelled, nowSec)
             }
+            detected to result
         }
         val parseMs = System.currentTimeMillis() - parseStart
         val rate = if (parseMs > 0) parse.rows.size * 1000L / parseMs else parse.rows.size.toLong()
@@ -261,18 +259,17 @@ object LocationImporter {
         contentResolver.openInputStream(uri)
             ?: throw IllegalStateException("Could not open input stream for $uri")
 
-    private fun readSniff(contentResolver: ContentResolver, uri: Uri): Pair<ByteArray, String> {
-        openStream(contentResolver, uri).use { stream ->
-            val buf = ByteArray(SNIFF_BYTES)
-            var total = 0
-            while (total < buf.size) {
-                val n = stream.read(buf, total, buf.size - total)
-                if (n <= 0) break
-                total += n
-            }
-            val trimmed = if (total == buf.size) buf else buf.copyOf(total)
-            return trimmed to String(trimmed, Charsets.UTF_8)
+    // Leaves `stream` positioned just past the sniffed bytes so the caller can prepend them.
+    private fun readSniff(stream: InputStream): Pair<ByteArray, String> {
+        val buf = ByteArray(SNIFF_BYTES)
+        var total = 0
+        while (total < buf.size) {
+            val n = stream.read(buf, total, buf.size - total)
+            if (n <= 0) break
+            total += n
         }
+        val trimmed = if (total == buf.size) buf else buf.copyOf(total)
+        return trimmed to String(trimmed, Charsets.UTF_8)
     }
 
     internal fun dedupKey(ts: Long, lat: Double, lon: Double): DedupKey =

--- a/apps/mobile/android/app/src/test/java/com/Colota/importer/LocationImporterTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/importer/LocationImporterTest.kt
@@ -469,6 +469,45 @@ class LocationImporterTest {
         assertEquals(1_704_110_500L, preview.dateRangeEndSec)
     }
 
+    @Test
+    fun `preview parses a GPX larger than the sniff buffer without corrupting the stream`() {
+        // Files past the 4KB sniff buffer used to get the sniffed prefix spliced back into
+        // the document; smaller fixtures hid it because the parser stops at the first root close.
+        val pointCount = 200
+        val gpx = buildString {
+            append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+            append("<gpx version=\"1.1\" xmlns=\"http://www.topografix.com/GPX/1/1\">\n")
+            append("<trk><trkseg>\n")
+            for (i in 0 until pointCount) {
+                val lat = 52.5 + i * 0.0001
+                val lon = 13.4 + i * 0.0001
+                val iso = java.time.Instant.ofEpochSecond(1_704_110_400L + i).toString()
+                append("<trkpt lat=\"$lat\" lon=\"$lon\"><ele>30</ele><time>$iso</time></trkpt>\n")
+            }
+            append("</trkseg></trk>\n</gpx>\n")
+        }
+        assertTrue(
+            "fixture must exceed the sniff buffer to exercise the splice",
+            gpx.toByteArray(Charsets.UTF_8).size > 4096,
+        )
+
+        val uri = writeFixture("large.gpx", gpx)
+        val resolver = ApplicationProvider.getApplicationContext<android.content.Context>().contentResolver
+
+        val preview = LocationImporter.preview(
+            contentResolver = resolver,
+            uri = uri,
+            db = db,
+            cancelled = AtomicBoolean(false),
+            nowSec = 1_750_000_000L,
+        )
+
+        assertEquals(ImportFormat.GPX, preview.format)
+        assertEquals(pointCount, preview.totalParsed)
+        assertEquals(0, preview.invalid)
+        assertEquals(pointCount, preview.rowsToCommit.size)
+    }
+
     private fun writeFixture(name: String, content: String): android.net.Uri {
         val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
         val file = java.io.File(ctx.cacheDir, name)

--- a/fastlane/metadata/android/en-US/changelogs/39.txt
+++ b/fastlane/metadata/android/en-US/changelogs/39.txt
@@ -1,8 +1,8 @@
-- Multi-select trips: long-press a trip in Location History to select.
+- Multi-select trips via long-press in Location History.
 - Tasker support: start/stop tracking via broadcast intent.
-- Battery charging status now shows correctly in the Data tab.
+- Battery charging status now correct in the Data tab.
 - Backup password field switched to hold-to-reveal.
-- Fixed app freezes on slower devices caused by motion detection.
-- Trip detail: track on the map now matches the trip's title color.
-- Trip detail: switch between trips with prev/next arrows next to the title.
-- Activity Log is now Logging, with a new File tab for persistent bug-report logs.
+- Fixed motion-detection freezes on slower devices.
+- Trip detail: map track matches the title color; prev/next arrows switch trips.
+- Activity Log renamed to Logging, with a File tab for bug-report logs.
+- Fixed location import failing on files larger than a few KB.


### PR DESCRIPTION
Parsing re-opened the file from byte 0 and re-prepended the sniffed prefix, corrupting any document past the 4KB buffer. Sniff and parse now share one stream.

Related to #377