### PR TITLE
feat(history): delete a single point from the map popup

### DIFF
--- a/apps/docs/docs/guides/data-export.md
+++ b/apps/docs/docs/guides/data-export.md
@@ -41,11 +41,7 @@ For a single trip you can also tap the card to open **Trip Detail**, then use th
 
 Trip exports include a `trip` column/property so each location is tagged with its trip number. Custom selections produce a single file containing only the chosen trips.
 
-### Delete Trips
-
-From the **Trips** tab, long-press a trip card to enter selection mode, add any other trips you want to remove, then tap the trash icon in the selection header. You'll be asked to confirm before the underlying location points are permanently deleted from the device.
-
-Single-trip delete is also available from the **Trip Detail** screen via the trash icon in the header.
+To remove trips or single points instead of exporting them, see [Data Management](data-management.md#deleting-from-location-history).
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 

--- a/apps/docs/docs/guides/data-import.md
+++ b/apps/docs/docs/guides/data-import.md
@@ -8,7 +8,7 @@ Merge location history from external files into your Colota database. Data Impor
 
 :::warning[Back up before a large import]
 
-Imports can't be selectively undone. Colota has no per-point delete - you can only delete a whole trip, all points since N days or wipe everything, so removing an import also takes any genuine points recorded in the same window. Take a [Backup](backup-restore.md) first if you're unsure.
+Imports can't be selectively undone. Points can only be removed one at a time, by trip, by age or all at once, so unpicking a large import means clearing a window that also holds genuine points. Take a [Backup](backup-restore.md) first if you're unsure.
 
 :::
 

--- a/apps/docs/docs/guides/data-management.md
+++ b/apps/docs/docs/guides/data-management.md
@@ -26,6 +26,24 @@ In [offline mode](/docs/configuration/server-settings#offline-mode), sync-relate
 
 For a full archive of locations, settings and credentials in a single password-encrypted file, use **Settings → Backup & Restore** - see [Backup & Restore](backup-restore.md).
 
+## Deleting from Location History
+
+The actions above work on the whole database. To remove specific recordings, use the **Location History** screen.
+
+### Trips
+
+From the **Trips** tab, long-press a trip card to enter selection mode, add any other trips you want to remove, then tap the trash icon in the selection header. You'll be asked to confirm before the underlying location points are permanently deleted from the device.
+
+Single-trip delete is also available from the **Trip Detail** screen via the trash icon in the header.
+
+### Single points
+
+A stray fix can land far from where you actually were, which drags the track and the day's distance with it. On the **Map** tab, tap the point to open its popup, check the time and accuracy to make sure it is the one you mean, then tap the trash icon next to the close button. You'll be asked to confirm.
+
+Only that one point is removed, so the rest of the trip stays intact. If the point had not synced yet, its pending upload is dropped with it.
+
+Deleting locally does not remove anything already uploaded to your server.
+
 ## Imported locations and the queue
 
 Locations brought in via [Data Import](data-import.md) are marked as already synced by default, so they **do not show up in the queue counter** and don't get re-uploaded to your backend. If you used the **Import + Queue for Sync** button on the import dialog instead (the "migration" path), the imported rows do land in the queue and the next sync drains them - the counters here will reflect that until they finish uploading.

--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -15,7 +15,7 @@ Colota is a self-hosted GPS tracking app for Android. It sends your location to 
 - **Offline Maps** - Download map areas to your device for use without an internet connection.
 - **Scheduled Export** - Automatic daily, weekly or monthly exports to a local directory with file retention management.
 - **Encrypted Backup** - Single password-encrypted archive of locations, settings, geofences and credentials.
-- **Location History** - View daily summaries, trip segmentation, calendar with activity dots, per-trip export and notes on individual points.
+- **Location History** - View daily summaries, trip segmentation, calendar with activity dots, per-trip export and per-point notes or deletion.
 - **Reliable Tracking** - Foreground service, auto-start on boot and exponential backoff retry.
 - **Geofencing** - Pause zones that stop recording locations. Optionally stop GPS entirely when on WiFi or when the device is motionless.
 - **Tracking Profiles** - Automatically adjust GPS interval, distance filter and sync settings based on conditions like charging, Android Auto, speed or stationary detection.
@@ -43,7 +43,7 @@ Colota has twenty-two screens, each focused on a specific task:
 | **Offline Maps** | Download map areas to the device for use without an internet connection |
 | **Tracking Profiles** | Create and manage condition-based profiles that automatically adjust tracking settings |
 | **Profile Editor** | Configure profile name, condition trigger, GPS interval, distance filter, sync interval, priority, and deactivation delay |
-| **Location History** | Browse recorded locations on a track map with calendar day picker and trip-colored segments, view segmented trips with per-trip stats; tap a point to add a note |
+| **Location History** | Browse recorded locations on a track map with calendar day picker and trip-colored segments, view segmented trips with per-trip stats; tap a point to add a note or delete it |
 | **Trip Detail** | Full trip view with dedicated map, stats grid (distance, duration, avg speed, elevation), speed and elevation profile charts, export, and delete |
 | **Location Summary** | Aggregated stats (total distance, trips, active days, avg distance) for selectable periods with daily breakdown and tap-to-inspect navigation |
 | **Export Data** | Export tracked locations as CSV, GeoJSON, GPX, or KML |

--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
@@ -446,7 +446,17 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
         }
         deleteThenVacuum(refresh = true) { dbHelper.deleteInRanges(pairs) }
     }
-    
+
+    @ReactMethod
+    fun deleteLocationsByIds(ids: ReadableArray, promise: Promise) = executeAsync(promise) {
+        val locationIds = (0 until ids.size()).map { ids.getDouble(it).toLong() }
+        val deleted = dbHelper.deleteLocations(locationIds)
+        if (deleted > 0) refreshNotificationIfTracking()
+        // No vacuum here: a few rows are not worth rewriting the database, and this delete gets
+        // repeated. Data Management has an explicit Vacuum action.
+        deleted
+    }
+
     @ReactMethod
     fun vacuumDatabase(promise: Promise) = executeAsync(promise) { 
         dbHelper.vacuum()

--- a/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
@@ -686,12 +686,12 @@ class DatabaseHelper private constructor(context: Context) :
         }
     }
 
-    fun deleteLocations(locationIds: List<Long>) {
+    fun deleteLocations(locationIds: List<Long>): Int {
         requireNotRestoring()
-        if (locationIds.isEmpty()) return
+        if (locationIds.isEmpty()) return 0
         val placeholders = locationIds.joinToString(",") { "?" }
         val args = locationIds.map { it.toString() }.toTypedArray()
-        writableDatabase.delete(TABLE_LOCATIONS, "id IN ($placeholders)", args)
+        return writableDatabase.delete(TABLE_LOCATIONS, "id IN ($placeholders)", args)
     }
 
     /** Sets or clears the free-text note on a single location. Pass null to clear. */

--- a/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
@@ -330,6 +330,15 @@ class DatabaseHelperSQLiteTest {
     }
 
     @Test
+    fun `deleteLocations returns the number of rows removed`() {
+        val id1 = db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = 1000L)
+        val id2 = db.saveLocation(latitude = 53.0, longitude = 14.0, timestamp = 2000L)
+
+        assertEquals(2, db.deleteLocations(listOf(id1, id2)))
+        assertEquals(0, db.deleteLocations(listOf(id1)))
+    }
+
+    @Test
     fun `deleteLocations is no-op for empty list`() {
         db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = 1000L)
         db.deleteLocations(emptyList())
@@ -480,14 +489,18 @@ class DatabaseHelperSQLiteTest {
     @Test
     fun `deleting location cascades to queue entries`() {
         val locId = db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = 1000L)
+        val keptId = db.saveLocation(latitude = 53.0, longitude = 14.0, timestamp = 2000L)
         db.addToQueue(locId, """{"lat":52.0}""")
         db.addToQueue(locId, """{"lat":52.0,"v":2}""")
-        assertEquals(2, db.getQueuedCount())
+        db.addToQueue(keptId, """{"lat":53.0}""")
+        assertEquals(3, db.getQueuedCount())
 
-        // Delete the location — should cascade to queue
+        // Delete the location - should cascade to queue, leaving other points queued
         db.deleteLocations(listOf(locId))
 
-        assertEquals(0, db.getQueuedCount())
+        val queued = db.getQueuedLocations(10)
+        assertEquals(1, queued.size)
+        assertEquals(keptId, queued[0].locationId)
     }
 
     @Test

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -7,7 +7,7 @@ import React, { useRef, useEffect, useMemo, useState, useCallback } from "react"
 import { View, StyleSheet, Text, Pressable, TextInput } from "react-native"
 import { GeoJSONSource, Layer, type PressEventWithFeatures } from "@maplibre/maplibre-react-native"
 import type { NativeSyntheticEvent } from "react-native"
-import { MapPinOff, X, Check } from "lucide-react-native"
+import { MapPinOff, X, Check, Trash2 } from "lucide-react-native"
 import { ThemeColors, Trip } from "../../../types/global"
 import { getTripColor } from "../../../utils/trips"
 import { fonts } from "../../../styles/typography"
@@ -40,9 +40,19 @@ interface Props {
   fitVersion?: number
   /** When provided, the point popup gains an editable note field. Omit for read-only maps. */
   onPointNoteChange?: (id: number, note: string | null) => void
+  /** When provided, the point popup gains a delete action. Omit for read-only maps. */
+  onPointDelete?: (id: number) => void
 }
 
-export function TrackMap({ locations, colors, trips, trackColor, fitVersion, onPointNoteChange }: Props) {
+export function TrackMap({
+  locations,
+  colors,
+  trips,
+  trackColor,
+  fitVersion,
+  onPointNoteChange,
+  onPointDelete
+}: Props) {
   const mapRef = useRef<ColotaMapRef>(null)
   const [isCentered, setIsCentered] = useState(true)
   const [selectedPoint, setSelectedPoint] = useState<{
@@ -297,16 +307,30 @@ export function TrackMap({ locations, colors, trips, trackColor, fitVersion, onP
             <Text style={[styles.popupTime, { color: colors.text }]}>
               {popup.timestamp ? new Date(popup.timestamp * 1000).toLocaleTimeString() : "-"}
             </Text>
-            <Pressable
-              onPress={() => {
-                setPopup(null)
-                setSelectedPoint(null)
-              }}
-              hitSlop={HIT_SLOP_MD}
-              style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
-            >
-              <X size={16} color={colors.textSecondary} />
-            </Pressable>
+            <View style={styles.popupActions}>
+              {onPointDelete && popup.id >= 0 && (
+                <Pressable
+                  testID="popup-delete-point"
+                  onPress={() => onPointDelete(popup.id)}
+                  hitSlop={HIT_SLOP_MD}
+                  style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Delete this point"
+                >
+                  <Trash2 size={16} color={colors.error} />
+                </Pressable>
+              )}
+              <Pressable
+                onPress={() => {
+                  setPopup(null)
+                  setSelectedPoint(null)
+                }}
+                hitSlop={HIT_SLOP_MD}
+                style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+              >
+                <X size={16} color={colors.textSecondary} />
+              </Pressable>
+            </View>
           </View>
           <View style={styles.popupRow}>
             <Text style={[styles.popupLabel, { color: colors.textSecondary }]}>Speed</Text>
@@ -427,6 +451,12 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "center",
     marginBottom: 4
+  },
+  popupActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    // Both icons carry HIT_SLOP_MD, so a smaller gap overlaps delete with close
+    gap: 20
   },
   popupTime: {
     fontWeight: "600",

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, act } from "@testing-library/react-native"
+import { render, act, fireEvent } from "@testing-library/react-native"
 import { TrackMap } from "../TrackMap"
 import { DEFAULT_MAP_ZOOM } from "../../../../constants"
 import type { Trip } from "../../../../types/global"
@@ -42,7 +42,8 @@ jest.mock("@maplibre/maplibre-react-native", () => {
   const R = require("react")
   const { View } = require("react-native")
   const stub = (name: string) => {
-    const Stub = (props: any) => R.createElement(View, { testID: name }, props.children)
+    const Stub = (props: any) =>
+      R.createElement(View, { testID: props.id ?? name, onPress: props.onPress }, props.children)
     Stub.displayName = name
     return Stub
   }
@@ -90,18 +91,22 @@ const loc = (lat: number, lon: number) => ({
   battery_status: 2
 })
 
+// Run the auto-fit synchronously, otherwise it lands after the test has torn down
+beforeEach(() => {
+  jest.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb: any) => {
+    cb(0)
+    return 0
+  })
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
 describe("TrackMap auto-fit", () => {
   beforeEach(() => {
     mockFitBounds.mockClear()
     mockSetStop.mockClear()
-    jest.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb: any) => {
-      cb(0)
-      return 0
-    })
-  })
-
-  afterEach(() => {
-    jest.restoreAllMocks()
   })
 
   it("fits bounds when switching from empty day to non-empty day", () => {
@@ -130,6 +135,52 @@ describe("TrackMap auto-fit", () => {
     // A zero-extent bounds would make fitBounds zoom to the max level, so a lone point must not fit
     expect(mockFitBounds).not.toHaveBeenCalled()
     expect(mockSetStop).toHaveBeenCalledWith(expect.objectContaining({ center: [13.4, 52.5], zoom: DEFAULT_MAP_ZOOM }))
+  })
+})
+
+describe("TrackMap point deletion", () => {
+  const tapPoint = (points: any, id: number) =>
+    fireEvent(points, "press", {
+      nativeEvent: {
+        features: [
+          {
+            properties: { id, color: "#000", speed: 0, timestamp: 1000, accuracy: 5, altitude: 10, note: "" },
+            geometry: { type: "Point", coordinates: [13.4, 52.5] }
+          }
+        ]
+      }
+    })
+
+  it("reports the tapped point's id to the delete handler", () => {
+    const onPointDelete = jest.fn()
+    const { getByTestId } = render(
+      <TrackMap locations={[loc(52.5, 13.4)]} colors={colors} trackColor="#000" onPointDelete={onPointDelete} />
+    )
+
+    tapPoint(getByTestId("track-points"), 42)
+    fireEvent.press(getByTestId("popup-delete-point"))
+
+    expect(onPointDelete).toHaveBeenCalledWith(42)
+  })
+
+  it("offers no delete action on a read-only map", () => {
+    const { getByTestId, queryByTestId } = render(
+      <TrackMap locations={[loc(52.5, 13.4)]} colors={colors} trackColor="#000" />
+    )
+
+    tapPoint(getByTestId("track-points"), 42)
+
+    expect(queryByTestId("popup-delete-point")).toBeNull()
+  })
+
+  it("offers no delete action for a point with no row id", () => {
+    const { getByTestId, queryByTestId } = render(
+      <TrackMap locations={[loc(52.5, 13.4)]} colors={colors} trackColor="#000" onPointDelete={jest.fn()} />
+    )
+
+    tapPoint(getByTestId("track-points"), -1)
+
+    expect(queryByTestId("popup-delete-point")).toBeNull()
   })
 })
 

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -18,7 +18,7 @@ import { CalendarPicker } from "../components/features/inspector/CalendarPicker"
 import { TrackMap } from "../components/features/inspector/TrackMap"
 import { TripList } from "../components/features/inspector/TripList"
 import { LocationTable } from "../components/features/inspector/LocationTable"
-import { formatDistance, startOfDaySec, endOfDaySec } from "../utils/geo"
+import { formatDistance, formatTime, startOfDaySec, endOfDaySec } from "../utils/geo"
 import { pad2 } from "../utils/format"
 import { segmentTrips, getTripColor } from "../utils/trips"
 import { EXPORT_FORMATS, type ExportFormat } from "../utils/exportConverters"
@@ -61,6 +61,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
   }, [trips])
 
   const fetchTrackIdRef = useRef(0)
+  const deletingPointRef = useRef(false)
 
   // Summary navigation button
   const headerRight = useCallback(
@@ -208,6 +209,15 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
     setFitVersion((v) => v + 1)
   }, [])
 
+  const refreshAfterDelete = useCallback(async () => {
+    const key = `${mapDate.getFullYear()}-${pad2(mapDate.getMonth() + 1)}`
+    daysCache.current.delete(key)
+    notesCache.current.delete(key)
+    distanceCache.current.delete(key)
+    await fetchTrackData()
+    await fetchDaysWithData(mapDate.getFullYear(), mapDate.getMonth())
+  }, [mapDate, fetchTrackData, fetchDaysWithData])
+
   const handleDeleteTrips = useCallback(
     async (toDelete: Trip[]) => {
       if (toDelete.length === 0) return
@@ -225,18 +235,41 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         await NativeLocationService.deleteLocationsInRanges(
           toDelete.map((t) => ({ start: t.startTime, end: t.endTime }))
         )
-        const key = `${mapDate.getFullYear()}-${pad2(mapDate.getMonth() + 1)}`
-        daysCache.current.delete(key)
-        notesCache.current.delete(key)
-        distanceCache.current.delete(key)
-        await fetchTrackData()
-        await fetchDaysWithData(mapDate.getFullYear(), mapDate.getMonth())
+        await refreshAfterDelete()
       } catch (error) {
         logger.error("[LocationHistory] Trip delete failed:", error)
         showAlert("Delete Failed", "Unable to delete selection. Please try again.", "error")
       }
     },
-    [mapDate, fetchTrackData, fetchDaysWithData]
+    [refreshAfterDelete]
+  )
+
+  const handlePointDelete = useCallback(
+    async (id: number) => {
+      if (deletingPointRef.current) return
+      // The confirm covers the popup, so name the point in it
+      const point = trackLocations.find((l) => l.id === id)
+      const at = point?.timestamp ? formatTime(point.timestamp, true) : null
+      const confirmed = await showConfirm({
+        title: at ? `Delete the point at ${at}?` : "Delete Point?",
+        message:
+          "Removes this point from this device only. If it has already synced it stays on your server, and if it has not it will never be uploaded.",
+        confirmText: "Delete",
+        destructive: true
+      })
+      if (!confirmed) return
+      deletingPointRef.current = true
+      try {
+        await NativeLocationService.deleteLocationsByIds([id])
+        await refreshAfterDelete()
+      } catch (error) {
+        logger.error("[LocationHistory] Point delete failed:", error)
+        showAlert("Delete Failed", "Unable to delete point. Please try again.", "error")
+      } finally {
+        deletingPointRef.current = false
+      }
+    },
+    [trackLocations, refreshAfterDelete]
   )
 
   const handlePointNoteChange = useCallback(
@@ -313,6 +346,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
             trackColor={colors.primary}
             fitVersion={fitVersion}
             onPointNoteChange={handlePointNoteChange}
+            onPointDelete={handlePointDelete}
           />
           {selectedTrip && (
             <Pressable

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, fireEvent } from "@testing-library/react-native"
+import { render, fireEvent, waitFor } from "@testing-library/react-native"
 
 // --- Mocks ---
 
@@ -12,7 +12,8 @@ jest.mock("../../services/NativeLocationService", () => ({
     getLocationsByDateRange: jest.fn().mockResolvedValue([]),
     exportTripsToFile: jest.fn().mockResolvedValue("/tmp/export"),
     shareFile: jest.fn(),
-    deleteLocationsInRange: jest.fn().mockResolvedValue(0)
+    deleteLocationsInRange: jest.fn().mockResolvedValue(0),
+    deleteLocationsByIds: jest.fn().mockResolvedValue(0)
   }
 }))
 
@@ -82,9 +83,16 @@ jest.mock("../../components/features/inspector/CalendarPicker", () => {
 
 jest.mock("../../components/features/inspector/TrackMap", () => {
   const R = require("react")
-  const { View } = require("react-native")
+  const { View, Pressable } = require("react-native")
   return {
-    TrackMap: (_props: any) => R.createElement(View, { testID: "TrackMap" })
+    TrackMap: (props: any) =>
+      R.createElement(
+        View,
+        { testID: "TrackMap" },
+        props.onPointDelete
+          ? R.createElement(Pressable, { testID: "trigger-point-delete", onPress: () => props.onPointDelete(7) })
+          : null
+      )
   }
 })
 
@@ -117,6 +125,8 @@ jest.mock("@react-navigation/native", () => ({
 }))
 
 import { LocationHistoryScreen } from "../LocationInspectorScreen"
+import NativeLocationService from "../../services/NativeLocationService"
+import { showConfirm } from "../../services/modalService"
 
 const createProps = () =>
   ({
@@ -152,6 +162,16 @@ describe("LocationHistoryScreen", () => {
     // Trips and Data content should not be visible
     expect(queryByTestId("TripList")).toBeNull()
     expect(queryByTestId("LocationTable")).toBeNull()
+  })
+
+  it("deletes nothing when the point delete confirm is dismissed", async () => {
+    const props = createProps()
+    const { getByTestId } = render(<LocationHistoryScreen {...props} />)
+
+    fireEvent.press(getByTestId("trigger-point-delete"))
+
+    await waitFor(() => expect(showConfirm).toHaveBeenCalled())
+    expect(NativeLocationService.deleteLocationsByIds).not.toHaveBeenCalled()
   })
 
   it("switches to Trips tab on press", () => {

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -310,6 +310,17 @@ class NativeLocationService {
   }
 
   /**
+   * Deletes individual locations by row id
+   * @returns Count of deleted records
+   */
+  static async deleteLocationsByIds(ids: number[]): Promise<number> {
+    this.ensureModule()
+    if (ids.length === 0) return 0
+    logger.debug(`[NativeLocationService] Deleting ${ids.length} locations by id`)
+    return LocationServiceModule.deleteLocationsByIds(ids)
+  }
+
+  /**
    * Runs SQLite VACUUM to reclaim disk space
    */
   static async vacuumDatabase(): Promise<void> {

--- a/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
+++ b/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
@@ -20,6 +20,7 @@ jest.mock("react-native", () => ({
       clearAllLocations: jest.fn().mockResolvedValue(50),
       deleteOlderThan: jest.fn().mockResolvedValue(25),
       deleteLocationsInRange: jest.fn().mockResolvedValue(7),
+      deleteLocationsByIds: jest.fn().mockResolvedValue(1),
       vacuumDatabase: jest.fn().mockResolvedValue(undefined),
       getGeofences: jest.fn().mockResolvedValue([]),
       createGeofence: jest.fn().mockResolvedValue(1),
@@ -338,6 +339,20 @@ describe("NativeLocationService", () => {
       nativeMock.getActiveProfile.mockRejectedValueOnce(new Error("Native error"))
       const name = await NativeLocationService.getActiveProfileName()
       expect(name).toBeNull()
+    })
+  })
+
+  describe("deleteLocationsByIds", () => {
+    it("passes the ids to the native module", async () => {
+      const deleted = await NativeLocationService.deleteLocationsByIds([12, 34])
+      expect(deleted).toBe(1)
+      expect(nativeMock.deleteLocationsByIds).toHaveBeenCalledWith([12, 34])
+    })
+
+    it("skips the bridge call for an empty list", async () => {
+      const deleted = await NativeLocationService.deleteLocationsByIds([])
+      expect(deleted).toBe(0)
+      expect(nativeMock.deleteLocationsByIds).not.toHaveBeenCalled()
     })
   })
 

--- a/fastlane/metadata/android/en-US/changelogs/44.txt
+++ b/fastlane/metadata/android/en-US/changelogs/44.txt
@@ -1,4 +1,5 @@
 - The Stationary profile now records a point at each interval while the device is still
 - Auto-export file names are now customisable with {date}, {time} and {device} placeholders
 - Add {device} to the file name to keep retention per device model when several phones share an export folder
-- Stationary heartbeat points no longer show up as 0 m trips in the history - a run of points now has to cover at least 100 m to count as a trip
+- Stationary heartbeat points no longer show up as 0 m trips in the history
+- Delete a single point by tapping it on the map and using the trash icon in its popup


### PR DESCRIPTION
The popup gains a trash action behind a confirmation naming the point by time, going through a new by-id bridge call, since the existing delete is range-based and would take every point sharing that second. It skips the vacuum the bulk deletes do, which is not worth rewriting the database for a few rows, and an unsent point's queued upload goes with it via the foreign key cascade.

Closes  #544