### PR TITLE
fix(motion): resync detector on profile stationary-entry

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -1334,6 +1334,8 @@ class LocationForegroundService : Service() {
 
     private fun handleStationaryChanged(stationary: Boolean) {
         ensureMotionDetectorRunning()
+        // Reset the edge-triggered detector so continuing motion re-fires a MOVING edge.
+        if (stationary) (motionDetector as? RawSensorMotionDetector)?.resyncStationaryBaseline()
     }
 
     // ── Debug-only motion injection (BuildConfig.DEBUG) ───────────────────

--- a/apps/mobile/android/app/src/main/java/com/colota/service/RawSensorMotionDetector.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/RawSensorMotionDetector.kt
@@ -136,6 +136,17 @@ class RawSensorMotionDetector(
         }
     }
 
+    /** Reset to STATIONARY so the next sustained motion re-fires a MOVING edge. */
+    fun resyncStationaryBaseline() {
+        val handler = sensorHandler ?: return
+        handler.post {
+            if (BuildConfig.DEBUG) AppLogger.d(TAG, "Resynced to STATIONARY (was $currentState)")
+            currentState = MotionState.STATIONARY
+            aboveThresholdSinceMs = 0L
+            belowThresholdSinceMs = 0L
+        }
+    }
+
     private fun processSample(nowMs: Long, magnitude: Double) {
         sampleWindow.addLast(Sample(nowMs, magnitude))
         while (sampleWindow.isNotEmpty() && nowMs - sampleWindow.first().timestampMs > VARIANCE_WINDOW_MS) {

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -2143,6 +2143,28 @@ class LocationForegroundServiceTest {
         verify { detector.stop() }
     }
 
+    @Test
+    fun `handleStationaryChanged true resyncs detector baseline`() {
+        val detector = mockk<RawSensorMotionDetector>(relaxed = true)
+        setField("motionDetector", detector)
+        every { profileManager.isStationary } returns true
+
+        invokeHandleStationaryChanged(true)
+
+        verify { detector.resyncStationaryBaseline() }
+    }
+
+    @Test
+    fun `handleStationaryChanged false does not resync`() {
+        val detector = mockk<RawSensorMotionDetector>(relaxed = true)
+        setField("motionDetector", detector)
+        every { profileManager.isStationary } returns false
+
+        invokeHandleStationaryChanged(false)
+
+        verify(exactly = 0) { detector.resyncStationaryBaseline() }
+    }
+
     // =========================================================================
     // maybeResumeGps - dual hold logic
     // =========================================================================
@@ -2548,6 +2570,14 @@ class LocationForegroundServiceTest {
         val method = LocationForegroundService::class.java.getDeclaredMethod("ensureMotionDetectorRunning")
         method.isAccessible = true
         method.invoke(service)
+    }
+
+    private fun invokeHandleStationaryChanged(stationary: Boolean) {
+        val method = LocationForegroundService::class.java.getDeclaredMethod(
+            "handleStationaryChanged", Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        method.invoke(service, stationary)
     }
 
     private fun invokeMaybeResumeGps() {

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/RawSensorMotionDetectorTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/RawSensorMotionDetectorTest.kt
@@ -365,4 +365,51 @@ class RawSensorMotionDetectorTest {
 
         assertEquals(listOf(MotionState.STATIONARY), received)
     }
+
+    @Test
+    fun `resyncStationaryBaseline re-arms a fresh MOVING edge after currentState is already MOVING`() {
+        val received = mutableListOf<MotionState>()
+        val detector = makeDetector()
+        detector.start { received += it }
+        // Already MOVING: high-variance samples produce no edge (the deadlock).
+        var t = 0L
+        var hi = true
+        while (t <= 4_000L) {
+            feedSample(magnitude = if (hi) 0.6 else -0.6, atMs = t)
+            hi = !hi
+            t += 100L
+        }
+        assertTrue("MOVING edge must not fire while already MOVING", received.isEmpty())
+
+        detector.resyncStationaryBaseline()
+
+        // Continuing motion now re-fires a fresh MOVING edge (dwell = 3000ms).
+        while (t <= 8_000L) {
+            feedSample(magnitude = if (hi) 0.6 else -0.6, atMs = t)
+            hi = !hi
+            t += 100L
+        }
+
+        assertEquals(listOf(MotionState.MOVING), received)
+    }
+
+    @Test
+    fun `resyncStationaryBaseline emits no listener callback itself`() {
+        val received = mutableListOf<MotionState>()
+        val detector = makeDetector()
+        detector.start { received += it }
+        received.clear()
+
+        detector.resyncStationaryBaseline()
+
+        assertTrue(received.isEmpty())
+    }
+
+    @Test
+    fun `resyncStationaryBaseline before start is a no-op`() {
+        val received = mutableListOf<MotionState>()
+        val detector = makeDetector()
+        detector.resyncStationaryBaseline()
+        assertTrue(received.isEmpty())
+    }
 }


### PR DESCRIPTION
## Problem
After you leave a geofence and start driving, the app switches to the Stationary profile and never switches back for the rest of the drive. In that profile it hardly records any GPS, so the whole trip shows up as a straight line. It only fixes itself once GPS gets a good enough reading to notice you're moving, which can take minutes.

## Root Cause
Two separate parts of the app each decide on their own whether you're stationary, and
they can get out of sync.

The motion detector watches the accelerometer. When it sees you start moving it says
"moving" once, and then it stays quiet until it sees you stop. It only announces the
change, so once it's in the moving state it doesn't say anything more.

The profile manager decides separately, based on GPS speed. If it hasn't seen a
reading with any speed for a while, it assumes you've stopped and switches to
Stationary.

A geofence exit can line these up:

1. You're still inside the geofence, e.g. walking to your car. The detector sees that motion and announces "moving." It now sits quietly in the moving state.
2. You drive off, but GPS is still cold and its first readings are too inaccurate, so the accuracy filter drops them before they ever reach the profile manager. With no speed coming in, the profile manager assumes you've stopped and switches to Stationary.
3. Now the two disagree. The profile thinks you're stationary, the detector still thinks you're moving. You keep driving, but because the detector already announced "moving" earlier and nothing has changed since, it stays quiet and never corrects the profile.

## Fix
 - Added `resyncStationaryBaseline()`. When called, it resets the detector back to the stationary state and clears its internal timers, so the next bit of real movement gets announced as a fresh "moving" instead of being swallowed. It resets the state quietly, without triggering a false "now stationary" signal, and does it on the detector's own thread so its timers stay consistent.
- `handleStationaryChanged` calls this whenever the profile switches to Stationary. If the detector is already in the stationary state it changes nothing, so this only has an effect in the stuck case described above.

## Test coverage
Tests in `RawSensorMotionDetectorTest` and `LocationForegroundServiceTest`:
- arms a fresh MOVING edge after the detector is already MOVING (this is the deadlock; it fails without the fix)
- fires no listener callback of its own
- calling it before the detector has started does nothing and doesn't crash
- `handleStationaryChanged(true)` resyncs, `(false)` doesn't


## Testing
- `./gradlew testGmsDebugUnitTest testFossDebugUnitTest` (both flavors, 0 failures)
- `npm run lint`, `tsc --noEmit`, `npm test` (897 examples, 0 failures)
- Confirmed the main test actually catches the bug: changing the fix to reset the detector to moving instead of stationary makes the test fail.
- Installed Colota on Google Pixel 10  (fossDebug variant, JS bundled in) and the app worked as usual. (Bug is very hard to reproduce, lining up Geofence, movement detection and forcing bad GPS signal is not possible for me, so I reproduced only in Tests)