### PR TITLE
fix(logging): mask token-like path segments and the invalid-URL test message

### DIFF
--- a/apps/docs/docs/development/local-setup.md
+++ b/apps/docs/docs/development/local-setup.md
@@ -168,7 +168,7 @@ Test files are located in `apps/mobile/android/app/src/test/java/com/Colota/`. T
 - **SyncManager** - Instant/periodic sync modes, retry logic, Wi-Fi only gating, backoff
 - **NetworkManager** - Query string building, URL variable substitution
 - **UrlSafety** - HTTPS-for-public enforcement, private/CGNAT host detection
-- **AppLogger** - Sensitive HTTP header value masking
+- **AppLogger** - Masking of sensitive header values, URL query values and token-like URL path segments
 - **DatabaseHelper** - Data model, cutoff calculations, batch operations
 - **SecureStorageHelper** - Basic Auth, Bearer token, custom headers, JSON parsing
 - **DeviceInfoHelper** - Battery threshold logic, status code mapping, percentage calculation

--- a/apps/docs/docs/security.md
+++ b/apps/docs/docs/security.md
@@ -27,7 +27,7 @@ For servers that require a client certificate at the TLS handshake (e.g. nginx `
 
 Authentication credentials (Basic auth, Bearer tokens, custom headers) are stored using Android's [`EncryptedSharedPreferences`](https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences) with **AES-256-GCM** encryption. Credentials never leave the device except as HTTP headers sent to your configured endpoint.
 
-Sensitive values (Authorization, Bearer, Token, API-Key) are automatically masked in log exports.
+Sensitive values (Authorization, Bearer, Token, API-Key) and token-like parts of the endpoint URL are automatically masked in log exports.
 
 ## Location Data at Rest
 

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/NetworkManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/NetworkManager.kt
@@ -268,7 +268,7 @@ class NetworkManager(private val context: Context) {
         val url = try {
             URL(resolvedEndpoint)
         } catch (_: Exception) {
-            return@withContext TestEndpointResult(false, errorMessage = "Invalid URL: $resolvedEndpoint")
+            return@withContext TestEndpointResult(false, errorMessage = "Invalid URL: ${AppLogger.maskSensitiveUrlValues(resolvedEndpoint)}")
         }
         if (!UrlSafety.isValidProtocol(resolvedEndpoint)) {
             return@withContext TestEndpointResult(

--- a/apps/mobile/android/app/src/main/java/com/colota/util/AppLogger.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/util/AppLogger.kt
@@ -48,6 +48,8 @@ object AppLogger {
         RegexOption.IGNORE_CASE
     )
 
+    private val opaquePathSegmentRegex = Regex("^[A-Za-z0-9_-]{16,}$")
+
     /**
      * Masks the value of sensitive HTTP headers before logging.
      * Shows the first 4 characters followed by "***", or "***" for values shorter than 5.
@@ -60,20 +62,25 @@ object AppLogger {
     }
 
     /**
-     * Masks sensitive query parameter values inside a URL before logging.
-     * Returns the input unchanged if the URL has no query string or can't be parsed.
+     * Masks sensitive query parameter values and token-like path segments inside a URL before logging.
+     * Returns the input unchanged if the URL can't be parsed.
      */
     fun maskSensitiveUrlValues(url: String): String {
         return try {
             val uri = android.net.Uri.parse(url)
-            val names = uri.queryParameterNames
-            if (names.isEmpty()) return url
+            val builder = uri.buildUpon()
+            uri.encodedPath?.let { path ->
+                builder.encodedPath(path.split("/").joinToString("/") { if (opaquePathSegmentRegex.matches(it)) maskValue(it) else it })
+            }
 
-            val builder = uri.buildUpon().clearQuery()
-            for (name in names) {
-                val isSensitive = sensitiveQueryRegex.containsMatchIn(name)
-                for (value in uri.getQueryParameters(name)) {
-                    builder.appendQueryParameter(name, if (isSensitive) maskValue(value) else value)
+            val names = uri.queryParameterNames
+            if (names.isNotEmpty()) {
+                builder.clearQuery()
+                for (name in names) {
+                    val isSensitive = sensitiveQueryRegex.containsMatchIn(name)
+                    for (value in uri.getQueryParameters(name)) {
+                        builder.appendQueryParameter(name, if (isSensitive) maskValue(value) else value)
+                    }
                 }
             }
             builder.build().toString()

--- a/apps/mobile/android/app/src/test/java/com/Colota/sync/NetworkManagerTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/sync/NetworkManagerTest.kt
@@ -148,6 +148,21 @@ class NetworkManagerTest {
 
     // --- Reflection helpers to access private methods ---
 
+    // --- testEndpoint ---
+
+    @Test
+    fun `testEndpoint invalid URL message goes through the URL mask`() {
+        // Plain JUnit has no android.net.Uri, so the mask itself is covered in AppLoggerTest
+        every { AppLogger.maskSensitiveUrlValues(any()) } answers { "masked(${firstArg<String>()})" }
+
+        val result = kotlinx.coroutines.runBlocking {
+            createNetworkManagerViaReflection().testEndpoint(JSONObject(), "htps://ha.example.com/api/webhook/abc")
+        }
+
+        assertFalse(result.ok)
+        assertEquals("Invalid URL: masked(htps://ha.example.com/api/webhook/abc)", result.errorMessage)
+    }
+
     private fun invokeReadErrorBody(body: String?): String {
         val connection = io.mockk.mockk<java.net.HttpURLConnection>(relaxed = true)
         io.mockk.every { connection.errorStream } returns body?.byteInputStream()

--- a/apps/mobile/android/app/src/test/java/com/Colota/util/AppLoggerTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/util/AppLoggerTest.kt
@@ -121,4 +121,59 @@ class AppLoggerTest {
         val masked = AppLogger.maskSensitiveUrlValues("https://example.com/x?auth=abcdefgh")
         assertEquals("https://example.com/x?auth=abcd***", masked)
     }
+
+    @Test
+    fun `maskSensitiveUrlValues masks a webhook id in the path`() {
+        val masked = AppLogger.maskSensitiveUrlValues(
+            "https://ha.example.com/api/webhook/3f9a1c2b7d4e5f6a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a"
+        )
+        assertEquals("https://ha.example.com/api/webhook/3f9a***", masked)
+    }
+
+    @Test
+    fun `maskSensitiveUrlValues masks a session token but keeps the device name`() {
+        val masked = AppLogger.maskSensitiveUrlValues(
+            "https://cloud.example.com/apps/phonetrack/log/owntracks/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6/pixel"
+        )
+        assertEquals("https://cloud.example.com/apps/phonetrack/log/owntracks/a1b2***/pixel", masked)
+    }
+
+    @Test
+    fun `maskSensitiveUrlValues keeps route words and dates`() {
+        val url = "https://example.com/api/v1/owntracks/points/2026/08/29"
+        assertEquals(url, AppLogger.maskSensitiveUrlValues(url))
+    }
+
+    @Test
+    fun `maskSensitiveUrlValues masks a letters-only id because a missed secret costs more than a masked word`() {
+        val masked = AppLogger.maskSensitiveUrlValues("https://ha.example.com/api/webhook/my-personal-webhook-id")
+        assertEquals("https://ha.example.com/api/webhook/my-p***", masked)
+    }
+
+    @Test
+    fun `maskSensitiveUrlValues masks from 16 characters`() {
+        val kept = "https://example.com/abcdefghijklmno"
+        assertEquals(kept, AppLogger.maskSensitiveUrlValues(kept))
+        assertEquals("https://example.com/abcd***", AppLogger.maskSensitiveUrlValues("https://example.com/abcdefghijklmnop"))
+    }
+
+    @Test
+    fun `maskSensitiveUrlValues keeps unresolved URL variables`() {
+        val url = "https://example.com/locations/%YEAR/%MONTH/%DAY?id=my-phone"
+        assertEquals(url, AppLogger.maskSensitiveUrlValues(url))
+    }
+
+    @Test
+    fun `maskSensitiveUrlValues masks path token and query key together`() {
+        val masked = AppLogger.maskSensitiveUrlValues(
+            "https://example.com/hooks/abcdef1234567890abcdef/points?api_key=secret123&lat=1.5"
+        )
+        assertEquals("https://example.com/hooks/abcd***/points?api_key=secr***&lat=1.5", masked)
+    }
+
+    @Test
+    fun `maskSensitiveUrlValues masks a token in a URL with an unknown scheme`() {
+        val masked = AppLogger.maskSensitiveUrlValues("htps://ha.example.com/api/webhook/abcdef1234567890abcdef")
+        assertEquals("htps://ha.example.com/api/webhook/abcd***", masked)
+    }
 }

--- a/fastlane/metadata/android/en-US/changelogs/48.txt
+++ b/fastlane/metadata/android/en-US/changelogs/48.txt
@@ -1,1 +1,2 @@
 - Settings are no longer replaced with defaults when the app fails to read them
+- Log exports no longer contain webhook ids or session tokens from the endpoint address


### PR DESCRIPTION
The Test Connection error echoed the raw endpoint into the exported log and the URL mask only rewrote query values, so a webhook id or session token in the path reached the file users attach to issues.