### PR TITLE
fix(traccar): send GET timestamps as integers, not scientific notation

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/sync/NetworkManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/NetworkManager.kt
@@ -403,10 +403,16 @@ class NetworkManager(private val context: Context) {
         val keys = payload.keys()
         while (keys.hasNext()) {
             val key = keys.next()
-            val value = payload.opt(key)?.toString() ?: continue
+            val raw = payload.opt(key) ?: continue
+            val value = formatQueryValue(raw)
             params.add("${URLEncoder.encode(key, "UTF-8")}=${URLEncoder.encode(value, "UTF-8")}")
         }
         return params.joinToString("&")
+    }
+
+    private fun formatQueryValue(raw: Any): String = when {
+        raw is Double && raw == raw.toLong().toDouble() -> raw.toLong().toString()
+        else -> raw.toString()
     }
 
     /**

--- a/apps/mobile/android/app/src/test/java/com/Colota/sync/NetworkManagerTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/sync/NetworkManagerTest.kt
@@ -48,6 +48,26 @@ class NetworkManagerTest {
     }
 
     @Test
+    fun `buildQueryString renders whole-number doubles as integers`() {
+        // JS numbers cross the RN bridge as doubles, so a Test Connection unix
+        // timestamp serializes as 1.780257432E9. Traccar's OsmAnd endpoint rejects
+        // a scientific-notation timestamp and drops the connection without
+        // replying (okhttp surfaces this as "unexpected end of stream").
+        val payload = JSONObject().apply {
+            put("tst", 1780257432.0)
+            put("acc", 5.0)
+            put("lat", 48.0685105)
+        }
+
+        val result = invokeBuildQueryString(payload)
+
+        assertTrue(result.contains("tst=1780257432"))
+        assertFalse("scientific notation breaks Traccar's parser", result.contains("1.780257432E9"))
+        assertFalse("whole-number doubles must drop the .0", result.contains("acc=5.0"))
+        assertTrue("fractional values keep their decimals", result.contains("lat=48.0685105"))
+    }
+
+    @Test
     fun `buildQueryString URL-encodes special characters`() {
         val payload = JSONObject().put("name", "hello world&more")
 


### PR DESCRIPTION
RN bridge turns JS ints into doubles, so the timestamp went out as 1.78e9 and Traccar dropped the request. buildQueryString now formats whole doubles as plain ints. Refs #425