### PR TITLE
fix(export): verify the auto-export copy by bytes written

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -287,9 +287,9 @@ For backups, two `internal` methods support the export/import flow without expos
 | `TimedCache` | Generic TTL cache used for queue count, device info, profiles, and network state |
 | `BuildConfigModule` | Exposes build constants (SDK versions, app version) to JS |
 | `AppLogger` | Centralized logger - always active, all tags prefixed with `Colota.` for logcat filtering |
-| `AutoExportWorker` | WorkManager `CoroutineWorker` enqueued by `AutoExportAlarmReceiver` - performs the export (chunked writes, foreground service, retries, retention cleanup) and re-arms the next alarm in `finally` |
+| `AutoExportWorker` | WorkManager `CoroutineWorker` enqueued by `AutoExportAlarmReceiver` - performs the export (chunked writes to a per-run temp file, foreground service, retries, retention cleanup), verifies the copy by bytes written and re-arms the next alarm in `finally` |
 | `AutoExportAlarmReceiver` | Broadcast receiver fired by AlarmManager at the configured time - hands off to `AutoExportWorker` because the receiver's 10s budget can't run an export |
-| `AutoExportScheduler` | Arms `AlarmManager.setAndAllowWhileIdle` for the next configured wall-clock time. Called on enable, after each worker run, after schedule edits and on boot |
+| `AutoExportScheduler` | Arms `AlarmManager.setAndAllowWhileIdle` for the next configured wall-clock time. Called on enable, by the alarm receiver on every fire, after each worker run, after schedule edits and on boot |
 | `AutoExportConfig` | Typed data class wrapping auto-export settings (interval, time-of-day, weekday, day-of-month, enabledAt) from the SQLite settings table with validation, `isExportDue()` and `nextExportTimestamp()` |
 | `ExportConverters` | Native CSV/GeoJSON/GPX/KML serialization for both "Export all" (flat, streamed via `exportToFile`) and per-trip / multi-select export (trip-segmented via `convertTrips`, reached through the `exportTripsToFile` bridge). In-memory, streaming, and file-based interfaces |
 | `ShortcutHandlerActivity` | Transparent activity handling app shortcut intents (start/stop tracking) without UI. Delegates to the shared `TrackingControl` helper |

--- a/apps/docs/docs/guides/data-export.md
+++ b/apps/docs/docs/guides/data-export.md
@@ -96,8 +96,8 @@ If several devices export into the same folder and none of the templates include
 - Promotes to a foreground service during export, preventing Android from killing long-running exports
 - Streams data in chunks (10,000 locations at a time) to keep memory usage low even with very large datasets
 - Writes to a temporary file first, then copies to the export directory - if something goes wrong mid-export, you never get a partial or corrupted file
-- After copying, verifies the destination file exists and has the correct size before deleting the temp file
-- If the export loop is cancelled (e.g. by disabling auto-export), it cleans up gracefully without leaving partial files
+- After copying, verifies that every byte of the temp file was written before deleting it. The destination is never queried back, so a folder app that registers the new file late cannot fail the export
+- Switching auto-export off stops a running export without leaving partial files; a file already being copied to the folder is finished first
 - Permanent errors (invalid config, directory access issues) fail immediately; transient errors (I/O failures, a failed database read) retry up to 3 times
 - If the selected directory becomes inaccessible (permissions revoked), auto-export disables itself and a notification prompts you to re-select the directory
 - A notification is shown after each export with the file name and location count

--- a/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportAlarmReceiver.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportAlarmReceiver.kt
@@ -8,19 +8,17 @@ package com.Colota.export
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
 import com.Colota.util.AppLogger
 
 class AutoExportAlarmReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         AppLogger.i(TAG, "Alarm fired")
+        // The alarm is one-shot: re-arm before anything that can fail, or the schedule ends here
+        AutoExportScheduler.scheduleNext(context)
         try {
-            WorkManager.getInstance(context.applicationContext)
-                .enqueue(OneTimeWorkRequestBuilder<AutoExportWorker>().build())
+            AutoExportScheduler.enqueueScheduled(context)
         } catch (e: Exception) {
-            // Next alarm or boot will re-arm; just log so the failure is diagnosable.
             AppLogger.e(TAG, "Failed to enqueue export worker", e)
         }
     }

--- a/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportScheduler.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportScheduler.kt
@@ -59,10 +59,17 @@ object AutoExportScheduler {
         AppLogger.i(TAG, "Enqueued immediate auto-export")
     }
 
+    internal fun enqueueScheduled(context: Context) {
+        WorkManager.getInstance(context.applicationContext)
+            .enqueue(OneTimeWorkRequestBuilder<AutoExportWorker>().build())
+    }
+
     fun cancel(context: Context) {
         val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         am.cancel(pendingIntent(context))
-        AppLogger.i(TAG, "Cancelled auto-export alarm")
+        // WorkManager tags every request with the worker's class name, so this stops a running export too
+        WorkManager.getInstance(context.applicationContext).cancelAllWorkByTag(AutoExportWorker::class.java.name)
+        AppLogger.i(TAG, "Cancelled auto-export alarm and any queued or running export")
     }
 
     private fun pendingIntent(context: Context): PendingIntent {

--- a/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
@@ -138,8 +138,8 @@ class AutoExportWorker(
             Date(exportStartSec * 1000)
         )
 
-        // Write to cache first, then copy to SAF.
-        val tempFile = File(appContext.cacheDir, "auto_export_temp$ext")
+        // Write to cache first, then copy to SAF. One file per run, so two runs can never truncate each other
+        val tempFile = File.createTempFile("auto_export_", ext, appContext.cacheDir)
 
         return try {
             val rowCount = if (config.mode == "incremental" && config.lastExportTimestamp > 0) {
@@ -166,17 +166,7 @@ class AutoExportWorker(
                 return Result.success()
             }
 
-            val tempSize = tempFile.length()
             val destDocFile = copyToSafDirectory(dirUri, fileName, tempFile, config.format)
-
-            val destSize = destDocFile.length()
-            if (!destDocFile.exists() || destSize == 0L) {
-                tempFile.delete()
-                throw IOException("Export verification failed: destination file missing or empty")
-            }
-            if (destSize != tempSize) {
-                AppLogger.w(TAG, "Export size mismatch: temp=$tempSize, dest=$destSize")
-            }
 
             tempFile.delete()
 
@@ -284,12 +274,21 @@ class AutoExportWorker(
             ?.createFile(mimeType, fileName)
             ?: throw DirectoryAccessException("Failed to create file in selected directory")
 
-        resolver.openOutputStream(docFile.uri)?.use { outStream ->
-            sourceFile.inputStream().use { inStream ->
-                inStream.copyTo(outStream)
+        val expected = sourceFile.length()
+        try {
+            val copied = resolver.openOutputStream(docFile.uri)?.use { outStream ->
+                sourceFile.inputStream().use { inStream ->
+                    inStream.copyTo(outStream)
+                }
+            } ?: throw DirectoryAccessException("Failed to open output stream")
+            // Verified by what was written, never by querying the document back: cloud providers report size 0 until synced
+            if (copied != expected) {
+                throw IOException("Export verification failed: copied $copied of $expected bytes")
             }
-        } ?: throw DirectoryAccessException("Failed to open output stream")
-
+        } catch (e: Exception) {
+            docFile.delete()
+            throw e
+        }
         return docFile
     }
 

--- a/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportSchedulerTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportSchedulerTest.kt
@@ -7,10 +7,11 @@ package com.Colota.export
 
 import android.app.AlarmManager
 import android.content.Context
+import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
-import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.Colota.data.DatabaseHelper
 import com.Colota.util.AppLogger
@@ -34,9 +35,9 @@ class AutoExportSchedulerTest {
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
 
-        // scheduleNext calls WorkManager.cancelUniqueWork; needs WorkManager initialized.
+        // A WorkManager whose worker executor never runs, so enqueued work stays unfinished and cancel is observable
         val config = Configuration.Builder()
-            .setExecutor(SynchronousExecutor())
+            .setExecutor { }
             .build()
         WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
 
@@ -100,6 +101,35 @@ class AutoExportSchedulerTest {
             "AlarmManager should have no scheduled alarms after cancel",
             shadowOf(alarmManager).scheduledAlarms.isEmpty()
         )
+    }
+
+    @Test
+    fun `cancel also stops a queued or running export`() {
+        AutoExportScheduler.runNow(context)
+        val wm = WorkManager.getInstance(context)
+        assertFalse(wm.getWorkInfosByTag(AutoExportWorker::class.java.name).get().single().state.isFinished)
+
+        AutoExportScheduler.cancel(context)
+
+        assertEquals(WorkInfo.State.CANCELLED, wm.getWorkInfosByTag(AutoExportWorker::class.java.name).get().single().state)
+    }
+
+    @Test
+    fun `the alarm receiver re-arms the alarm before enqueuing so a failed enqueue cannot end the schedule`() {
+        mockkObject(AutoExportScheduler)
+        every { AutoExportScheduler.enqueueScheduled(any()) } throws RuntimeException("WorkManager not initialized")
+        every { AutoExportScheduler.scheduleNext(any()) } just Runs
+        try {
+            AutoExportAlarmReceiver().onReceive(context, Intent())
+
+            verifyOrder {
+                AutoExportScheduler.scheduleNext(context)
+                AutoExportScheduler.enqueueScheduled(context)
+            }
+            verify { AppLogger.e("AutoExportAlarm", "Failed to enqueue export worker", any()) }
+        } finally {
+            unmockkObject(AutoExportScheduler)
+        }
     }
 
     @Test

--- a/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportWorkerRunTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportWorkerRunTest.kt
@@ -1,0 +1,128 @@
+package com.Colota.export
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.Colota.data.DatabaseHelper
+import com.Colota.util.AppLogger
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+/** The worker end to end against a document tree whose provider reports sizes lazily, as cloud providers do. */
+@RunWith(RobolectricTestRunner::class)
+class AutoExportWorkerRunTest {
+
+    private lateinit var db: DatabaseHelper
+    private lateinit var createdDoc: DocumentFile
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val docUri: Uri = Uri.parse("content://com.colota.test.docs/document/export-1")
+    private val written = ByteArrayOutputStream()
+
+    @Before
+    fun setUp() {
+        resetSingleton()
+        db = DatabaseHelper.getInstance(context)
+
+        mockkObject(AppLogger)
+        every { AppLogger.d(any(), any()) } just Runs
+        every { AppLogger.i(any(), any()) } just Runs
+        every { AppLogger.w(any(), any()) } just Runs
+        every { AppLogger.e(any(), any()) } just Runs
+        every { AppLogger.e(any(), any(), any()) } just Runs
+
+        db.saveSetting("autoExportEnabled", "true")
+        db.saveSetting("autoExportUri", "content://com.colota.test.docs/tree/root")
+        db.saveSetting("autoExportFormat", "csv")
+        db.saveSetting("autoExportMode", "incremental")
+        db.saveSetting("lastAutoExportTimestamp", "1700000000")
+        // Enough rows for the temp file to exceed one copy buffer, so a truncation mid-copy is observable
+        db.writableDatabase.beginTransaction()
+        try {
+            for (i in 0 until 200) db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = 1700000500L + i)
+            db.writableDatabase.setTransactionSuccessful()
+        } finally {
+            db.writableDatabase.endTransaction()
+        }
+
+        createdDoc = mockk<DocumentFile>()
+        every { createdDoc.uri } returns docUri
+        every { createdDoc.name } returns "colota_export.csv"
+        every { createdDoc.exists() } returns false
+        every { createdDoc.length() } returns 0L
+        every { createdDoc.delete() } returns true
+        val tree = mockk<DocumentFile>()
+        every { tree.createFile(any(), any()) } returns createdDoc
+        every { tree.listFiles() } returns emptyArray()
+        mockkStatic(DocumentFile::class)
+        every { DocumentFile.fromTreeUri(any(), any()) } returns tree
+        shadowOf(context.contentResolver).registerOutputStream(docUri, written)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(DocumentFile::class)
+        unmockkObject(AppLogger)
+        db.close()
+        resetSingleton()
+    }
+
+    private fun resetSingleton() {
+        val field = DatabaseHelper::class.java.getDeclaredField("INSTANCE")
+        field.isAccessible = true
+        field.set(null, null)
+    }
+
+    private fun runWorker(): ListenableWorker.Result {
+        val worker = TestListenableWorkerBuilder<AutoExportWorker>(context)
+            .setTags(listOf(AutoExportScheduler.IMMEDIATE_WORK_TAG))
+            .build()
+        return runBlocking { worker.doWork() }
+    }
+
+    @Test
+    fun `an export succeeds on a provider that reports the document size lazily`() {
+        val result = runWorker()
+
+        assertTrue("expected success, got $result", result is ListenableWorker.Result.Success)
+        val csv = written.toString(Charsets.UTF_8.name())
+        assertTrue(csv.startsWith("id,timestamp"))
+        assertTrue(csv.contains("1700000500"))
+        val config = AutoExportConfig.from(db)
+        assertTrue("watermark should advance past the exported rows", config.lastExportTimestamp > 1700000000L)
+        assertEquals("colota_export.csv", config.lastFileName)
+        assertEquals(200, config.lastRowCount)
+        assertTrue("temp file should be gone", context.cacheDir.listFiles { f -> f.name.startsWith("auto_export_") }!!.isEmpty())
+    }
+
+    @Test
+    fun `a copy that delivers fewer bytes than the temp file held is retried, not reported complete`() {
+        // Another writer truncating the temp file under the running copy
+        val truncating = object : OutputStream() {
+            override fun write(b: Int) = Unit
+            override fun write(b: ByteArray, off: Int, len: Int) {
+                context.cacheDir.listFiles { f -> f.name.startsWith("auto_export_") }!!.forEach { it.writeText("") }
+            }
+        }
+        shadowOf(context.contentResolver).registerOutputStream(docUri, truncating)
+
+        val result = runWorker()
+
+        assertTrue("expected retry, got $result", result is ListenableWorker.Result.Retry)
+        val config = AutoExportConfig.from(db)
+        assertEquals(1700000000L, config.lastExportTimestamp)
+        assertTrue("expected the verification error, got ${config.lastError}", config.lastError!!.contains("Export verification failed"))
+        verify { createdDoc.delete() }
+    }
+}

--- a/fastlane/metadata/android/en-US/changelogs/48.txt
+++ b/fastlane/metadata/android/en-US/changelogs/48.txt
@@ -1,3 +1,5 @@
 - Settings are no longer replaced with defaults when the app fails to read them
 - Log exports no longer contain webhook ids or session tokens from the endpoint address
 - Exports stop with an error instead of silently leaving out locations when a database read fails
+- Auto-export no longer fails when the folder app has not registered the new file yet
+- Switching auto-export off stops a running export


### PR DESCRIPTION
The post-copy check asked the folder's provider for the new file's size, which some providers only report later, so exports into such folders failed and retried. The copy is now verified by what was written, a failed copy removes the document, each run gets its own temp file so overlapping runs cannot truncate each other, switching auto-export off stops a running export, and the alarm receiver re-arms the schedule before it enqueues.