### PR TITLE
feat(location): use fused location provider on Android 12+ in FOSS variant

### DIFF
--- a/apps/docs/docs/configuration/gps-settings.md
+++ b/apps/docs/docs/configuration/gps-settings.md
@@ -32,7 +32,7 @@ Only records a new location if you've moved at least this many meters since the 
 
 When enabled, GPS fixes with accuracy worse than the threshold are discarded. This prevents recording poor-quality positions from indoor or urban environments.
 
-The Google Play variant uses Android's `HIGH_ACCURACY` positioning mode via FusedLocationProvider, which combines GPS, Wi-Fi, and cellular data. The FOSS variant uses Android's native `LocationManager` with `GPS_PROVIDER` directly.
+The Google Play variant uses Android's `HIGH_ACCURACY` positioning mode via FusedLocationProvider, which combines GPS, Wi-Fi, and cellular data. The FOSS variant requests the same high-accuracy mode from the platform's fused location provider on Android 12+ and falls back to `GPS_PROVIDER` on older versions or ROMs without a fused provider.
 
 ## Position-Jump Filter
 

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -138,7 +138,7 @@ The on-disk format is **never** authoritative for sync decisions: imported rows 
 Location services are abstracted behind a `LocationProvider` interface (`location/LocationProvider.kt`), with flavor-specific implementations:
 
 - **GMS** (`src/gms/`) - `GmsLocationProvider` wraps Google Play Services `FusedLocationProviderClient`
-- **FOSS** (`src/foss/`) - `NativeLocationProvider` wraps Android's native `LocationManager` with `GPS_PROVIDER`
+- **FOSS** (`src/foss/`) - `NativeLocationProvider` wraps Android's native `LocationManager`, using the platform `FUSED_PROVIDER` on Android 12+ where available and `GPS_PROVIDER` otherwise
 
 Each flavor provides a `LocationProviderFactory` that instantiates and returns the correct implementation at runtime. The service and bridge code in `src/main/` depends only on the `LocationProvider` interface, never on a concrete class.
 

--- a/apps/docs/docs/faq.md
+++ b/apps/docs/docs/faq.md
@@ -20,7 +20,9 @@ No, but you can use [Dawarich](/docs/integrations/dawarich) or a custom backend 
 
 Yes. The **FOSS variant** (available on F-Droid, IzzyOnDroid and GitHub Releases) uses Android's native `LocationManager` and has no Google Play Services dependency. It works on LineageOS, GrapheneOS, CalyxOS and any ROM without Google services.
 
-The Google Play variant uses `FusedLocationProvider` for potentially better location accuracy through Wi-Fi and cell tower fusion.
+On Android 12+ the FOSS variant requests the platform's built-in fused location provider (an AOSP API, not Google Play Services), which adds Wi-Fi and cell tower fusion on ROMs that provide a network location backend. Without such a backend, or on Android 11 and older, it transparently uses raw GPS.
+
+The Google Play variant uses `FusedLocationProvider` from Google Play Services for the same Wi-Fi and cell tower fusion on any Android version.
 
 **GrapheneOS users:** You can use the GMS variant with sandboxed Google Play. GrapheneOS reroutes location requests to its own reimplementation of the Play geolocation service, so you get the accuracy benefits of `FusedLocationProvider` without sending location data to Google.
 
@@ -28,7 +30,7 @@ The Google Play variant uses `FusedLocationProvider` for potentially better loca
 
 The **Google Play variant** is generally the better choice for most users. `FusedLocationProvider` combines GPS, Wi-Fi, cell towers and motion sensors to deliver faster fixes and better battery efficiency, especially indoors and in dense urban areas.
 
-The **FOSS variant** uses Android's raw `LocationManager` with GPS as primary and network as fallback. It works reliably outdoors, but cold-start fixes can be slower and indoor accuracy is weaker without Wi-Fi and cell tower fusion.
+The **FOSS variant** uses the platform's fused location provider on Android 12+, which delivers comparable accuracy on stock ROMs. On de-Googled ROMs without a network location backend and on Android 11 or older it falls back to raw GPS - reliable outdoors, but cold-start fixes can be slower and indoor accuracy is weaker without Wi-Fi and cell tower fusion.
 
 If avoiding (sandboxed) Play Services is a priority, the FOSS variant is a perfectly fine option. On GrapheneOS with sandboxed Google Play, the GMS variant gives you the accuracy benefits without sending location data to Google (see above).
 

--- a/apps/mobile/android/app/src/foss/java/com/Colota/location/NativeLocationProvider.kt
+++ b/apps/mobile/android/app/src/foss/java/com/Colota/location/NativeLocationProvider.kt
@@ -10,30 +10,45 @@ import android.content.Context
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
-import android.os.Bundle
+import android.os.Build
 import android.os.CancellationSignal
 import android.os.Handler
 import android.os.Looper
+import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
+import androidx.core.location.LocationRequestCompat
 import androidx.core.util.Consumer
 import com.Colota.util.AppLogger
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * LocationManager-based GPS provider for FOSS flavor (no Google Play Services).
+ * LocationManager-based location provider for FOSS flavor (no Google Play Services).
+ * Uses the platform fused provider on Android 12+ where available, raw GPS otherwise.
  */
 @SuppressLint("MissingPermission")
 class NativeLocationProvider(context: Context) : LocationProvider {
 
     companion object {
         private const val TAG = "NativeLocationProvider"
+
+        internal fun selectProvider(locationManager: LocationManager): String =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                && LocationManagerCompat.hasProvider(locationManager, LocationManager.FUSED_PROVIDER)
+            ) LocationManager.FUSED_PROVIDER
+            else LocationManager.GPS_PROVIDER
     }
 
     private val locationManager: LocationManager =
         context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
+    private val provider: String = selectProvider(locationManager)
+
     private val listenerMap = java.util.concurrent.ConcurrentHashMap<LocationUpdateCallback, LocationListener>()
+
+    init {
+        AppLogger.i(TAG, "Location provider: $provider")
+    }
 
     override fun requestLocationUpdates(
         intervalMs: Long,
@@ -41,25 +56,22 @@ class NativeLocationProvider(context: Context) : LocationProvider {
         looper: Looper,
         callback: LocationUpdateCallback
     ) {
-        val listener = object : LocationListener {
+        val listener = object : LocationListenerCompat {
             override fun onLocationChanged(location: Location) {
                 callback.onLocationUpdate(location)
             }
-            @Deprecated("Deprecated in API 29")
-            override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
-            override fun onProviderEnabled(provider: String) {}
-            override fun onProviderDisabled(provider: String) {}
         }
 
+        // The legacy requestLocationUpdates overload runs at balanced power on API 31+,
+        // which can keep the fused provider from ever engaging GNSS.
+        val request = LocationRequestCompat.Builder(intervalMs)
+            .setQuality(LocationRequestCompat.QUALITY_HIGH_ACCURACY)
+            .setMinUpdateDistanceMeters(minDistanceMeters)
+            .build()
+
         try {
-            locationManager.requestLocationUpdates(
-                LocationManager.GPS_PROVIDER,
-                intervalMs,
-                minDistanceMeters,
-                listener,
-                looper
-            )
-            AppLogger.d(TAG, "Started GPS_PROVIDER updates: interval=${intervalMs}ms, distance=${minDistanceMeters}m")
+            LocationManagerCompat.requestLocationUpdates(locationManager, provider, request, listener, looper)
+            AppLogger.d(TAG, "Started $provider updates: interval=${intervalMs}ms, distance=${minDistanceMeters}m")
         } catch (e: SecurityException) {
             locationManager.removeUpdates(listener)
             throw e
@@ -71,7 +83,7 @@ class NativeLocationProvider(context: Context) : LocationProvider {
     override fun removeLocationUpdates(callback: LocationUpdateCallback) {
         listenerMap.remove(callback)?.let { listener ->
             locationManager.removeUpdates(listener)
-            AppLogger.d(TAG, "Stopped GPS_PROVIDER updates")
+            AppLogger.d(TAG, "Stopped $provider updates")
         }
     }
 
@@ -80,7 +92,7 @@ class NativeLocationProvider(context: Context) : LocationProvider {
         onFailure: (Exception) -> Unit
     ) {
         try {
-            onSuccess(locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER))
+            onSuccess(locationManager.getLastKnownLocation(provider))
         } catch (e: SecurityException) {
             onFailure(e)
         }
@@ -103,7 +115,7 @@ class NativeLocationProvider(context: Context) : LocationProvider {
         try {
             LocationManagerCompat.getCurrentLocation(
                 locationManager,
-                LocationManager.GPS_PROVIDER,
+                provider,
                 cancellationSignal,
                 Executor { handler.post(it) },
                 Consumer { location ->
@@ -112,9 +124,9 @@ class NativeLocationProvider(context: Context) : LocationProvider {
                 }
             )
             handler.postDelayed(timeoutRunnable, timeoutMs)
-            AppLogger.d(TAG, "Requested fresh GPS_PROVIDER fix (timeout=${timeoutMs}ms)")
+            AppLogger.d(TAG, "Requested fresh $provider fix (timeout=${timeoutMs}ms)")
         } catch (e: Exception) {
-            AppLogger.w(TAG, "Fresh GPS_PROVIDER fix failed: ${e.message}")
+            AppLogger.w(TAG, "Fresh $provider fix failed: ${e.message}")
             handler.removeCallbacks(timeoutRunnable)
             deliver(null)
         }

--- a/apps/mobile/android/app/src/testFoss/java/com/Colota/location/NativeLocationProviderTest.kt
+++ b/apps/mobile/android/app/src/testFoss/java/com/Colota/location/NativeLocationProviderTest.kt
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+package com.Colota.location
+
+import android.content.Context
+import android.location.LocationManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class NativeLocationProviderTest {
+
+    private val locationManager: LocationManager =
+        ApplicationProvider.getApplicationContext<Context>()
+            .getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    @Test
+    fun `selects the fused provider when the platform has one`() {
+        shadowOf(locationManager).setProviderEnabled(LocationManager.FUSED_PROVIDER, true)
+
+        assertEquals(LocationManager.FUSED_PROVIDER, NativeLocationProvider.selectProvider(locationManager))
+    }
+
+    @Test
+    fun `falls back to gps when the platform ships no fused provider`() {
+        shadowOf(locationManager).removeProvider(LocationManager.FUSED_PROVIDER)
+
+        assertEquals(LocationManager.GPS_PROVIDER, NativeLocationProvider.selectProvider(locationManager))
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `uses gps below api 31 even if a fused provider is reported`() {
+        shadowOf(locationManager).setProviderEnabled(LocationManager.FUSED_PROVIDER, true)
+
+        assertEquals(LocationManager.GPS_PROVIDER, NativeLocationProvider.selectProvider(locationManager))
+    }
+}

--- a/fastlane/metadata/android/en-US/changelogs/42.txt
+++ b/fastlane/metadata/android/en-US/changelogs/42.txt
@@ -1,0 +1,1 @@
+- FOSS variant: faster and more accurate fixes on Android 12+ via the platform fused location provider, with GPS fallback on older versions


### PR DESCRIPTION
The platform fused provider is AOSP, no GMS involved, so FOSS gets the same fix quality as the GMS variant on stock ROMs. Falls back to plain GPS below API 31 or when a ROM doesn't ship it. Has to go through LocationRequestCompat with HIGH_ACCURACY, the legacy overload only gets balanced power on 31+.

Closes #417