### PR TITLE
fix(tracking): restart tracking after app update

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -99,13 +99,14 @@
             android:foregroundServiceType="shortService"
             android:exported="false" />
 
-        <!-- Boot Receiver -->
+        <!-- Tracking restart receiver (boot / app update) -->
         <receiver
             android:name=".triggers.LocationBootReceiver"
             android:enabled="true"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
                 <category android:name="android.intent.CATEGORY_DEFAULT" />
             </intent-filter>
         </receiver>

--- a/apps/mobile/android/app/src/main/java/com/colota/triggers/BootReceiver.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/triggers/BootReceiver.kt
@@ -20,15 +20,15 @@ import com.Colota.util.DeviceInfoHelper
 import kotlinx.coroutines.*
 
 /**
- * Receiver responsible for restarting the location tracking service after device reboot.
+ * Receiver responsible for restarting the location tracking service after a device
+ * reboot or after the app is updated.
  */
 class LocationBootReceiver : BroadcastReceiver() {
-    
     companion object {
         private const val TAG = "BootReceiver"
-        
-        private val BOOT_ACTIONS = setOf(
-            Intent.ACTION_BOOT_COMPLETED
+        private val HANDLED_ACTIONS = setOf(
+            Intent.ACTION_BOOT_COMPLETED,
+            Intent.ACTION_MY_PACKAGE_REPLACED
         )
         
         private const val MAX_DB_RETRIES = 3
@@ -38,8 +38,7 @@ class LocationBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action ?: return
         
-        // Check if this is a boot-related action
-        if (action !in BOOT_ACTIONS) return
+        if (action !in HANDLED_ACTIONS) return
         
         // Use goAsync() to prevent ANR during database access
         val pendingResult = goAsync()
@@ -97,7 +96,7 @@ class LocationBootReceiver : BroadcastReceiver() {
             val isEnabled = dbHelper.getSetting(SettingsKeys.TRACKING_ENABLED, "false") == "true"
             
             if (!isEnabled) {
-                AppLogger.d(TAG, "Boot detected but tracking disabled")
+                AppLogger.d(TAG, "Trigger received but tracking disabled")
 
                 // Charger auto-resume: only if the stop was battery-triggered (not a user stop).
                 val stoppedByBattery = dbHelper.getSetting(SettingsKeys.STOPPED_BY_BATTERY, "false") == "true"
@@ -121,9 +120,10 @@ class LocationBootReceiver : BroadcastReceiver() {
                 return
             }
             
-            AppLogger.d(TAG, "Boot detected ($action). Restarting service...")
+            AppLogger.d(TAG, "Trigger received ($action). Restarting service...")
 
-            LocationForegroundService.startTracking(context, dbHelper, "Device rebooted")
+            val reason = if (action == Intent.ACTION_MY_PACKAGE_REPLACED) "App updated" else "Device rebooted"
+            LocationForegroundService.startTracking(context, dbHelper, reason)
 
             AppLogger.d(TAG, "Service start requested successfully")
             

--- a/apps/mobile/android/app/src/test/java/com/Colota/triggers/LocationBootReceiverTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/triggers/LocationBootReceiverTest.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import com.Colota.data.DatabaseHelper
 import com.Colota.service.BatteryRecoveryScheduler
+import com.Colota.service.LocationForegroundService
 import com.Colota.service.NotificationHelper
 import com.Colota.util.AppLogger
 import com.Colota.util.DeviceInfoHelper
@@ -24,7 +25,7 @@ import kotlin.coroutines.Continuation
 
 /**
  * Tests for LocationBootReceiver:
- * - onReceive action filtering (null, unknown, valid boot actions)
+ * - onReceive action filtering (null, unknown, boot and app-update actions)
  * - handleBootCompleted logic (tracking disabled/enabled, DB not ready, SecurityException)
  * - waitForDatabaseReady retry logic
  */
@@ -101,6 +102,22 @@ class LocationBootReceiverTest {
     }
 
     @Test
+    fun `onReceive calls goAsync for ACTION_MY_PACKAGE_REPLACED`() {
+        val spy = spyk(receiver)
+        val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
+        every { spy.goAsync() } returns pendingResult
+        every { mockContext.applicationContext } returns mockContext
+        mockDbReadyAndDisabled()
+
+        val intent = mockk<Intent> { every { action } returns Intent.ACTION_MY_PACKAGE_REPLACED }
+        spy.onReceive(mockContext, intent)
+        Thread.sleep(500)
+
+        verify { spy.goAsync() }
+        verify { pendingResult.finish() }
+    }
+
+    @Test
     fun `onReceive always calls finish even on error`() {
         val spy = spyk(receiver)
         val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
@@ -136,6 +153,28 @@ class LocationBootReceiverTest {
         callHandleBootCompleted(mockContext, Intent.ACTION_BOOT_COMPLETED)
 
         verify { mockContext.startForegroundService(any()) }
+    }
+
+    @Test
+    fun `handleBootCompleted passes 'App updated' reason on app update`() = runTest {
+        mockkObject(LocationForegroundService.Companion)
+        every { LocationForegroundService.startTracking(any(), any(), any()) } just Runs
+        mockDbReadyAndEnabled()
+
+        callHandleBootCompleted(mockContext, Intent.ACTION_MY_PACKAGE_REPLACED)
+
+        verify { LocationForegroundService.startTracking(any(), any(), "App updated") }
+    }
+
+    @Test
+    fun `handleBootCompleted passes 'Device rebooted' reason on boot`() = runTest {
+        mockkObject(LocationForegroundService.Companion)
+        every { LocationForegroundService.startTracking(any(), any(), any()) } just Runs
+        mockDbReadyAndEnabled()
+
+        callHandleBootCompleted(mockContext, Intent.ACTION_BOOT_COMPLETED)
+
+        verify { LocationForegroundService.startTracking(any(), any(), "Device rebooted") }
     }
 
     @Test

--- a/fastlane/metadata/android/en-US/changelogs/41.txt
+++ b/fastlane/metadata/android/en-US/changelogs/41.txt
@@ -1,1 +1,2 @@
 - Share your setup as a link: pick which settings, geofences and profiles to include from the new Share Setup screen in Settings.
+- Fixed tracking stopping after an app update.


### PR DESCRIPTION
A Play Store update kills the app process and stops the foreground service, but unlike a reboot nothing restarted it, so tracking died silently while the UI still showed it as active.

Handle MY_PACKAGE_REPLACED in LocationBootReceiver alongside BOOT_COMPLETED, reusing the same restart path. The action is on Android's exemption list for starting a foreground service from the background, needs no extra permission and fires only on update of an existing install.

CLoses #474