### PR TITLE
fix(sync): resolve the private-host check on every call

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -215,7 +215,7 @@ For mTLS-protected endpoints, builds the `HttpsURLConnection` with a custom `SSL
 
 ### UrlSafety
 
-HTTP endpoint policy: HTTPS is required for public hosts, HTTP is only allowed when the host resolves to a private/local address (loopback, RFC 1918 site-local, link-local, or CGNAT 100.64.0.0/10). Resolves hostnames via `InetAddress` so server.local-style mDNS names work, with a per-hostname cache. Pure validation with no transport state, also exposed to the JS bridge for pre-save endpoint checks.
+HTTP endpoint policy: HTTPS is required for public hosts, HTTP is only allowed when the host resolves to a private/local address (loopback, RFC 1918 site-local, link-local, or CGNAT 100.64.0.0/10). Resolves hostnames via `InetAddress` so server.local-style mDNS names work. The lookup runs on every call, so a host that stops resolving to a private address is no longer trusted for plain HTTP after a network change. Pure validation with no transport state, also exposed to the JS bridge for pre-save endpoint checks.
 
 ### ClientCertSslContextProvider
 

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/UrlSafety.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/UrlSafety.kt
@@ -8,7 +8,6 @@ package com.Colota.sync
 import androidx.annotation.VisibleForTesting
 import java.net.InetAddress
 import java.net.URL
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * HTTP endpoint policy: which protocols and hosts the app is willing to talk to.
@@ -16,10 +15,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 object UrlSafety {
 
-    /** Per-hostname cache. Only successful lookups are cached: a failed one must not pin a host as public. */
-    private val privateHostCache = ConcurrentHashMap<String, Boolean>()
-
-    /** Performs DNS resolution and caches a successful lookup. */
+    /** Resolves the host on every call, so a host that stops resolving privately stops being trusted. */
     fun isPrivateEndpoint(endpoint: String): Boolean {
         val host = try {
             URL(endpoint).host ?: return false
@@ -53,7 +49,6 @@ object UrlSafety {
     @VisibleForTesting
     internal fun isPrivateHost(host: String, resolve: (String) -> InetAddress): Boolean {
         if (host == "localhost") return true
-        privateHostCache[host]?.let { return it }
 
         val address = try {
             resolve(host)
@@ -66,12 +61,8 @@ object UrlSafety {
             address.isSiteLocalAddress ||
             address.isLinkLocalAddress ||
             isCgnatAddress(address)
-        privateHostCache[host] = isPrivate
         return isPrivate
     }
-
-    @VisibleForTesting
-    internal fun clearCache() = privateHostCache.clear()
 
     /** Checks if the address falls in the CGNAT range 100.64.0.0/10. */
     private fun isCgnatAddress(address: InetAddress): Boolean {

--- a/apps/mobile/android/app/src/test/java/com/Colota/sync/UrlSafetyTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/sync/UrlSafetyTest.kt
@@ -3,15 +3,9 @@ package com.Colota.sync
 import java.net.InetAddress
 import java.net.UnknownHostException
 import org.junit.Assert.*
-import org.junit.Before
 import org.junit.Test
 
 class UrlSafetyTest {
-
-    @Before
-    fun setUp() {
-        UrlSafety.clearCache()
-    }
 
     // --- isValidProtocol ---
 
@@ -155,32 +149,23 @@ class UrlSafetyTest {
     }
 
     @Test
-    fun `a failed lookup does not pin a LAN host as public for the rest of the process`() {
+    fun `every check re-resolves, so a host that stops resolving privately stops being trusted`() {
+        val host = "nas.moved.test"
+        val lan = InetAddress.getByName("192.168.1.50")
+        val wan = InetAddress.getByName("93.184.216.34")
+
+        assertTrue(UrlSafety.isPrivateHost(host) { lan })
+        assertFalse(UrlSafety.isPrivateHost(host) { wan })
+        assertFalse(UrlSafety.isPrivateHost(host) { throw UnknownHostException(it) })
+        assertTrue(UrlSafety.isPrivateHost(host) { lan })
+    }
+
+    @Test
+    fun `a failed lookup does not stick, the next check resolves again`() {
         val host = "nas.blip.test"
         val lan = InetAddress.getByName("192.168.1.50")
 
         assertFalse(UrlSafety.isPrivateHost(host) { throw UnknownHostException(it) })
-
         assertTrue(UrlSafety.isPrivateHost(host) { lan })
-        assertTrue(UrlSafety.isValidProtocol("http://$host/api"))
-    }
-
-    @Test
-    fun `a resolved host is cached so a later lookup failure cannot flip the verdict`() {
-        val host = "nas.cached.test"
-        val lan = InetAddress.getByName("10.0.0.7")
-
-        assertTrue(UrlSafety.isPrivateHost(host) { lan })
-        assertTrue(UrlSafety.isPrivateHost(host) { throw UnknownHostException(it) })
-    }
-
-    @Test
-    fun `a host that resolves to a public address stays cached as public`() {
-        val host = "tracker.public.test"
-        val wan = InetAddress.getByName("93.184.216.34")
-
-        assertFalse(UrlSafety.isPrivateHost(host) { wan })
-        assertFalse(UrlSafety.isPrivateHost(host) { throw UnknownHostException(it) })
-        assertFalse(UrlSafety.isValidProtocol("http://$host/api"))
     }
 }

--- a/fastlane/metadata/android/en-US/changelogs/48.txt
+++ b/fastlane/metadata/android/en-US/changelogs/48.txt
@@ -6,3 +6,4 @@
 - Auto-export keeps its schedule after a backup restore
 - An aborted backup restore starts tracking again instead of leaving it off
 - Uploads to a local server recover after a temporary DNS failure instead of waiting for an app restart
+- A local server that moves off your network is no longer trusted for unencrypted uploads


### PR DESCRIPTION
The private/public host check kept its answer for the life of the process, so a host that stopped resolving to a private address stayed trusted for plain HTTP after the phone moved networks. The cache is gone and this  also supersedes 90117c7, since a failed lookup can no longer be remembered either.
