### PR TITLE
fix(permissions): start tracking when notifications are denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Colota sends your location to your own server over HTTP(S). It works offline, su
 
 1. Install from [Google Play](https://play.google.com/store/apps/details?id=com.Colota&hl=en-US), [F-Droid](https://f-droid.org/packages/com.Colota/), [IzzyOnDroid](https://apt.izzysoft.de/packages/com.Colota/) or download the APK from [GitHub Releases](https://github.com/dietrichmax/colota/releases)
 2. Grant location permissions (precise, all the time)
-3. Grant notification permission (required for the foreground service)
+3. Grant notification permission (optional; on Android 13+ refusing it hides the status notification)
 4. Disable battery optimization for Colota
 5. Press **Start Tracking**
 

--- a/apps/docs/docs/development/permissions.md
+++ b/apps/docs/docs/development/permissions.md
@@ -19,7 +19,7 @@ These are the permissions Colota uses and why. None are related to analytics, ad
 | Network State                  | Yes         | Check connectivity before syncing                                     |
 | Wi-Fi State                    | Yes         | Detect current SSID for sync condition filtering                      |
 | Boot Completed                 | Yes         | Auto-restart tracking after device reboot                             |
-| Notifications                  | Android 13+ | Display the foreground service notification                           |
+| Notifications                  | Optional    | Show the tracking notification (Android 13+)                          |
 | Local Network Access           | Android 17+ | Access local network servers (self-hosted)                            |
 | Battery Optimization Exemption | Optional    | Prevent Android from killing the tracking service                     |
 | Wake Lock                      | Yes         | Briefly wake the CPU for the stationary heartbeat and background jobs |
@@ -30,10 +30,10 @@ When you start tracking for the first time, Colota requests permissions in seque
 
 1. **Fine Location** - Required to access GPS hardware
 2. **Background Location** (Android 10+) - Appears as a separate dialog asking to "Allow all the time"
-3. **Notification Permission** (Android 13+) - Required for the foreground service notification
+3. **Notification Permission** (Android 13+) - Shows the tracking notification
 4. **Battery Optimization Exemption** - Optional dialog to prevent the system from restricting the app
 
-If any required permission is denied, tracking cannot start. The app does not request permissions until you explicitly tap "Start Tracking".
+Only the two location permissions are required. The app does not request anything until you tap "Start Tracking".
 
 The **Local Network Permission** (Android 17+) is not part of this sequence. It is requested separately when you use **Test Connection** with a local/private server endpoint.
 
@@ -83,7 +83,7 @@ If tracking was active when the device was powered off, Colota automatically res
 android.permission.POST_NOTIFICATIONS
 ```
 
-Starting with Android 13, apps must request notification permission explicitly. Colota uses a foreground service for GPS tracking, which requires a persistent notification. Without this permission, the service cannot start - including after a device reboot.
+On Android 13 and later, apps need this permission before they can show notifications. Colota asks for it but does not require it - tracking runs either way. Denying it hides the tracking notification, so you lose the live status and any alert when tracking stops.
 
 ### Local Network Access
 

--- a/apps/docs/docs/faq.md
+++ b/apps/docs/docs/faq.md
@@ -64,7 +64,7 @@ Yes. Restore is replace-everything: locations, settings, geofences and credentia
 
 ### What happens when the phone restarts?
 
-If auto-start on boot is enabled, Colota automatically resumes tracking after a device restart when tracking was active before.
+Colota resumes tracking after a restart if tracking was active before it. There is no setting for this. If it does not resume, see [Troubleshooting](guides/troubleshooting.md).
 
 ### How much battery does it use?
 

--- a/apps/docs/docs/getting-started/quick-start.md
+++ b/apps/docs/docs/getting-started/quick-start.md
@@ -8,7 +8,7 @@ Minimal setup to start tracking:
 
 1. Install the app ([Google Play](https://play.google.com/store/apps/details?id=com.Colota&hl=en-US), [F-Droid](https://f-droid.org/packages/com.Colota/), [IzzyOnDroid](https://apt.izzysoft.de/packages/com.Colota/) or [APK](https://github.com/dietrichmax/colota/releases))
 2. Grant location permissions - select **Precise location** and **Allow all the time**
-3. Grant notification permission - required for the foreground service that keeps GPS tracking alive
+3. Grant notification permission - optional. On Android 13 and later, refusing it hides the tracking status notification
 4. Disable battery optimization for Colota in Android settings (otherwise background tracking won't work reliably)
 5. Press **Start Tracking**
 6. View live coordinates on the dashboard

--- a/apps/docs/docs/guides/troubleshooting.md
+++ b/apps/docs/docs/guides/troubleshooting.md
@@ -8,14 +8,16 @@ sidebar_position: 4
 
 - Go to **Settings > Apps > Colota > Battery** and select **Unrestricted**
 - Verify location permissions are set to **Allow all the time**
-- Ensure notification permission is granted - Colota uses a foreground service which requires a persistent notification. Without it, the service cannot start.
+- Grant notification permission if you want to see tracking status
 
 ## Tracking doesn't start after reboot
 
 - Make sure tracking was active before the reboot
-- Notification permission must be granted - without it the foreground service cannot start on boot
+- Do not force-stop Colota. A force-stopped app receives no boot broadcast until you open it again
+- **Samsung**: turn off "Pause app activity if unused" for Colota (**Settings > Apps > Colota > Battery**)
+- **Xiaomi, Huawei, Oppo, Vivo, OnePlus**: allow Autostart for Colota in the phone's own security or battery app
 - Disable battery optimization for Colota (**Settings > Apps > Colota > Battery > Unrestricted**)
-- **Samsung**: Make sure "Pause app activity if unused" is turned off for Colota (**Settings > Apps > Colota > Battery**)
+- Open the app once if you have not used it for months. Android resets permissions for unused apps
 
 ## Tracking stopped on low battery and didn't resume
 

--- a/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
@@ -22,8 +22,7 @@ export function LocationDisclosureModal() {
       title="Location Data Collection"
       paragraphs={[
         "Colota collects location data to enable GPS tracking and sending your position to your configured server, even when the app is closed or not in use.",
-        "This data is sent only to the server you set up. No data is shared with third parties.",
-        "The app requires notification permission to show a persistent notification for the foreground service that keeps GPS tracking alive. Battery optimization should be disabled for reliable background operation."
+        "This data is sent only to the server you set up. No data is shared with third parties."
       ]}
       confirmLabel="Agree"
       registerCallback={registerDisclosureCallback}

--- a/apps/mobile/src/services/LocationServicePermission.ts
+++ b/apps/mobile/src/services/LocationServicePermission.ts
@@ -64,30 +64,28 @@ export async function ensurePermissions(): Promise<boolean> {
   if (Platform.OS !== "android") return true
 
   try {
-    // Skip disclosure + requests if everything is already granted
     const status = await checkPermissions()
-    if (status.location && status.background && status.notifications) {
-      await requestBatteryOptimizationExemption()
-      return true
+
+    // Location grants only - including notifications here replays the disclosure on every start
+    if (!status.location || !status.background) {
+      // Prominent disclosure (required by Google Play User Data policy)
+      const consented = _disclosureCallback ? await _disclosureCallback() : await fallbackDisclosure()
+      if (!consented) return false
+
+      // Fine location
+      if (!status.location) {
+        const result = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION)
+        if (result !== PermissionsAndroid.RESULTS.GRANTED) return false
+      }
+
+      // Background location (Android 10+)
+      if (Platform.Version >= ANDROID_10 && !status.background) {
+        const result = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION)
+        if (result !== PermissionsAndroid.RESULTS.GRANTED) return false
+      }
     }
 
-    // Prominent disclosure (required by Google Play User Data policy)
-    const consented = _disclosureCallback ? await _disclosureCallback() : await fallbackDisclosure()
-    if (!consented) return false
-
-    // Fine location
-    if (!status.location) {
-      const result = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION)
-      if (result !== PermissionsAndroid.RESULTS.GRANTED) return false
-    }
-
-    // Background location (Android 10+)
-    if (Platform.Version >= ANDROID_10 && !status.background) {
-      const result = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION)
-      if (result !== PermissionsAndroid.RESULTS.GRANTED) return false
-    }
-
-    // Notifications (Android 13+, non-blocking)
+    // Notifications (Android 13+, non-blocking) - the app has no other way to ask
     if (Platform.Version >= ANDROID_13 && !status.notifications) {
       await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
     }

--- a/apps/mobile/src/services/__tests__/LocationServicePermission.test.ts
+++ b/apps/mobile/src/services/__tests__/LocationServicePermission.test.ts
@@ -78,6 +78,47 @@ describe("ensurePermissions", () => {
     expect(requestSpy).not.toHaveBeenCalled()
   })
 
+  it("skips the disclosure when only notification permission is missing", async () => {
+    setPlatform("android", 33)
+    checkSpy.mockImplementation((perm: string) =>
+      Promise.resolve(perm !== PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
+    )
+    const disclosureSpy = jest.fn().mockResolvedValue(true)
+    registerDisclosureCallback(disclosureSpy)
+
+    const result = await ensurePermissions()
+
+    expect(result).toBe(true)
+    expect(disclosureSpy).not.toHaveBeenCalled()
+    expect(requestSpy).toHaveBeenCalledWith(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
+  })
+
+  it("starts tracking when notifications are denied even if the disclosure would be declined", async () => {
+    setPlatform("android", 33)
+    checkSpy.mockImplementation((perm: string) =>
+      Promise.resolve(perm !== PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
+    )
+    requestSpy.mockResolvedValue(PermissionsAndroid.RESULTS.DENIED)
+    registerDisclosureCallback(() => Promise.resolve(false))
+
+    expect(await ensurePermissions()).toBe(true)
+  })
+
+  it("still shows the disclosure when only background location is missing", async () => {
+    setPlatform("android", 33)
+    checkSpy.mockImplementation((perm: string) =>
+      Promise.resolve(perm !== PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION)
+    )
+    const disclosureSpy = jest.fn().mockResolvedValue(true)
+    registerDisclosureCallback(disclosureSpy)
+
+    await ensurePermissions()
+
+    // Google Play requires the disclosure immediately before the background location request
+    expect(disclosureSpy).toHaveBeenCalledTimes(1)
+    expect(requestSpy).toHaveBeenCalledWith(PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION)
+  })
+
   it("shows disclosure before requesting permissions", async () => {
     setPlatform("android", 28)
     const disclosureSpy = jest.fn().mockResolvedValue(true)

--- a/fastlane/metadata/android/en-US/changelogs/46.txt
+++ b/fastlane/metadata/android/en-US/changelogs/46.txt
@@ -1,1 +1,2 @@
 - Map requests identify the app by name and version, never the device or user
+- Tracking no longer refuses to start when notifications are turned off


### PR DESCRIPTION
Denying the notification permission left ensurePermissions() short of its early return, so every Start Tracking replayed the location disclosure and declining that modal stopped tracking from starting at all. Only the location grants gate the disclosure now, and the docs no longer claim the service cannot start without the permission.