### PR TITLE
ci: scan FOSS in CodeQL, document release APKs, dedupe non-release setup

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,26 @@
+name: Setup Android build environment
+description: Set up Node and Java, install dependencies, build the shared package
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+
+    - name: Setup Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'gradle'
+
+    - name: Install dependencies
+      run: npm ci
+      shell: bash
+
+    - name: Build shared package
+      run: npm run build -w @colota/shared
+      shell: bash

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -49,4 +49,14 @@ category-template: '## $TITLE'
 template: |
   $CHANGES
 
+  ## Which APK should I download?
+
+  Pick the build that matches your device:
+
+  - **arm64-v8a** - almost every phone from the last several years (recommended)
+  - **armeabi-v7a** - older 32-bit devices
+  - **universal** - one larger APK that runs on any device, if you are unsure
+
+  Choose a **gms** build if you use Google Play Services (better for most users) or a **foss** build for no Google dependencies.
+
   **Full Changelog**: https://github.com/dietrichmax/colota/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -17,7 +17,7 @@ on:
       - 'package-lock.json'
 
 concurrency:
-  group: build-check-${{ github.head_ref }}
+  group: build-check-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -32,24 +32,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build shared package
-        run: npm run build -w @colota/shared
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
 
       - name: Run ESLint
         run: npm run lint -w @colota/mobile
@@ -75,24 +59,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build shared package
-        run: npm run build -w @colota/shared
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
 
       - name: Build GMS Debug APK
         run: |
@@ -109,24 +77,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build shared package
-        run: npm run build -w @colota/shared
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
 
       - name: Build FOSS Debug APK
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,17 +23,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-      - run: npm ci
-      - run: npm run build -w @colota/shared
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
       - run: npm run lint -w @colota/mobile
       - run: npx -w @colota/mobile tsc --noEmit
       - run: npm test -w @colota/mobile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,24 +26,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build shared package
-        run: npm run build -w @colota/shared
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -56,7 +40,7 @@ jobs:
         run: |
           cd apps/mobile/android
           chmod +x gradlew
-          ./gradlew compileGmsDebugSources --no-daemon
+          ./gradlew compileGmsDebugSources compileFossDebugSources --no-daemon
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - 'apps/docs/**'
       - 'packages/shared/**'


### PR DESCRIPTION
- add setup-build composite action for build-check / codeql / release tests
- CodeQL now compiles the foss flavor (compileFossDebugSources)
- add "which APK to download" guide to the release-drafter template
- drop nonexistent develop branch from docs-check
- fix build-check concurrency collapsing all main pushes into one group