### PR TITLE
fix(notifications): make an unexpected stop audible

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -175,7 +175,7 @@ Handles all notification logic for the tracking service:
 - Status text generation (coordinates, sync status, pause zones)
 - Throttled updates (10s minimum interval, 2m minimum movement)
 - Deduplication to avoid unnecessary notification redraws
-- Stopped notification, posted on a deliberate stop and by the tracking watchdog when Android refuses a background restart, in which case tapping it opens the app so the reconciler can resume
+- Stopped notification, posted on a deliberate stop and by the tracking watchdog when Android refuses a background restart, in which case tapping it opens the app so the reconciler can resume. Two channels back it. `location_service_channel` at `IMPORTANCE_LOW` carries the ongoing status and any stop the user asked for; `tracking_stopped_channel` at `IMPORTANCE_DEFAULT` carries the ones they did not, so a killed service is audible instead of sitting silently under the ongoing notification. `buildStoppedNotification` defaults to the silent channel and callers opt in
 
 ### DatabaseHelper
 

--- a/apps/docs/docs/guides/troubleshooting.md
+++ b/apps/docs/docs/guides/troubleshooting.md
@@ -10,6 +10,7 @@ sidebar_position: 4
 - Verify location permissions are set to **Allow all the time**
 - Grant notification permission if you want to see tracking status
 - If the notification disappeared while the app still shows tracking on, Android killed the service. Opening the app restarts it. With battery set to **Unrestricted** it also restarts on its own, usually within 15 to 30 minutes
+- When Colota cannot restart itself it posts a **Tracking stopped** notification instead, and tapping that resumes tracking. It has its own notification channel, so if you never see it, check that **Tracking stopped** is enabled in Android's notification settings for Colota
 
 ## Tracking doesn't start after reboot
 

--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -385,7 +385,8 @@ class LocationForegroundService : Service() {
             ACTION_STATIONARY_HEARTBEAT -> handleStationaryHeartbeatFired()
             ACTION_GEOFENCE_HEARTBEAT -> handleGeofenceHeartbeatFired(shouldBeTracking)
             ACTION_STOP_REQUEST -> stopForegroundServiceWithReason(
-                intent?.getStringExtra(EXTRA_STOP_REASON) ?: "Stopped"
+                intent?.getStringExtra(EXTRA_STOP_REASON) ?: "Stopped",
+                unexpected = false
             )
             else -> handleStart()
         }
@@ -1465,7 +1466,11 @@ class LocationForegroundService : Service() {
         stopForegroundServiceWithReason("Battery below 5% - tracking paused", stoppedByBattery = true)
     }
 
-    private fun stopForegroundServiceWithReason(reason: String, stoppedByBattery: Boolean = false) {
+    private fun stopForegroundServiceWithReason(
+        reason: String,
+        stoppedByBattery: Boolean = false,
+        unexpected: Boolean = true
+    ) {
         if (isStopping) return
         isStopping = true
         AppLogger.i(TAG, "Stopping: $reason")
@@ -1488,7 +1493,7 @@ class LocationForegroundService : Service() {
 
         notificationManager.notify(
             NotificationHelper.STOPPED_NOTIFICATION_ID,
-            notificationHelper.buildStoppedNotification(reason)
+            notificationHelper.buildStoppedNotification(reason, unexpected = unexpected)
         )
 
         stopLocationUpdates()

--- a/apps/mobile/android/app/src/main/java/com/colota/service/NotificationHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/NotificationHelper.kt
@@ -29,6 +29,7 @@ class NotificationHelper(
 
     companion object {
         const val CHANNEL_ID = "location_service_channel"
+        const val STOPPED_CHANNEL_ID = "tracking_stopped_channel"
         const val NOTIFICATION_ID = 1
         const val STOPPED_NOTIFICATION_ID = 2
         const val THROTTLE_MS = 10000L
@@ -45,6 +46,16 @@ class NotificationHelper(
             setShowBadge(false)
         }
         notificationManager.createNotificationChannel(channel)
+
+        val stoppedChannel = NotificationChannel(
+            STOPPED_CHANNEL_ID,
+            "Tracking stopped",
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = "Alerts when tracking stops without you asking it to"
+            setShowBadge(true)
+        }
+        notificationManager.createNotificationChannel(stoppedChannel)
     }
 
     fun buildTrackingNotification(title: String, statusText: String): Notification {
@@ -69,7 +80,11 @@ class NotificationHelper(
     fun buildTitle(activeProfileName: String?): String =
         if (activeProfileName != null) "Colota \u00b7 $activeProfileName" else "Colota Tracking"
 
-    fun buildStoppedNotification(reason: String): Notification {
+    /**
+     * @param unexpected a stop the user did not ask for, which alerts. Anything else stays on the
+     * silent tracking channel, so a caller has to opt in rather than inherit the alert.
+     */
+    fun buildStoppedNotification(reason: String, unexpected: Boolean = false): Notification {
         // Opening the app is the recovery path when the watchdog cannot restart the service
         // itself, so this notification has to be tappable.
         val pendingIntent = PendingIntent.getActivity(
@@ -79,12 +94,17 @@ class NotificationHelper(
             PendingIntent.FLAG_IMMUTABLE
         )
 
-        return NotificationCompat.Builder(context, CHANNEL_ID)
-            .setContentTitle("Colota: Stopped")
+        return NotificationCompat.Builder(
+            context,
+            if (unexpected) STOPPED_CHANNEL_ID else CHANNEL_ID
+        )
+            .setContentTitle("Tracking stopped")
             .setContentText(reason)
             .setSmallIcon(android.R.drawable.ic_lock_power_off)
             .setOngoing(false)
             .setAutoCancel(true)
+            // Silences the watchdog's 15-minute re-post while this one still shows. Dismissing it
+            // starts a fresh post, which alerts again: tracking is still down and a tap is the fix.
             .setOnlyAlertOnce(true)
             .setContentIntent(pendingIntent)
             .build()

--- a/apps/mobile/android/app/src/main/java/com/colota/service/TrackingWatchdogReceiver.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/TrackingWatchdogReceiver.kt
@@ -58,7 +58,7 @@ class TrackingWatchdogReceiver : BroadcastReceiver() {
                 AppLogger.e(TAG, "Watchdog restart failed (${e.javaClass.simpleName})", e)
                 // Tracking can run with notifications denied, so the tap-to-resume fallback
                 // is not always available. Say so rather than assume the user was told.
-                if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+                if (canPromptToResume(context)) {
                     notifyTapToResume(context)
                 } else {
                     AppLogger.w(TAG, "Cannot prompt to resume either - notifications are denied")
@@ -71,6 +71,14 @@ class TrackingWatchdogReceiver : BroadcastReceiver() {
         }
     }
 
+    /** App permission is not enough: the stop notification has its own channel, blockable alone. */
+    private fun canPromptToResume(context: Context): Boolean {
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) return false
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = manager.getNotificationChannel(NotificationHelper.STOPPED_CHANNEL_ID)
+        return channel == null || channel.importance != NotificationManager.IMPORTANCE_NONE
+    }
+
     private fun notifyTapToResume(context: Context) {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -78,7 +86,7 @@ class TrackingWatchdogReceiver : BroadcastReceiver() {
             it.createChannel()
             notificationManager.notify(
                 NotificationHelper.STOPPED_NOTIFICATION_ID,
-                it.buildStoppedNotification("Tracking service was killed - tap to resume")
+                it.buildStoppedNotification("Tracking service was killed - tap to resume", unexpected = true)
             )
         }
     }

--- a/apps/mobile/android/app/src/main/java/com/colota/triggers/BootReceiver.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/triggers/BootReceiver.kt
@@ -113,7 +113,12 @@ class LocationBootReceiver : BroadcastReceiver() {
                         notificationHelper.createChannel()
                         notificationManager.notify(
                             NotificationHelper.STOPPED_NOTIFICATION_ID,
-                            notificationHelper.buildStoppedNotification("Battery below 5% - tracking paused")
+                            // Re-announced after a reboot, but the user still has tracking off
+                            // without asking for it, so it alerts like the original stop did.
+                            notificationHelper.buildStoppedNotification(
+                                "Battery below 5% - tracking paused",
+                                unexpected = true
+                            )
                         )
                     }
                 }

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/LocationForegroundServiceTest.kt
@@ -2221,6 +2221,21 @@ class LocationForegroundServiceTest {
     // =========================================================================
 
     @Test
+    fun `a stop request from a shortcut or automation does not alert`() = runServiceTest {
+        service.onStartCommand(intentFor(LocationForegroundService.ACTION_STOP_REQUEST), 0, 1)
+        advanceUntilIdle()
+
+        verify { notificationHelper.buildStoppedNotification(any(), false) }
+    }
+
+    @Test
+    fun `a stop the user did not ask for alerts`() {
+        invokeStopWithReason("Location permission missing", false)
+
+        verify { notificationHelper.buildStoppedNotification("Location permission missing", true) }
+    }
+
+    @Test
     fun `stopForBattery clears active profile event`() {
         every { profileManager.getActiveProfileName() } returns "Charging"
 
@@ -2686,12 +2701,19 @@ class LocationForegroundServiceTest {
         method.invoke(service, location)
     }
 
-    private fun invokeStopWithReason(reason: String, stoppedByBattery: Boolean) {
+    private fun invokeStopWithReason(
+        reason: String,
+        stoppedByBattery: Boolean,
+        unexpected: Boolean = true
+    ) {
         val method = LocationForegroundService::class.java.getDeclaredMethod(
-            "stopForegroundServiceWithReason", String::class.java, Boolean::class.javaPrimitiveType
+            "stopForegroundServiceWithReason",
+            String::class.java,
+            Boolean::class.javaPrimitiveType,
+            Boolean::class.javaPrimitiveType
         )
         method.isAccessible = true
-        method.invoke(service, reason, stoppedByBattery)
+        method.invoke(service, reason, stoppedByBattery, unexpected)
     }
 
     private fun invokeOnBatteryCritical() {

--- a/apps/mobile/android/app/src/test/java/com/Colota/service/NotificationHelperTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/NotificationHelperTest.kt
@@ -16,6 +16,49 @@ import org.junit.Test
  */
 class NotificationHelperTest {
 
+    // --- channel routing (Robolectric: a real Notification, so the channel can be read back) ---
+
+    @org.junit.runner.RunWith(org.robolectric.RobolectricTestRunner::class)
+    class ChannelRouting {
+        private fun helperFor(): Pair<NotificationHelper, android.app.NotificationManager> {
+            val ctx = org.robolectric.RuntimeEnvironment.getApplication()
+            val nm = ctx.getSystemService(android.app.NotificationManager::class.java)
+            return NotificationHelper(ctx, nm) to nm
+        }
+
+        @Test
+        fun `an unexpected stop goes to the alerting channel`() {
+            val (helper, _) = helperFor()
+            helper.createChannel()
+
+            val n = helper.buildStoppedNotification("killed", unexpected = true)
+
+            assertEquals(NotificationHelper.STOPPED_CHANNEL_ID, n.channelId)
+        }
+
+        @Test
+        fun `a stop the user asked for stays on the silent tracking channel`() {
+            val (helper, _) = helperFor()
+            helper.createChannel()
+
+            val n = helper.buildStoppedNotification("stopped via shortcut", unexpected = false)
+
+            assertEquals(NotificationHelper.CHANNEL_ID, n.channelId)
+        }
+
+        @Test
+        fun `the alerting channel can actually alert and the tracking channel cannot`() {
+            val (helper, nm) = helperFor()
+            helper.createChannel()
+
+            val tracking = nm.getNotificationChannel(NotificationHelper.CHANNEL_ID)
+            val stopped = nm.getNotificationChannel(NotificationHelper.STOPPED_CHANNEL_ID)
+
+            assertEquals(android.app.NotificationManager.IMPORTANCE_LOW, tracking.importance)
+            assertEquals(android.app.NotificationManager.IMPORTANCE_DEFAULT, stopped.importance)
+        }
+    }
+
     private lateinit var helper: NotificationHelper
 
     @Before

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -1,0 +1,1 @@
+- A notification now alerts you when tracking stops on its own, instead of appearing silently


### PR DESCRIPTION
A stop the user did not trigger went out on the ongoing tracking channel at IMPORTANCE_LOW, so it was silent, unbadged and sat under the notification that had been there all along. For anyone not exempt from battery optimisation that notification is the recovery path: the watchdog cannot restart the service itself and only a tap can.

Those stops get their own  MPORTANCE_DEFAULT channel. The builder defaults to the silent one so a caller opts in, and a stop requested by shortcut or automation stays quiet. The watchdog now checks that channel is not blocked before claiming it prompted, which app-level permission no longer tells it.