### PR TITLE
fix(trips): derive average speed from position when no fix reports one

### DIFF
--- a/apps/mobile/src/utils/__tests__/trips.test.ts
+++ b/apps/mobile/src/utils/__tests__/trips.test.ts
@@ -218,6 +218,25 @@ describe("computeTripStats", () => {
     expect(stats.avgSpeed).toBe(10) // only the 10 counts
   })
 
+  it("derives average speed from position when no point has a usable speed", () => {
+    const locations = [
+      { latitude: 52.52, longitude: 13.405, timestamp: 1000, speed: 0 },
+      { latitude: 52.521, longitude: 13.405, timestamp: 1050, speed: 0 }
+    ]
+    // 0.001 degrees of latitude is ~111.2m, covered in 50s
+    const stats = computeTripStats(locations)
+    expect(stats.avgSpeed).toBeCloseTo(2.224, 3)
+  })
+
+  it("prefers reported speeds over the position-derived fallback", () => {
+    const locations = [
+      { latitude: 52.52, longitude: 13.405, timestamp: 1000, speed: 3 },
+      { latitude: 52.53, longitude: 13.405, timestamp: 1050, speed: 3 }
+    ]
+    // Position implies ~22 m/s over these 50s, so a flipped precedence would be visible
+    expect(computeTripStats(locations).avgSpeed).toBe(3)
+  })
+
   it("computes elevation gain and loss", () => {
     const locations = [
       { latitude: 0, longitude: 0, altitude: 100 },

--- a/apps/mobile/src/utils/trips.ts
+++ b/apps/mobile/src/utils/trips.ts
@@ -108,8 +108,20 @@ export function computeTripStats(locations: LocationCoords[]): TripStats {
     }
   }
 
+  let avgSpeed = 0
+  if (speedCount > 0) {
+    avgSpeed = speedSum / speedCount
+  } else if (locations.length > 1) {
+    // Points reach here with no usable speed three ways: a chip reporting 0 on every fix, an
+    // update interval past applySpeedFallback's 60s window, or an import whose source file
+    // carried none. Without this the trip reads 0 next to a correct distance. Note this counts
+    // stopped time, unlike the reported-speed branch above, which averages moving fixes only.
+    const seconds = (locations[locations.length - 1].timestamp ?? 0) - (locations[0].timestamp ?? 0)
+    if (seconds > 0) avgSpeed = computeTotalDistance(locations) / seconds
+  }
+
   return {
-    avgSpeed: speedCount > 0 ? speedSum / speedCount : 0,
+    avgSpeed,
     elevationGain,
     elevationLoss
   }

--- a/fastlane/metadata/android/en-US/changelogs/45.txt
+++ b/fastlane/metadata/android/en-US/changelogs/45.txt
@@ -1,3 +1,4 @@
 - Large point counts stay on one line in the settings summary, shown as 123K or 2.0M
 - Geofence heartbeat now records points in offline mode and when the server is unreachable
 - No duplicate heartbeat point after the app restarts in the background
+- Trips show an average speed instead of 0 km/h when the points carry no speed, including imported tracks


### PR DESCRIPTION
computeTripStats only counted speeds > 0, so a trip whose points all carry 0 or null read "0 km/h" next to a correct distance and duration. Three ways in: a chip reporting 0 on every fix (applySpeedFallback returns early when hasSpeed() is true), an update interval past that fallback's 60s window, and imported tracks, which never pass through handleLocationUpdate at all.

The fallback measures distance over total elapsed time, so it counts stopped time, unlike the reported-speed path which averages moving fixes only. Left that way deliberately: unifying them would redefine Avg Speed for everyone. Partial reporting (one usable fix labelling a whole trip) is unchanged.
