### PR TITLE
fix(settings): stop a failed settings read from wiping every setting

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
@@ -737,7 +737,7 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getAllSettings(promise: Promise) = executeAsync(promise) {
-        val settingsMap = dbHelper.getAllSettings()
+        val settingsMap = dbHelper.getAllSettingsOrThrow()
         Arguments.createMap().apply {
             settingsMap.forEach { (k, v) -> putString(k, v) }
         }

--- a/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
@@ -963,31 +963,41 @@ class DatabaseHelper private constructor(context: Context) :
 
     fun getAllSettings(): Map<String, String> {
         val settings = mutableMapOf<String, String>()
-        
-        try {
-            readableDatabase.query(
-                TABLE_SETTINGS, 
-                arrayOf("key", "value"),
-                null, null, null, null, null
-            ).use { cursor ->
-                val keyIdx = cursor.getColumnIndexOrThrow("key")
-                val valIdx = cursor.getColumnIndexOrThrow("value")
 
-                while (cursor.moveToNext()) {
-                    val key = cursor.getString(keyIdx)
-                    val value = cursor.getString(valIdx)
-                    if (key != null && value != null) {
-                        settings[key] = value
-                    }
-                }
-            }
+        try {
+            loadSettingsInto(settings)
         } catch (e: Exception) {
             AppLogger.e(TAG, "Error loading settings", e)
         }
-        
+
         return settings
     }
 
+    /** Throws on a read failure, because JS seeds the table with defaults when this comes back empty. */
+    fun getAllSettingsOrThrow(): Map<String, String> {
+        val settings = mutableMapOf<String, String>()
+        loadSettingsInto(settings)
+        return settings
+    }
+
+    private fun loadSettingsInto(settings: MutableMap<String, String>) {
+        readableDatabase.query(
+            TABLE_SETTINGS,
+            arrayOf("key", "value"),
+            null, null, null, null, null
+        ).use { cursor ->
+            val keyIdx = cursor.getColumnIndexOrThrow("key")
+            val valIdx = cursor.getColumnIndexOrThrow("value")
+
+            while (cursor.moveToNext()) {
+                val key = cursor.getString(keyIdx)
+                val value = cursor.getString(valIdx)
+                if (key != null && value != null) {
+                    settings[key] = value
+                }
+            }
+        }
+    }
 
     /**
      * Returns distinct dates (YYYY-MM-DD) that have location data within the range.

--- a/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
@@ -7,6 +7,7 @@ package com.Colota.data
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
 import androidx.test.core.app.ApplicationProvider
 import org.junit.After
 import org.junit.Assert.*
@@ -622,6 +623,28 @@ class DatabaseHelperSQLiteTest {
         assertEquals("value2", all["custom2"])
         // Plus prepopulated defaults
         assertTrue(all.size >= 18)
+    }
+
+    @Test
+    fun `getAllSettingsOrThrow reads the same map as getAllSettings`() {
+        db.saveSetting("custom1", "value1")
+
+        assertEquals(db.getAllSettings(), db.getAllSettingsOrThrow())
+    }
+
+    /** JS writes defaults over an empty read, so the bridge needs the failure, not an empty map. */
+    @Test
+    fun `getAllSettingsOrThrow throws on a failed read that getAllSettings reports as empty`() {
+        db.writableDatabase.execSQL("DROP TABLE ${DatabaseHelper.TABLE_SETTINGS}")
+
+        assertTrue(db.getAllSettings().isEmpty())
+
+        try {
+            db.getAllSettingsOrThrow()
+            fail("Expected SQLiteException")
+        } catch (e: SQLiteException) {
+            assertTrue(e.message?.contains("no such table") == true)
+        }
     }
 
     // ========================================================================

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -15,6 +15,8 @@ export const SAVE_SUCCESS_DISPLAY_MS = 2000
 export const TEST_RESULT_DISPLAY_MS = 5_000
 export const SERVICE_RESTART_DELAY_MS = 500
 export const RESTART_DEBOUNCE_MS = 100
+export const SETTINGS_READ_ATTEMPTS = 3
+export const SETTINGS_READ_RETRY_DELAY_MS = 150
 
 // Touch targets
 export const HIT_SLOP_SM = { top: 6, right: 6, bottom: 6, left: 6 } as const

--- a/apps/mobile/src/contexts/TrackingProvider.tsx
+++ b/apps/mobile/src/contexts/TrackingProvider.tsx
@@ -22,6 +22,7 @@ type TrackingContextType = {
   updateSettingsLocal: (s: Settings) => void
   tracking: boolean
   isLoading: boolean
+  settingsHydrated: boolean
   error: Error | null
   activeProfileName: string | null
   startTracking: () => Promise<void>
@@ -109,11 +110,21 @@ export function TrackingProvider({ children }: { children: React.ReactNode }) {
   // Ref to track if initialization has been done (prevents re-running on dependency changes)
   const hasInitializedRef = useRef(false)
 
+  const settingsReadRef = useRef(false)
+
   /**
    * Batch updates settings across both UI state and Native storage.
    * Wrapped in useCallback to maintain referential equality.
    */
   const setSettings = useCallback(async (newSettings: Settings) => {
+    // State holds DEFAULT_SETTINGS until the read lands, so a save before then overwrites the stored ones.
+    if (!settingsReadRef.current) {
+      const err = new Error("Settings are not loaded, so nothing was saved")
+      logger.error("[TrackingContext] Save blocked, settings not loaded")
+      if (isMountedRef.current) setError(err)
+      throw err
+    }
+
     try {
       logger.debug("[TrackingContext] Batch syncing to Native storage...")
       // SettingsService handles unit conversion (seconds -> ms)
@@ -153,13 +164,17 @@ export function TrackingProvider({ children }: { children: React.ReactNode }) {
       try {
         logger.debug("[TrackingContext] Hydrating settings and state...")
         const allRaw = await NativeLocationService.getAllSettings()
+        settingsReadRef.current = true
 
         if (!isMountedRef.current) return
 
         // Initialize DB with defaults if empty
         if (Object.keys(allRaw).length === 0) {
           logger.debug("[TrackingContext] Initializing DB with defaults")
-          await setSettings(DEFAULT_SETTINGS)
+          // The table is empty either way, so the defaults on screen are the truth even unwritten.
+          await setSettings(DEFAULT_SETTINGS).catch((err) =>
+            logger.error("[TrackingContext] Seeding defaults failed:", err)
+          )
           if (isMountedRef.current) setHydrated(true)
           return
         }
@@ -240,6 +255,14 @@ export function TrackingProvider({ children }: { children: React.ReactNode }) {
    * Wrapped tracking controls with useCallback for stable references
    */
   const startTracking = useCallback(async () => {
+    // Same latch as setSettings: an unhydrated start would run the service on DEFAULT_SETTINGS.
+    if (!settingsReadRef.current) {
+      const err = new Error("Settings are not loaded, so tracking was not started")
+      logger.error("[TrackingContext] Start blocked, settings not loaded")
+      if (isMountedRef.current) setError(err)
+      throw err
+    }
+
     try {
       await internalStart(settings)
       if (isMountedRef.current) {
@@ -298,13 +321,25 @@ export function TrackingProvider({ children }: { children: React.ReactNode }) {
       updateSettingsLocal: setSettingsState,
       tracking,
       isLoading,
+      settingsHydrated: hydrated,
       error,
       activeProfileName,
       startTracking,
       stopTracking,
       restartTracking
     }),
-    [settings, tracking, isLoading, error, activeProfileName, setSettings, startTracking, stopTracking, restartTracking]
+    [
+      settings,
+      tracking,
+      isLoading,
+      hydrated,
+      error,
+      activeProfileName,
+      setSettings,
+      startTracking,
+      stopTracking,
+      restartTracking
+    ]
   )
 
   return (

--- a/apps/mobile/src/contexts/__tests__/TrackingProvider.test.tsx
+++ b/apps/mobile/src/contexts/__tests__/TrackingProvider.test.tsx
@@ -62,10 +62,18 @@ import { logger } from "../../utils/logger"
 
 const mockGetAllSettings = NativeLocationService.getAllSettings as jest.Mock
 const mockUpdateMultiple = SettingsService.updateMultiple as jest.Mock
+const mockGetActiveProfileName = NativeLocationService.getActiveProfileName as jest.Mock
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockGetAllSettings.mockResolvedValue({})
 })
+
+const settleHydration = async () => {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100))
+  })
+}
 
 const wrapper = ({ children }: { children: React.ReactNode }) => <TrackingProvider>{children}</TrackingProvider>
 
@@ -123,6 +131,8 @@ describe("useTracking", () => {
 
     const { result } = renderHook(() => useTracking(), { wrapper })
 
+    await settleHydration()
+
     const newSettings = { ...DEFAULT_SETTINGS, interval: 30, endpoint: "https://new.com" }
 
     await act(async () => {
@@ -145,18 +155,98 @@ describe("useTracking", () => {
   })
 
   it("sets error state when hydration fails", async () => {
-    mockGetAllSettings.mockRejectedValueOnce(new Error("DB read failed"))
+    mockGetAllSettings.mockRejectedValue(new Error("DB read failed"))
 
     const { result } = renderHook(() => useTracking(), { wrapper })
 
-    await act(async () => {
-      await new Promise<void>((resolve) => setTimeout(resolve, 100))
-    })
+    await settleHydration()
 
     expect(result.current.error).toBeInstanceOf(Error)
     expect(result.current.error?.message).toBe("DB read failed")
     expect(result.current.isLoading).toBe(false)
     expect(logger.error).toHaveBeenCalledWith("[TrackingContext] Hydration failed:", expect.any(Error))
+  })
+
+  it("does not seed defaults over the database when the settings read fails", async () => {
+    // A failed read must not land in the empty-map branch, which overwrites every stored setting.
+    mockGetAllSettings.mockRejectedValue(new Error("DB read failed"))
+
+    renderHook(() => useTracking(), { wrapper })
+
+    await settleHydration()
+
+    expect(mockUpdateMultiple).not.toHaveBeenCalled()
+  })
+
+  it("hydrates a first run even when seeding the defaults fails", async () => {
+    // An empty table is a real first run, so the UI must not stay gated on the write succeeding.
+    mockGetAllSettings.mockResolvedValueOnce({})
+    mockUpdateMultiple.mockRejectedValueOnce(new Error("disk full"))
+
+    const { result } = renderHook(() => useTracking(), { wrapper })
+
+    await settleHydration()
+
+    expect(result.current.settingsHydrated).toBe(true)
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  it("refuses to start tracking before the settings read lands", async () => {
+    // start() sends every key, so an unhydrated start runs the service on DEFAULT_SETTINGS.
+    mockGetAllSettings.mockReturnValueOnce(new Promise(() => {}))
+
+    const { result } = renderHook(() => useTracking(), { wrapper })
+
+    await act(async () => {
+      await expect(result.current.startTracking()).rejects.toThrow("Settings are not loaded")
+    })
+
+    expect(mockStartTracking).not.toHaveBeenCalled()
+  })
+
+  it("refuses to save before the settings read lands", async () => {
+    mockGetAllSettings.mockReturnValueOnce(new Promise(() => {}))
+
+    const { result } = renderHook(() => useTracking(), { wrapper })
+
+    await act(async () => {
+      await expect(result.current.setSettings(DEFAULT_SETTINGS)).rejects.toThrow("Settings are not loaded")
+    })
+
+    expect(mockUpdateMultiple).not.toHaveBeenCalled()
+  })
+
+  it("keeps saving when hydration fails after the read landed", async () => {
+    // The stored settings are on screen at that point, so blocking saves would be wrong.
+    mockGetAllSettings.mockResolvedValueOnce({ endpoint: "https://kept.example/api", tracking_enabled: "true" })
+    mockGetActiveProfileName.mockRejectedValueOnce(new Error("bridge died"))
+
+    const { result } = renderHook(() => useTracking(), { wrapper })
+
+    await settleHydration()
+
+    await act(async () => {
+      await result.current.setSettings({ ...DEFAULT_SETTINGS, endpoint: "https://kept.example/api" })
+    })
+
+    expect(mockUpdateMultiple).toHaveBeenCalled()
+  })
+
+  it("refuses to save while the settings read has failed", async () => {
+    // Every screen saves the whole Settings object, so one edit here would persist the defaults.
+    mockGetAllSettings.mockRejectedValue(new Error("DB read failed"))
+
+    const { result } = renderHook(() => useTracking(), { wrapper })
+
+    await settleHydration()
+
+    await act(async () => {
+      await expect(result.current.setSettings({ ...DEFAULT_SETTINGS, hasCompletedSetup: true })).rejects.toThrow(
+        "Settings are not loaded"
+      )
+    })
+
+    expect(mockUpdateMultiple).not.toHaveBeenCalled()
   })
 
   it("sets isLoading to false after successful hydration", async () => {
@@ -322,7 +412,6 @@ describe("useTracking", () => {
   })
 
   it("restores activeProfileName on reconnect when tracking was active", async () => {
-    const mockGetActiveProfileName = NativeLocationService.getActiveProfileName as jest.Mock
     mockGetActiveProfileName.mockResolvedValueOnce("Charging")
     mockGetAllSettings.mockResolvedValueOnce({
       interval: "5000",

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -25,7 +25,8 @@ import { Square, Play } from "lucide-react-native"
 import { logger } from "../utils/logger"
 
 export function DashboardScreen({ navigation }: ScreenProps) {
-  const { settings, tracking, startTracking, stopTracking, setSettings, activeProfileName } = useTracking()
+  const { settings, tracking, startTracking, stopTracking, setSettings, activeProfileName, settingsHydrated } =
+    useTracking()
   const { colors } = useTheme()
 
   const [stats, setStats] = useState<DatabaseStats>({
@@ -232,7 +233,7 @@ export function DashboardScreen({ navigation }: ScreenProps) {
               icon={tracking ? Square : Play}
               onPress={tracking ? handleStop : handleStart}
               activeOpacity={0.9}
-              disabled={!tracking && isBatteryCritical}
+              disabled={!tracking && (isBatteryCritical || !settingsHydrated)}
               title={tracking ? "Stop Tracking" : "Start Tracking"}
             />
           </Animated.View>
@@ -240,13 +241,17 @@ export function DashboardScreen({ navigation }: ScreenProps) {
 
         {/* Content Section */}
         <View style={[styles.content, { backgroundColor: colors.background }]}>
-          {/* Welcome Card (first run) */}
-          {!settings.hasCompletedSetup && (
+          {/* Welcome Card (first run). Unhydrated settings read as a first run and cannot be dismissed. */}
+          {settingsHydrated && !settings.hasCompletedSetup && (
             <WelcomeCard
               settings={settings}
               tracking={tracking}
               colors={colors}
-              onDismiss={() => setSettings({ ...settings, hasCompletedSetup: true })}
+              onDismiss={() =>
+                setSettings({ ...settings, hasCompletedSetup: true }).catch((err) =>
+                  logger.error("[DashboardScreen] Failed to dismiss welcome card:", err)
+                )
+              }
               onStartTracking={handleStart}
               onNavigateToConnection={() => navigation.navigate("Connection")}
               onNavigateToTrackingSync={() => navigation.navigate("Tracking & Sync")}

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -10,7 +10,6 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { Container, Card, Button, SectionTitle } from "../components"
 import { fonts } from "../styles/typography"
 import { CircleAlert, CircleCheck, Import } from "lucide-react-native"
-import SettingsService from "../services/SettingsService"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -65,7 +64,6 @@ export function SetupImportScreen({ route, navigation }: any) {
       }
       merged.syncPreset = detectPreset(merged)
 
-      await SettingsService.updateMultiple(merged)
       await setSettings(merged)
 
       // Apply auth - deep merge customHeaders

--- a/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
@@ -13,6 +13,7 @@ const mockShowConfirm = jest.fn().mockResolvedValue(false)
 
 let mockSettings: Settings = { ...DEFAULT_SETTINGS }
 let mockTracking = false
+let mockSettingsHydrated = true
 let mockCoords: { latitude: number; longitude: number } | null = null
 
 jest.mock("../../contexts/TrackingProvider", () => ({
@@ -22,7 +23,8 @@ jest.mock("../../contexts/TrackingProvider", () => ({
     startTracking: mockStartTracking,
     stopTracking: mockStopTracking,
     setSettings: mockSetSettings,
-    activeProfileName: "Default"
+    activeProfileName: "Default",
+    settingsHydrated: mockSettingsHydrated
   }),
   useCoords: () => mockCoords
 }))
@@ -88,7 +90,12 @@ jest.mock("../../components", () => {
     QuickAccess: () => R.createElement(View, { testID: "QuickAccess" }),
     WelcomeCard: () => R.createElement(View, { testID: "WelcomeCard" }),
     Container: ({ children }: any) => R.createElement(View, null, children),
-    Button: ({ title, onPress }: any) => R.createElement(Pressable, { onPress }, R.createElement(Text, null, title))
+    Button: ({ title, onPress, disabled }: any) =>
+      R.createElement(
+        Pressable,
+        { onPress, disabled, accessibilityState: { disabled: !!disabled } },
+        R.createElement(Text, null, title)
+      )
   }
 })
 
@@ -101,6 +108,7 @@ describe("DashboardScreen", () => {
     jest.clearAllMocks()
     mockSettings = { ...DEFAULT_SETTINGS }
     mockTracking = false
+    mockSettingsHydrated = true
     mockCoords = null
     mockIsLocationEnabled.mockResolvedValue(true)
     mockOpenLocationSettings.mockResolvedValue(true)
@@ -139,6 +147,25 @@ describe("DashboardScreen", () => {
     const { queryByTestId } = render(<DashboardScreen navigation={mockNavigation} />)
 
     expect(queryByTestId("CoordinateDisplay")).toBeNull()
+  })
+
+  it("disables Start Tracking while settings have not been read", () => {
+    // start() sends every key, and fromReadableMap prefers a present empty endpoint over the stored one.
+    mockSettingsHydrated = false
+
+    const { getByText } = render(<DashboardScreen navigation={mockNavigation} />)
+
+    expect(getByText("Start Tracking")).toBeDisabled()
+  })
+
+  it("hides WelcomeCard while settings have not been read", () => {
+    // Unhydrated settings read as a first run, and dismissing the card would save the defaults.
+    mockSettings = { ...DEFAULT_SETTINGS, hasCompletedSetup: false }
+    mockSettingsHydrated = false
+
+    const { queryByTestId } = render(<DashboardScreen navigation={mockNavigation} />)
+
+    expect(queryByTestId("WelcomeCard")).toBeNull()
   })
 
   it("shows WelcomeCard when hasCompletedSetup is false", () => {

--- a/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
@@ -32,13 +32,6 @@ jest.mock("../../services/NativeLocationService", () => ({
   }
 }))
 
-jest.mock("../../services/SettingsService", () => ({
-  __esModule: true,
-  default: {
-    updateMultiple: jest.fn().mockResolvedValue(undefined)
-  }
-}))
-
 jest.mock("../../services/modalService", () => ({
   showAlert: (...args: any[]) => mockShowAlert(...args)
 }))

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -20,6 +20,7 @@ import {
   TripBoundaryOverride
 } from "../types/global"
 import { logger } from "../utils/logger"
+import { SETTINGS_READ_ATTEMPTS, SETTINGS_READ_RETRY_DELAY_MS } from "../constants"
 
 const { LocationServiceModule, MtlsBridgeModule, BuildConfigModule } = NativeModules
 
@@ -576,11 +577,21 @@ class NativeLocationService {
   }
 
   /**
-   * Retrieves all settings as key-value pairs
+   * Retrieves all settings as key-value pairs.
+   * A few retries, then the rejection goes through: JS seeds defaults into the table on an empty result.
    */
   static async getAllSettings(): Promise<Record<string, string>> {
     this.ensureModule()
-    return this.safeExecute(() => LocationServiceModule.getAllSettings(), {}, "getAllSettings failed")
+
+    for (let attempt = 1; attempt < SETTINGS_READ_ATTEMPTS; attempt++) {
+      try {
+        return await LocationServiceModule.getAllSettings()
+      } catch (err) {
+        logger.warn(`[NativeLocationService] Settings read failed, retry ${attempt}/${SETTINGS_READ_ATTEMPTS}:`, err)
+        await new Promise<void>((resolve) => setTimeout(resolve, SETTINGS_READ_RETRY_DELAY_MS))
+      }
+    }
+    return LocationServiceModule.getAllSettings()
   }
 
   // ============================================================================

--- a/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
+++ b/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
@@ -96,11 +96,14 @@ jest.mock("react-native", () => ({
 
 import { NativeModules } from "react-native"
 import NativeLocationService from "../NativeLocationService"
+import { SETTINGS_READ_ATTEMPTS } from "../../constants"
 
 const nativeMock = NativeModules.LocationServiceModule as Record<string, jest.Mock>
 
 beforeEach(() => {
   jest.clearAllMocks()
+  // clearAllMocks keeps implementations, so a rejecting test would leak into the next one.
+  nativeMock.getAllSettings.mockResolvedValue({})
 })
 
 describe("NativeLocationService", () => {
@@ -246,6 +249,30 @@ describe("NativeLocationService", () => {
     it("passes table name, limit, and offset", async () => {
       await NativeLocationService.getTableData("queue", 50, 10)
       expect(nativeMock.getTableData).toHaveBeenCalledWith("queue", 50, 10)
+    })
+  })
+
+  describe("getAllSettings", () => {
+    it("returns the stored settings", async () => {
+      nativeMock.getAllSettings.mockResolvedValueOnce({ interval: "5000" })
+      await expect(NativeLocationService.getAllSettings()).resolves.toEqual({ interval: "5000" })
+    })
+
+    it("recovers when a retry succeeds", async () => {
+      nativeMock.getAllSettings
+        .mockRejectedValueOnce(new Error("database is locked"))
+        .mockResolvedValueOnce({ endpoint: "https://kept.example/api" })
+
+      await expect(NativeLocationService.getAllSettings()).resolves.toEqual({ endpoint: "https://kept.example/api" })
+      expect(nativeMock.getAllSettings).toHaveBeenCalledTimes(2)
+    })
+
+    // Hydration seeds the table with defaults on an empty result, so a read that never succeeded must reject.
+    it("rejects once every attempt has failed", async () => {
+      nativeMock.getAllSettings.mockRejectedValue(new Error("database is locked"))
+
+      await expect(NativeLocationService.getAllSettings()).rejects.toThrow("database is locked")
+      expect(nativeMock.getAllSettings).toHaveBeenCalledTimes(SETTINGS_READ_ATTEMPTS)
     })
   })
 

--- a/fastlane/metadata/android/en-US/changelogs/48.txt
+++ b/fastlane/metadata/android/en-US/changelogs/48.txt
@@ -1,0 +1,1 @@
+- Settings are no longer replaced with defaults when the app fails to read them


### PR DESCRIPTION
A failed read of the settings table arrived in JS as an empty map, and hydration writes DEFAULT_SETTINGS over the database when the map is empty. Endpoint, field map, custom fields and hasCompletedSetup were gone, and once the defaults were written the next launch read them back cleanly, so nothing showed it had happened.

The bridge now uses a read that throws, and retries a locked database a few times before giving up. The provider refuses to save until that read lands, since state holds the defaults until then and every screen saves the whole Settings object.