### PR TITLE
fix(profiles): heartbeat a point while a Stationary profile is active

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -228,7 +228,7 @@ Each geofence supports three independent GPS pause modes, configured per zone:
 
 A per-zone **stationary heartbeat** can send periodic location updates while paused. It sends the geofence center as a synthetic anchor point - no GPS wake required - bypassing sync conditions. Configured via `heartbeatEnabled` and `heartbeatIntervalMinutes` per geofence.
 
-Separately, a **Stationary tracking profile** drives its own heartbeat via `StationaryHeartbeatScheduler` (an allow-while-idle alarm): a still device produces no passive fixes, so it wakes at the profile's interval, requests a real GPS fix, and records it through the normal path.
+Separately, a **Stationary tracking profile** drives its own heartbeat via `StationaryHeartbeatScheduler` (an allow-while-idle alarm delivered through `StationaryHeartbeatReceiver`): a still device produces no passive fixes, so it wakes at the profile's interval, requests a real GPS fix and records it through the normal path.
 
 When both WiFi and motionless pause are enabled, GPS only resumes when both conditions clear - WiFi disconnected **and** motion detected. Changes made in the editor take effect immediately even when already inside the zone, via `applyZoneSettingsIfChanged` on the next zone recheck.
 

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -228,6 +228,8 @@ Each geofence supports three independent GPS pause modes, configured per zone:
 
 A per-zone **stationary heartbeat** can send periodic location updates while paused. It sends the geofence center as a synthetic anchor point - no GPS wake required - bypassing sync conditions. Configured via `heartbeatEnabled` and `heartbeatIntervalMinutes` per geofence.
 
+Separately, a **Stationary tracking profile** drives its own heartbeat via `StationaryHeartbeatScheduler` (an allow-while-idle alarm): a still device produces no passive fixes, so it wakes at the profile's interval, requests a real GPS fix, and records it through the normal path.
+
 When both WiFi and motionless pause are enabled, GPS only resumes when both conditions clear - WiFi disconnected **and** motion detected. Changes made in the editor take effect immediately even when already inside the zone, via `applyZoneSettingsIfChanged` on the next zone recheck.
 
 ### ProfileManager

--- a/apps/docs/docs/development/permissions.md
+++ b/apps/docs/docs/development/permissions.md
@@ -8,20 +8,21 @@ These are the permissions Colota uses and why. None are related to analytics, ad
 
 ## Permission Overview
 
-| Permission                     | Required    | Why                                               |
-| ------------------------------ | ----------- | ------------------------------------------------- |
-| Fine Location                  | Yes         | GPS-based location tracking                       |
-| Coarse Location                | Yes         | Network-based location fallback                   |
-| Background Location            | Yes         | Track while app is in the background              |
-| Foreground Service             | Yes         | Required by Android for background services       |
-| Foreground Service (Data Sync) | Yes         | Auto-export background processing                 |
-| Internet                       | Yes         | Send locations to your server                     |
-| Network State                  | Yes         | Check connectivity before syncing                 |
-| Wi-Fi State                    | Yes         | Detect current SSID for sync condition filtering  |
-| Boot Completed                 | Yes         | Auto-restart tracking after device reboot         |
-| Notifications                  | Android 13+ | Display the foreground service notification       |
-| Local Network Access           | Android 17+ | Access local network servers (self-hosted)        |
-| Battery Optimization Exemption | Optional    | Prevent Android from killing the tracking service |
+| Permission                     | Required    | Why                                                                   |
+| ------------------------------ | ----------- | --------------------------------------------------------------------- |
+| Fine Location                  | Yes         | GPS-based location tracking                                           |
+| Coarse Location                | Yes         | Network-based location fallback                                       |
+| Background Location            | Yes         | Track while app is in the background                                  |
+| Foreground Service             | Yes         | Required by Android for background services                           |
+| Foreground Service (Data Sync) | Yes         | Auto-export background processing                                     |
+| Internet                       | Yes         | Send locations to your server                                         |
+| Network State                  | Yes         | Check connectivity before syncing                                     |
+| Wi-Fi State                    | Yes         | Detect current SSID for sync condition filtering                      |
+| Boot Completed                 | Yes         | Auto-restart tracking after device reboot                             |
+| Notifications                  | Android 13+ | Display the foreground service notification                           |
+| Local Network Access           | Android 17+ | Access local network servers (self-hosted)                            |
+| Battery Optimization Exemption | Optional    | Prevent Android from killing the tracking service                     |
+| Wake Lock                      | Yes         | Briefly wake the CPU for the stationary heartbeat and background jobs |
 
 ## Permission Request Flow
 
@@ -105,6 +106,14 @@ android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
 ```
 
 This allows Colota to show the system dialog asking to exempt the app from battery optimization (Doze mode). When exempted, Android is less likely to kill the tracking service during idle periods. This is optional - tracking works without it, but may be less reliable on some devices.
+
+### Wake Lock
+
+```
+android.permission.WAKE_LOCK
+```
+
+Lets Colota briefly hold the CPU awake while it acquires a location fix for a stationary-profile heartbeat during Doze, and is used internally by WorkManager for auto-export and battery-recovery jobs. A normal permission - granted automatically, with no access to personal data.
 
 ## Revoking Permissions
 

--- a/apps/docs/docs/guides/battery-optimization.md
+++ b/apps/docs/docs/guides/battery-optimization.md
@@ -8,7 +8,7 @@ Settings and tips to reduce battery usage without losing GPS fixes.
 
 ## Built-in Optimizations
 
-- **Stationary detection**: Pauses GPS after 60s without movement via [tracking profiles](/docs/guides/tracking-profiles) or [geofence motionless detection](/docs/guides/geofencing), resumes on motion via hardware sensor
+- **Stationary detection**: When the device is still, [tracking profiles](/docs/guides/tracking-profiles) drop to a low-frequency heartbeat and [geofence motionless detection](/docs/guides/geofencing) stops GPS entirely; both resume on motion via the hardware sensor
 - **Notification throttling**: Max 1 update per 10 seconds, plus 2-meter movement filter
 - **Batch processing**: 50 items per batch, 10 concurrent network requests
 - **Smart sync**: Only syncs when queue has items and network is available

--- a/apps/docs/docs/guides/tracking-profiles.md
+++ b/apps/docs/docs/guides/tracking-profiles.md
@@ -40,7 +40,7 @@ Speed conditions use a rolling average of the last 5 GPS readings to avoid trigg
 
 :::tip
 
-Stationary profile When the device becomes stationary, the motion detector is started. It uses batched accelerometer variance plus the hardware significant motion sensor in parallel, so the profile deactivates within seconds of real movement regardless of the configured GPS interval (e.g. 30 min). The deactivation delay setting is not shown for stationary profiles since the motion detector handles instant resume. Set the distance filter to **0m** so points are recorded at every interval regardless of GPS drift.
+Stationary profile When the device becomes stationary, the motion detector is started. It uses batched accelerometer variance plus the hardware significant motion sensor in parallel, so the profile deactivates within seconds of real movement regardless of the configured GPS interval (e.g. 30 min). The deactivation delay setting is not shown for stationary profiles since the motion detector handles instant resume. The distance filter is forced to **0m** for stationary profiles so a point is recorded at every interval regardless of GPS drift - any other value would drop every stationary point.
 
 :::
 

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,9 @@
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- Held during the stationary heartbeat's fix acquisition; also used by WorkManager -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <application
         android:name=".MainApplication"
         android:label="@string/app_name"

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -120,6 +120,12 @@
             android:enabled="true"
             android:exported="false" />
 
+        <!-- Stationary heartbeat alarm receiver -->
+        <receiver
+            android:name=".service.StationaryHeartbeatReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
         <!-- Tracking control receiver (Tasker / automation) -->
         <receiver
             android:name=".triggers.TrackingControlReceiver"

--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -110,6 +110,7 @@ class LocationForegroundService : Service() {
     @Volatile private var pendingPauseZone: GeofenceHelper.Geofence? = null
     @Volatile private var entryDelayJob: Job? = null
     @Volatile private var heartbeatJob: Job? = null
+    @Volatile private var stationaryHeartbeatArmed = false
 
     // WiFi pause sub-state (same Main-only mutation contract as above)
     @Volatile private var isWifiPaused = false
@@ -148,6 +149,8 @@ class LocationForegroundService : Service() {
 
         /** Timeout for the active fresh-fix probe (ms). */
         private const val FRESH_FIX_TIMEOUT_MS = 30_000L
+        /** Safety cap on the heartbeat wakelock; must outlast the fix acquisition. */
+        private const val HEARTBEAT_WAKELOCK_TIMEOUT_MS = FRESH_FIX_TIMEOUT_MS + 5_000L
         /** Minimum spacing between fresh-fix probes; throttled callers get the last-known fix. */
         private const val FRESH_PROBE_MIN_INTERVAL_MS = 60_000L
         /** A fix older than this by the monotonic clock isn't trusted to hold a pause - usually a stale/replayed fix. */
@@ -167,6 +170,8 @@ class LocationForegroundService : Service() {
         const val EXTRA_STOP_REASON = "stop_reason"
         /** Debug-only: directly inject a MotionState transition. `--es state STATIONARY|MOVING`. */
         const val ACTION_DEBUG_FORCE_MOTION = "com.Colota.DEBUG_FORCE_MOTION"
+        /** Alarm delivery for the stationary-profile heartbeat; see [StationaryHeartbeatScheduler]. */
+        const val ACTION_STATIONARY_HEARTBEAT = "com.Colota.STATIONARY_HEARTBEAT"
 
         /** Actions that skip config reload and preserve current notification state. */
         private val LIGHTWEIGHT_ACTIONS = setOf(
@@ -174,7 +179,8 @@ class LocationForegroundService : Service() {
             ACTION_RECHECK_ZONE,
             ACTION_REFRESH_NOTIFICATION,
             ACTION_RECHECK_PROFILES,
-            ACTION_STOP_REQUEST
+            ACTION_STOP_REQUEST,
+            ACTION_STATIONARY_HEARTBEAT
         )
 
         /**
@@ -212,7 +218,7 @@ class LocationForegroundService : Service() {
         profileManager = ProfileManager(
             profileHelper, serviceScope!!,
             onConfigSwitch = { config ->
-                applyProfileConfig(config.interval, config.distance, config.syncInterval)
+                applyProfileConfig(config.interval, config.distance, config.syncInterval, config.conditionType)
             },
             onStationaryChanged = ::handleStationaryChanged
         )
@@ -333,6 +339,7 @@ class LocationForegroundService : Service() {
             ACTION_RECHECK_ZONE -> handleZoneRecheckAction()
             ACTION_RECHECK_PROFILES -> handleRecheckProfiles()
             ACTION_MANUAL_FLUSH -> handleManualFlush()
+            ACTION_STATIONARY_HEARTBEAT -> handleStationaryHeartbeatFired()
             ACTION_STOP_REQUEST -> stopForegroundServiceWithReason(
                 intent.getStringExtra(EXTRA_STOP_REASON) ?: "Stopped"
             )
@@ -407,6 +414,7 @@ class LocationForegroundService : Service() {
         }
         teardownStep("wifiPause") { unregisterWifiPause() }
         teardownStep("heartbeat") { cancelHeartbeat() }
+        teardownStep("stationaryHeartbeat") { cancelStationaryHeartbeat() }
         teardownStep("locationProvidersReceiver") { unregisterLocationProvidersReceiver() }
         teardownStep("debugMotionReceiver") { unregisterDebugMotionReceiver() }
         teardownStep("batteryMonitor") { batteryMonitor.stop() }
@@ -1390,10 +1398,12 @@ class LocationForegroundService : Service() {
     // ── Profile hot-swap ────────────────────────────────────────────────
 
     /** Hot-swaps GPS interval and sync config on profile change. */
-    private fun applyProfileConfig(interval: Long, distance: Float, syncInterval: Int) {
+    private fun applyProfileConfig(interval: Long, distance: Float, syncInterval: Int, conditionType: String) {
+        val isStationary = conditionType == ProfileConstants.CONDITION_STATIONARY
         config = config.copy(
             interval = interval,
-            minUpdateDistance = distance,
+            // A distance filter would drop every stationary point (each ~0m from the last), defeating the heartbeat.
+            minUpdateDistance = if (isStationary) 0f else distance,
             syncIntervalSeconds = syncInterval
         )
 
@@ -1407,9 +1417,45 @@ class LocationForegroundService : Service() {
         stopLocationUpdates()
         setupLocationUpdates()
 
+        // A stationary device gets no OS-pushed fixes, so drive it with an active heartbeat instead.
+        if (isStationary) scheduleStationaryHeartbeat() else cancelStationaryHeartbeat()
+
         refreshNotificationForCurrentState()
 
         AppLogger.i(TAG, "Profile config applied: ${profileManager.getActiveProfileName() ?: "default"} - interval=${interval}ms, distance=${distance}m, sync=${syncInterval}s")
+    }
+
+    private fun scheduleStationaryHeartbeat() {
+        stationaryHeartbeatArmed = true
+        StationaryHeartbeatScheduler.schedule(this, config.interval)
+    }
+
+    private fun cancelStationaryHeartbeat() {
+        if (!stationaryHeartbeatArmed) return
+        stationaryHeartbeatArmed = false
+        StationaryHeartbeatScheduler.cancel(this)
+    }
+
+    private fun handleStationaryHeartbeatFired() {
+        if (!stationaryHeartbeatArmed) return
+        // A pause hold (WiFi / motionless / zone) owns its own recording - don't double-log over it.
+        if (!isWifiPaused && !isMotionlessPaused && !insidePauseZone) {
+            // Wakelock holds the CPU across the async fix - the alarm's wake window ends here, and a foreground service won't.
+            val wakeLock = acquireHeartbeatWakeLock()
+            requestFreshOrLastLocation { location, _ ->
+                if (location != null) handleLocationUpdate(location)
+                else AppLogger.d(TAG, "Stationary heartbeat: no usable fix")
+                if (wakeLock?.isHeld == true) wakeLock.release()
+            }
+        }
+        scheduleStationaryHeartbeat()
+    }
+
+    private fun acquireHeartbeatWakeLock(): PowerManager.WakeLock? {
+        val pm = getSystemService(POWER_SERVICE) as? PowerManager ?: return null
+        return pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "colota:stationary-heartbeat").apply {
+            acquire(HEARTBEAT_WAKELOCK_TIMEOUT_MS)
+        }
     }
 
     private fun pushConfigToSyncManager() {

--- a/apps/mobile/android/app/src/main/java/com/colota/service/ProfileManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/ProfileManager.kt
@@ -37,6 +37,7 @@ class ProfileManager(
         val syncInterval: Int,
         val profileName: String?,
         val profileId: Int?,
+        val conditionType: String,
     )
 
     // Default config (written externally by the service, read inside @Synchronized deactivateToDefault)
@@ -239,6 +240,7 @@ class ProfileManager(
             syncInterval = profile.syncIntervalSeconds,
             profileName = profile.name,
             profileId = profile.id,
+            conditionType = profile.conditionType,
         ))
     }
 
@@ -366,6 +368,7 @@ class ProfileManager(
             syncInterval = defaultSyncInterval,
             profileName = null,
             profileId = null,
+            conditionType = "",
         ))
     }
 }

--- a/apps/mobile/android/app/src/main/java/com/colota/service/StationaryHeartbeatReceiver.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/StationaryHeartbeatReceiver.kt
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+package com.Colota.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.Colota.util.AppLogger
+
+/**
+ * Receives the stationary-heartbeat alarm and forwards it to [LocationForegroundService] as
+ * ACTION_STATIONARY_HEARTBEAT. The alarm targets this receiver (not the service directly) so the
+ * PendingIntent stays a plain explicit broadcast, and the foreground-service start runs inside the
+ * alarm's temporary allowlist window.
+ */
+class StationaryHeartbeatReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val serviceIntent = Intent(context, LocationForegroundService::class.java).apply {
+            action = LocationForegroundService.ACTION_STATIONARY_HEARTBEAT
+        }
+        try {
+            context.startForegroundService(serviceIntent)
+        } catch (e: Exception) {
+            // The heartbeat only fires while the service is already foreground, so this shouldn't
+            // throw; log rather than crash the receiver if the service is mid-teardown.
+            AppLogger.e(TAG, "Failed to deliver stationary heartbeat", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "StationaryHeartbeat"
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/colota/service/StationaryHeartbeatScheduler.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/StationaryHeartbeatScheduler.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+package com.Colota.service
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.Colota.util.AppLogger
+
+/**
+ * Schedules the stationary-profile heartbeat alarm. Uses setAndAllowWhileIdle (like
+ * AutoExportScheduler) so it fires through Doze without the SCHEDULE_EXACT_ALARM permission;
+ * the OS floors it to ~9min while idle, which suits a stationary cadence. Delivered to
+ * [LocationForegroundService] as ACTION_STATIONARY_HEARTBEAT.
+ */
+object StationaryHeartbeatScheduler {
+
+    private const val TAG = "StationaryHeartbeat"
+    private const val REQUEST_CODE = 9301
+    /** Cadence floor; Doze also floors allow-while-idle to ~9min. */
+    private const val MIN_INTERVAL_MS = 60_000L
+
+    fun schedule(context: Context, intervalMs: Long) {
+        val am = context.getSystemService(AlarmManager::class.java) ?: return
+        val delay = maxOf(intervalMs, MIN_INTERVAL_MS)
+        am.setAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            System.currentTimeMillis() + delay,
+            pendingIntent(context)
+        )
+        AppLogger.d(TAG, "Stationary heartbeat armed: ${delay / 1000}s")
+    }
+
+    fun cancel(context: Context) {
+        val am = context.getSystemService(AlarmManager::class.java) ?: return
+        am.cancel(pendingIntent(context))
+        AppLogger.d(TAG, "Stationary heartbeat cancelled")
+    }
+
+    private fun pendingIntent(context: Context): PendingIntent {
+        val intent = Intent(context, LocationForegroundService::class.java).apply {
+            action = LocationForegroundService.ACTION_STATIONARY_HEARTBEAT
+            setPackage(context.packageName)
+        }
+        return PendingIntent.getForegroundService(
+            context,
+            REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/colota/service/StationaryHeartbeatScheduler.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/StationaryHeartbeatScheduler.kt
@@ -15,7 +15,7 @@ import com.Colota.util.AppLogger
  * Schedules the stationary-profile heartbeat alarm. Uses setAndAllowWhileIdle (like
  * AutoExportScheduler) so it fires through Doze without the SCHEDULE_EXACT_ALARM permission;
  * the OS floors it to ~9min while idle, which suits a stationary cadence. Delivered to
- * [LocationForegroundService] as ACTION_STATIONARY_HEARTBEAT.
+ * [StationaryHeartbeatReceiver], which forwards it to [LocationForegroundService].
  */
 object StationaryHeartbeatScheduler {
 
@@ -42,11 +42,10 @@ object StationaryHeartbeatScheduler {
     }
 
     private fun pendingIntent(context: Context): PendingIntent {
-        val intent = Intent(context, LocationForegroundService::class.java).apply {
-            action = LocationForegroundService.ACTION_STATIONARY_HEARTBEAT
+        val intent = Intent(context, StationaryHeartbeatReceiver::class.java).apply {
             setPackage(context.packageName)
         }
-        return PendingIntent.getForegroundService(
+        return PendingIntent.getBroadcast(
             context,
             REQUEST_CODE,
             intent,

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -1549,6 +1549,44 @@ class LocationForegroundServiceTest {
     }
 
     @Test
+    fun `applyProfileConfig arms the stationary heartbeat for a stationary profile`() {
+        invokeApplyProfileConfig(
+            interval = 2000L, distance = 0f, syncInterval = 0,
+            conditionType = ProfileConstants.CONDITION_STATIONARY
+        )
+
+        assertTrue(getField("stationaryHeartbeatArmed"))
+    }
+
+    @Test
+    fun `applyProfileConfig forces the distance filter to 0 for a stationary profile`() {
+        invokeApplyProfileConfig(
+            interval = 2000L, distance = 5f, syncInterval = 0,
+            conditionType = ProfileConstants.CONDITION_STATIONARY
+        )
+
+        assertEquals(0f, getField<ServiceConfig>("config").minUpdateDistance)
+    }
+
+    @Test
+    fun `applyProfileConfig disarms the stationary heartbeat for a non-stationary profile`() {
+        invokeApplyProfileConfig(
+            interval = 2000L, distance = 0f, syncInterval = 0,
+            conditionType = ProfileConstants.CONDITION_STATIONARY
+        )
+        invokeApplyProfileConfig(interval = 5000L, distance = 0f, syncInterval = 0, conditionType = "")
+
+        assertFalse(getField("stationaryHeartbeatArmed"))
+    }
+
+    @Test
+    fun `stationary heartbeat fired is a no-op when not armed`() {
+        invokeStationaryHeartbeatFired()
+
+        assertFalse(getField("stationaryHeartbeatArmed"))
+    }
+
+    @Test
     fun `applyProfileConfig preserves non-profile config fields`() {
         setField("config", ServiceConfig(
             endpoint = "https://my-server.com",
@@ -2389,12 +2427,18 @@ class LocationForegroundServiceTest {
         method.invoke(service, location)
     }
 
-    private fun invokeApplyProfileConfig(interval: Long, distance: Float, syncInterval: Int) {
+    private fun invokeApplyProfileConfig(interval: Long, distance: Float, syncInterval: Int, conditionType: String = "") {
         val method = LocationForegroundService::class.java.getDeclaredMethod(
-            "applyProfileConfig", Long::class.java, Float::class.java, Int::class.java
+            "applyProfileConfig", Long::class.java, Float::class.java, Int::class.java, String::class.java
         )
         method.isAccessible = true
-        method.invoke(service, interval, distance, syncInterval)
+        method.invoke(service, interval, distance, syncInterval, conditionType)
+    }
+
+    private fun invokeStationaryHeartbeatFired() {
+        val method = LocationForegroundService::class.java.getDeclaredMethod("handleStationaryHeartbeatFired")
+        method.isAccessible = true
+        method.invoke(service)
     }
 
     private fun invokeTrackingStateLabel(): String {

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/StationaryHeartbeatSchedulerTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/StationaryHeartbeatSchedulerTest.kt
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+package com.Colota.service
+
+import android.app.AlarmManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.Colota.util.AppLogger
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class StationaryHeartbeatSchedulerTest {
+
+    private lateinit var context: Context
+    private lateinit var alarmManager: AlarmManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        mockkObject(AppLogger)
+        every { AppLogger.d(any(), any()) } just Runs
+        every { AppLogger.i(any(), any()) } just Runs
+        every { AppLogger.w(any(), any()) } just Runs
+        every { AppLogger.e(any(), any()) } just Runs
+
+        StationaryHeartbeatScheduler.cancel(context)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(AppLogger)
+    }
+
+    @Test
+    fun `schedule arms an allow-while-idle alarm`() {
+        StationaryHeartbeatScheduler.schedule(context, 600_000L)
+
+        assertEquals("Exactly one heartbeat alarm should be queued", 1, shadowOf(alarmManager).scheduledAlarms.size)
+    }
+
+    @Test
+    fun `cancel removes the pending heartbeat alarm`() {
+        StationaryHeartbeatScheduler.schedule(context, 600_000L)
+        assertEquals(1, shadowOf(alarmManager).scheduledAlarms.size)
+
+        StationaryHeartbeatScheduler.cancel(context)
+
+        assertTrue(
+            "No heartbeat alarm should remain after cancel",
+            shadowOf(alarmManager).scheduledAlarms.isEmpty()
+        )
+    }
+}

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -109,9 +109,12 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
   const setConditionType = useCallback(
     (type: ProfileConditionType) => {
       const isSpeed = type === "speed_above" || type === "speed_below"
+      const isStationary = type === "stationary"
       const { activationDelay: defaultActivation, deactivationDelay: defaultDeactivation } = defaultProfileDelays(type)
       setProfile((prev) => ({
         ...prev,
+        // A distance filter is ignored for a stationary profile; store 0 so UI, DB and runtime agree.
+        distance: isStationary ? 0 : prev.distance,
         deactivationDelay: prev.condition.type !== type ? defaultDeactivation : prev.deactivationDelay,
         activationDelay: prev.condition.type !== type ? defaultActivation : prev.activationDelay,
         condition: {
@@ -119,6 +122,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
           ...(isSpeed ? { speedThreshold: Number(speedKmh) / MS_TO_KMH } : {})
         }
       }))
+      if (isStationary) setDistanceStr("0")
       if (profile.condition.type !== type) {
         setDelayStr(String(defaultDeactivation))
         setActivationDelayStr(String(defaultActivation))
@@ -296,22 +300,28 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
           <Divider />
 
-          <SettingRow
-            label="Movement Threshold"
-            hint={`Default: ${metersToInput(settings.distance)} ${shortDistanceUnit()}`}
-          >
-            <View style={styles.inputWithUnit}>
-              <TextInput
-                style={inputStyle}
-                keyboardType="numeric"
-                value={distanceStr}
-                onChangeText={(val) => handleNumericChange(setDistanceStr, "distance", val, 0)}
-                placeholder="0"
-                placeholderTextColor={colors.placeholder}
-              />
-              <Text style={[styles.unit, { color: colors.textSecondary }]}>{shortDistanceUnit()}</Text>
-            </View>
-          </SettingRow>
+          {profile.condition.type === "stationary" ? (
+            <FieldMessage>
+              Movement threshold does not apply to a stationary profile - a point is recorded at every interval.
+            </FieldMessage>
+          ) : (
+            <SettingRow
+              label="Movement Threshold"
+              hint={`Default: ${metersToInput(settings.distance)} ${shortDistanceUnit()}`}
+            >
+              <View style={styles.inputWithUnit}>
+                <TextInput
+                  style={inputStyle}
+                  keyboardType="numeric"
+                  value={distanceStr}
+                  onChangeText={(val) => handleNumericChange(setDistanceStr, "distance", val, 0)}
+                  placeholder="0"
+                  placeholderTextColor={colors.placeholder}
+                />
+                <Text style={[styles.unit, { color: colors.textSecondary }]}>{shortDistanceUnit()}</Text>
+              </View>
+            </SettingRow>
+          )}
 
           {!settings.isOfflineMode && (
             <>

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -331,6 +331,18 @@ describe("ProfileEditorScreen", () => {
     expect(queryByText("Deactivation Delay")).toBeNull()
   })
 
+  it("hides the movement threshold for a stationary profile and shows a note instead", () => {
+    const { getByText, queryByText } = renderNewProfile()
+
+    // Default (charging): the field is shown
+    expect(getByText("Movement Threshold")).toBeTruthy()
+
+    // Stationary: field hidden (the distance filter is forced to 0), note shown instead
+    fireEvent.press(getByText("Stationary"))
+    expect(queryByText("Movement Threshold")).toBeNull()
+    expect(getByText(/Movement threshold does not apply/)).toBeTruthy()
+  })
+
   it("defaults stationary activation delay to 60", () => {
     const { getByText, getByDisplayValue } = renderNewProfile()
 

--- a/fastlane/metadata/android/en-US/changelogs/44.txt
+++ b/fastlane/metadata/android/en-US/changelogs/44.txt
@@ -1,0 +1,1 @@
+- The Stationary profile now records a point at each interval while the device is still


### PR DESCRIPTION
A Stationary profile only set the update interval, but Android pushes a fix only when it has a new one while still (and in Doze) it pushes nothing, so the profile logged nothing for hours.

Drive it actively: an allow-while-idle alarm (StationaryHeartbeatScheduler) wakes at the interval, pulls a fresh fix and records it through the normal path. setAndAllowWhileIdle survives Doze without SCHEDULE_EXACT_ALARM; a wakelock spans the async fix since the alarm's wake window ends before it lands.

The distance filter is forced to 0 for Stationary profiles (any value drops every ~0m point) and hidden in the editor. WAKE_LOCK added to the manifest.

Closes #494 