### PR TITLE
fix(export): let retention recognise the files auto-export wrote

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
@@ -298,7 +298,10 @@ class AutoExportWorker(
      * testable without SAF.
      */
     private fun cleanupOldExports(dirUri: Uri, config: AutoExportConfig) {
-        if (config.retentionCount <= 0) return // 0 = unlimited
+        if (config.retentionCount <= 0) {
+            AppLogger.d(TAG, "Export cleanup skipped - retention is unlimited")
+            return
+        }
 
         try {
             val dir = DocumentFile.fromTreeUri(appContext, dirUri) ?: return
@@ -306,17 +309,17 @@ class AutoExportWorker(
 
             // Each DocumentFile getter is its own query, so only the names that already match pay
             // for lastModified and isFile. A shared folder can hold far more files than ours.
-            val candidates = dir.listFiles()
+            val listed = dir.listFiles()
+            val candidates = listed
                 .map { it to it.name.orEmpty() }
                 .filter { (_, name) -> matchers.any { it.matches(name) } }
                 .map { (file, name) ->
                     file to ExportConverters.ExportEntry(name, file.lastModified(), file.isFile)
                 }
-            val doomed = ExportConverters
+            val selected = ExportConverters
                 .selectForDeletion(candidates.map { it.second }, config.retentionCount, matchers)
                 .map { it.name }
-                .toMutableList()
-            if (doomed.isEmpty()) return
+            val doomed = selected.toMutableList()
 
             var deleted = 0
             candidates.forEach { (file, entry) ->
@@ -330,7 +333,13 @@ class AutoExportWorker(
                 }
             }
 
-            AppLogger.i(TAG, "Cleaned up $deleted old export files (keeping ${config.retentionCount})")
+            // Logged on every run, zeros included: a cleanup that recognised none of its own files
+            // is otherwise indistinguishable from one that found nothing to delete.
+            AppLogger.i(
+                TAG,
+                "Export cleanup: ${listed.size} in folder, ${candidates.size} matched, " +
+                    "${selected.size} selected, $deleted deleted (keeping ${config.retentionCount})"
+            )
         } catch (e: Exception) {
             AppLogger.w(TAG, "Export cleanup failed (non-critical): ${e.message}")
         }

--- a/apps/mobile/android/app/src/main/java/com/colota/export/ExportConverters.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/ExportConverters.kt
@@ -203,9 +203,14 @@ object ExportConverters {
         return ExportFileMatcher(Regex(pattern.toString()), dateGroup, timeGroup)
     }
 
+    // A SAF provider appends the canonical extension for the MIME it was given when the name does
+    // not already end in one, so files written before the geo+json fix are named ".geojson.json".
+    private const val PROVIDER_SUFFIX_PATTERN = "(?:\\.json|\\.xml|\\.txt)?"
+
     // lazy so it does not depend on where extensionFor's format objects sit in the init order.
     private val EXTENSION_PATTERN: String by lazy {
-        listOf("csv", "geojson", "gpx", "kml").joinToString("|", "(?:", ")") { Regex.escape(extensionFor(it)) }
+        listOf("csv", "geojson", "gpx", "kml").joinToString("|", "(?:", ")") { Regex.escape(extensionFor(it)) } +
+            PROVIDER_SUFFIX_PATTERN
     }
 
     /** The rendered name is trimmed at both ends, so the outermost literals are trimmed too. */
@@ -370,7 +375,7 @@ object ExportConverters {
 
     // The whole export is one MultiPoint feature: coords stream inline while the property columns
     // (parallel arrays, index-aligned to coords) spool to disk and splice in at the footer, keeping memory O(1).
-    private object GeoJsonFormat : FormatWriter(".geojson", "application/json") {
+    private object GeoJsonFormat : FormatWriter(".geojson", "application/geo+json") {
         private val COLUMNS = listOf("accuracy", "altitude", "speed", "bearing", "battery", "battery_status", "note", "time")
 
         override fun newSideChannel(cacheDir: File): AutoCloseable = GeoJsonColumnSpooler(cacheDir, COLUMNS)

--- a/apps/mobile/android/app/src/test/java/com/Colota/export/ExportConvertersTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/export/ExportConvertersTest.kt
@@ -48,7 +48,7 @@ class ExportConvertersTest {
     @Test
     fun `mimeTypeFor returns correct mime types`() {
         assertEquals("text/csv", ExportConverters.mimeTypeFor("csv"))
-        assertEquals("application/json", ExportConverters.mimeTypeFor("geojson"))
+        assertEquals("application/geo+json", ExportConverters.mimeTypeFor("geojson"))
         assertEquals("application/gpx+xml", ExportConverters.mimeTypeFor("gpx"))
         assertEquals("application/vnd.google-earth.kml+xml", ExportConverters.mimeTypeFor("kml"))
         assertEquals("text/plain", ExportConverters.mimeTypeFor("unknown"))

--- a/apps/mobile/android/app/src/test/java/com/Colota/export/ExportFilenameTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/export/ExportFilenameTest.kt
@@ -155,6 +155,16 @@ class ExportFilenameTest {
     }
 
     @Test
+    fun `matcher accepts the extension a provider appends for the file's mime type`() {
+        // A provider that was handed application/json for a .geojson file appends .json, and the
+        // matcher then recognises none of the files it wrote - retention deletes nothing, forever.
+        assertTrue(defaultMatcher.matches("colota_export_2026-05-20_0815.geojson.json"))
+        assertTrue(defaultMatcher.matches("colota_export_2026-05-20_0815 (1).geojson.json"))
+        assertTrue(defaultMatcher.matches("colota_export_2026-05-20_0815.gpx.xml"))
+        assertFalse(defaultMatcher.matches("colota_export_2026-05-20_0815.geojson.zip"))
+    }
+
+    @Test
     fun `matcher rejects a directory sharing the marker`() {
         assertFalse(defaultMatcher.matches("colota_exports"))
         assertFalse(defaultMatcher.matches("colota_export_archive"))

--- a/apps/mobile/src/utils/fileFormats.ts
+++ b/apps/mobile/src/utils/fileFormats.ts
@@ -28,7 +28,7 @@ export const FILE_FORMATS: Record<ImportFormat, FileFormat> = {
     icon: Globe,
     extension: ".geojson",
     exportable: true,
-    mimeType: "application/json",
+    mimeType: "application/geo+json",
     subtitle: "Geographic Data",
     description: "Mapbox, Leaflet, QGIS. Best for backups - re-imports into Colota without losing data."
   },

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -1,1 +1,2 @@
 - A notification now alerts you when tracking stops on its own, instead of appearing silently
+- Auto-export now deletes old files on storage providers that rename them


### PR DESCRIPTION
GeoJSON went out as application/json while the name ended in .geojson, so  the provider appended .json to match. EXTENSION_PATTERN is a full match on the four known extensions, so retention recognised none of its own files and deleted nothing, in silence.

GeoJSON is now application/geo+json. The matcher tolerates a trailing .json, .xml or .txt as well, or the files earlier versions orphaned stay orphaned.

Cleanup logs its counts on every run. It only logged after a deletion, so a run that recognised nothing looked like a run with nothing to do.

Closes #649 