### PR TITLE
fix(service): promote a lightweight wake on a cold service to a full start

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -272,15 +272,29 @@ class LocationForegroundService : Service() {
             return START_NOT_STICKY
         }
 
-        val action = intent?.action
+        val requestedAction = intent?.action
+        // Captured before the config load below, which is what makes an instance warm.
+        val cold = !::config.isInitialized
+
+        // A lightweight wake can be the first thing a fresh instance sees. Running only its
+        // handler would leave a tracking notification over a service with no GPS stream and
+        // no sync, so run the full start instead.
+        val promoted = cold && shouldBeTracking &&
+            requestedAction in LIGHTWEIGHT_ACTIONS &&
+            requestedAction != ACTION_STOP_REQUEST
+        val action = if (promoted) null else requestedAction
         val isLightweight = action in LIGHTWEIGHT_ACTIONS
 
-        AppLogger.d(TAG, "onStartCommand: action=${action ?: "START"}, lightweight=$isLightweight")
+        AppLogger.d(
+            TAG,
+            "onStartCommand: action=${requestedAction ?: "START"}, lightweight=$isLightweight" +
+                if (promoted) " (promoted to full start)" else ""
+        )
 
         // Skip config reload for lightweight actions, but if the service was
         // killed and restarted by one, load from DB so SyncManager has an endpoint.
         if (!isLightweight) {
-            loadConfigFromIntent(intent)
+            loadConfigFromIntent(if (promoted) null else intent)
         } else if (!::config.isInitialized) {
             loadConfigFromIntent(null)
         }
@@ -344,6 +358,16 @@ class LocationForegroundService : Service() {
             return START_NOT_STICKY
         }
 
+        // A stale alarm can wake a fresh instance after the user stopped tracking. Its handler
+        // would find nothing to do and nothing would stop the service it just created.
+        if (cold && isLightweight && !shouldBeTracking &&
+            action != ACTION_STOP_REQUEST && action != ACTION_MANUAL_FLUSH
+        ) {
+            AppLogger.d(TAG, "Lightweight wake on a cold service with tracking off - stopping")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
         if (!isLightweight) {
             startTrackingHeartbeatLogger()
             dbHelper.saveSetting(SettingsKeys.TRACKING_ENABLED, "true")
@@ -357,11 +381,11 @@ class LocationForegroundService : Service() {
             ACTION_REFRESH_NOTIFICATION -> handleRefreshNotification()
             ACTION_RECHECK_ZONE -> handleZoneRecheckAction()
             ACTION_RECHECK_PROFILES -> handleRecheckProfiles()
-            ACTION_MANUAL_FLUSH -> handleManualFlush()
+            ACTION_MANUAL_FLUSH -> handleManualFlush(stopAfter = !shouldBeTracking)
             ACTION_STATIONARY_HEARTBEAT -> handleStationaryHeartbeatFired()
             ACTION_GEOFENCE_HEARTBEAT -> handleGeofenceHeartbeatFired(shouldBeTracking)
             ACTION_STOP_REQUEST -> stopForegroundServiceWithReason(
-                intent.getStringExtra(EXTRA_STOP_REASON) ?: "Stopped"
+                intent?.getStringExtra(EXTRA_STOP_REASON) ?: "Stopped"
             )
             else -> handleStart()
         }
@@ -393,9 +417,11 @@ class LocationForegroundService : Service() {
         }
     }
 
-    private fun handleManualFlush() {
+    /** [stopAfter] when the flush is the only reason this service exists, so it doesn't linger. */
+    private fun handleManualFlush(stopAfter: Boolean) {
         serviceScope?.launch {
             syncManager.manualFlush()
+            if (stopAfter) stopSelf()
         }
     }
 

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -109,6 +109,9 @@ class LocationForegroundServiceTest {
 
         mockkObject(BatteryRecoveryScheduler)
         mockkObject(GeofenceHeartbeatScheduler)
+        mockkObject(TrackingWatchdogScheduler)
+        every { TrackingWatchdogScheduler.schedule(any()) } just Runs
+        every { TrackingWatchdogScheduler.cancel(any()) } just Runs
         every { GeofenceHeartbeatScheduler.schedule(any(), any()) } just Runs
         every { GeofenceHeartbeatScheduler.cancel(any()) } just Runs
         every { BatteryRecoveryScheduler.schedule(any()) } just Runs
@@ -135,6 +138,7 @@ class LocationForegroundServiceTest {
         unmockkObject(AppLogger)
         unmockkObject(BatteryRecoveryScheduler)
         unmockkObject(GeofenceHeartbeatScheduler)
+        unmockkObject(TrackingWatchdogScheduler)
         unmockkStatic(android.os.Looper::class)
     }
 
@@ -3281,4 +3285,107 @@ class LocationForegroundServiceTest {
     private val homeGeofence = geofence("Home", 52.50, 13.40, 150.0)
     private val officeGeofence = geofence("Office", 48.14, 11.58, 200.0)
     private val parkGeofence = geofence("Park", 52.51, 13.35, 100.0)
+
+    // ========================================================================
+    // onStartCommand - a lightweight wake reaching a cold service
+    // ========================================================================
+
+    /** A fresh instance: `config` is what onStartCommand uses to tell cold from warm. */
+    private fun makeCold() {
+        setField("config", null)
+        every { dbHelper.getAllSettings() } returns mapOf(SettingsKeys.TRACKING_ENABLED to "true")
+        every { notificationHelper.getInitialStatus(any(), any(), any()) } returns "status"
+        every { notificationHelper.buildTitle(any()) } returns "Colota Tracking"
+        every { notificationHelper.buildTrackingNotification(any(), any()) } returns mockk(relaxed = true)
+        every { service.startForeground(any<Int>(), any(), any<Int>()) } returns Unit
+    }
+
+    private fun trackingOff() {
+        every { dbHelper.getAllSettings() } returns mapOf(SettingsKeys.TRACKING_ENABLED to "false")
+    }
+
+    private fun intentFor(action: String?): Intent = mockk(relaxed = true) {
+        every { this@mockk.action } returns action
+        every { getStringExtra(any()) } returns null
+        every { extras } returns null
+    }
+
+    /** Without this, the tracking notification sits over a service that records nothing. */
+    @Test
+    fun `a lightweight wake on a cold service starts tracking in full`() = runServiceTest {
+        makeCold()
+
+        service.onStartCommand(intentFor(LocationForegroundService.ACTION_RECHECK_ZONE), 0, 1)
+        advanceUntilIdle()
+
+        verify { service["handleStart"]() }
+        verify(exactly = 0) { service["handleZoneRecheckAction"]() }
+        verify { dbHelper.saveSetting(SettingsKeys.TRACKING_ENABLED, "true") }
+    }
+
+    @Test
+    fun `a lightweight action on a live service runs only its own handler`() = runServiceTest {
+        makeCold()
+        injectDependencies() // restores a non-null config, ie a warm instance
+
+        service.onStartCommand(intentFor(LocationForegroundService.ACTION_RECHECK_ZONE), 0, 1)
+        advanceUntilIdle()
+
+        verify { service["handleZoneRecheckAction"]() }
+        verify(exactly = 0) { service["handleStart"]() }
+    }
+
+    /** Promoting a stop into a start would resurrect tracking the user just ended. */
+    @Test
+    fun `a stop request on a cold service is never promoted`() = runServiceTest {
+        makeCold()
+
+        service.onStartCommand(intentFor(LocationForegroundService.ACTION_STOP_REQUEST), 0, 1)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { service["handleStart"]() }
+        verify { dbHelper.saveSetting(SettingsKeys.TRACKING_ENABLED, "false") }
+    }
+
+    /** A stale alarm outliving a user stop must not leave a half-built service behind. */
+    @Test
+    fun `a lightweight wake on a cold service with tracking off stops it`() = runServiceTest {
+        makeCold()
+        trackingOff()
+
+        val result = service.onStartCommand(
+            intentFor(LocationForegroundService.ACTION_STATIONARY_HEARTBEAT), 0, 1
+        )
+        advanceUntilIdle()
+
+        assertEquals(android.app.Service.START_NOT_STICKY, result)
+        verify { service.stopSelf() }
+        verify(exactly = 0) { dbHelper.saveSetting(SettingsKeys.TRACKING_ENABLED, any()) }
+    }
+
+    /** Sync Now with tracking off is supported, but the service it creates must not linger. */
+    @Test
+    fun `a manual flush with tracking off flushes and then stops`() = runServiceTest {
+        makeCold()
+        trackingOff()
+
+        service.onStartCommand(intentFor(LocationForegroundService.ACTION_MANUAL_FLUSH), 0, 1)
+        advanceUntilIdle()
+
+        coVerify { syncManager.manualFlush() }
+        verify { service.stopSelf() }
+    }
+
+    @Test
+    fun `a manual flush while tracking leaves the service running`() = runServiceTest {
+        makeCold()
+        injectDependencies()
+
+        service.onStartCommand(intentFor(LocationForegroundService.ACTION_MANUAL_FLUSH), 0, 1)
+        advanceUntilIdle()
+
+        coVerify { syncManager.manualFlush() }
+        verify(exactly = 0) { service.stopSelf() }
+    }
+
 }


### PR DESCRIPTION
A geofence edit, profile change or heartbeat alarm can be the first thing a fresh service instance sees. It ran only that action's handler, leaving a tracking notification over a service with no GPS stream, no sync and no profile monitor, which is the state people describe as tracking that records nothing.

Such a wake now runs the full start instead, unless it is a stop request. A wake that arrives after the user stopped tracking stops the service it just created rather than lingering, and Sync Now with tracking off flushes and then stops.