### PR TITLE
docs: fix stale screen paths and rename the gps settings page

### DIFF
--- a/apps/docs/docs/configuration/field-mapping.md
+++ b/apps/docs/docs/configuration/field-mapping.md
@@ -45,12 +45,12 @@ You can rename any field to match your backend. For example:
 }
 ```
 
-Configure field names in **Settings > API Settings > Field Mapping**.
+Configure field names in **Settings → API Field Mapping → Field Mappings**.
 
 ## Custom Static Fields
 
 Add arbitrary key-value pairs that are included in every API payload. For example, adding `_type: "location"` for OwnTracks-compatible backends.
 
-Configure in **Settings > API Settings > Custom Fields**.
+Configure in **Settings → API Field Mapping → Custom Fields**.
 
 **Note:** Custom field values are always sent as strings. Custom fields are added to the payload before location fields - if a custom field key matches a location field key, the location field takes precedence.

--- a/apps/docs/docs/configuration/tracking-settings.md
+++ b/apps/docs/docs/configuration/tracking-settings.md
@@ -2,16 +2,26 @@
 sidebar_position: 2
 ---
 
-# GPS Settings
+# Tracking Settings
+
+Found under **Settings → Tracking & Sync → Tracking Configuration**.
 
 ## Available Settings
 
-| Setting            | Description                          | Default   | Range      |
-| ------------------ | ------------------------------------ | --------- | ---------- |
-| Tracking Interval  | Time between GPS fixes               | 5 seconds | 1s - hours |
-| Movement Threshold | Minimum movement to trigger update   | 0 meters  | 0m - 1000m |
-| Accuracy Threshold | Filter out fixes above this accuracy | 50 meters | 1m - 1000m |
-| Filter Inaccurate  | Enable/disable accuracy filtering    | Disabled  | On/Off     |
+| Setting            | Description                          | Default   | Minimum |
+| ------------------ | ------------------------------------ | --------- | ------- |
+| Tracking Interval  | Time between GPS fixes               | 5 seconds | 1s      |
+| Movement Threshold | Minimum movement to trigger update   | 0         | 0       |
+| Accuracy Threshold | Filter out fixes above this accuracy | 50        | 1       |
+| Filter Inaccurate  | Enable/disable accuracy filtering    | Disabled  | On/Off  |
+
+The two distance settings use whichever unit you picked in **Settings → Appearance**, so they read as meters or feet. There is no upper limit on any of the three numbers.
+
+:::info[Tracking profiles override two of these]
+
+If a [tracking profile](/docs/guides/tracking-profiles) is active, it supplies its own tracking interval and movement threshold for as long as its condition holds. The values on this screen are what the app falls back to when no profile applies, so a profile is the usual reason fixes arrive at a different rate than the one set here.
+
+:::
 
 ## Tracking Interval
 
@@ -23,10 +33,10 @@ How often the app requests a GPS fix. Shorter intervals give denser track points
 
 ## Movement Threshold
 
-Only records a new location if you've moved at least this many meters since the last recorded point. Useful for filtering out stationary noise.
+Only records a new location if you've moved at least this far since the last recorded point. Useful for filtering out stationary noise.
 
-- **0m**: Record every GPS fix (default)
-- **10-50m**: Skip stationary updates, good for daily use
+- **0**: Record every GPS fix (default)
+- **10-50 m**: Skip stationary updates, good for daily use
 
 ## Accuracy Filter
 
@@ -42,6 +52,8 @@ Some GPS chips occasionally emit a single fix that's far off (10s of km) with a 
 
 Colota drops these automatically by comparing the chip's reported speed against the speed implied by the distance and time since the previous fix. When the two disagree by a wide margin, the fix is discarded. The filter is always on, has no user setting, and only triggers on this specific glitch pattern - normal travel passes through because the chip-reported and implied speeds agree closely.
 
-## Stationary Detection
+## See also
 
-Stationary detection is available through [tracking profiles](/docs/guides/tracking-profiles) (stationary condition) and [geofence zones](/docs/guides/geofencing) (pause when motionless). See those guides for configuration details.
+- [Sync Presets](sync-presets.md) - how often the queue is flushed to your server, and on which connections
+- [Tracking Profiles](/docs/guides/tracking-profiles) - switch interval and movement threshold automatically on charging, speed or a stationary phone
+- [Geofencing](/docs/guides/geofencing) - pause GPS entirely inside a zone

--- a/apps/docs/docs/faq.md
+++ b/apps/docs/docs/faq.md
@@ -10,11 +10,11 @@ No. The app stores location history locally. Server sync is optional.
 
 ### What data does the app send?
 
-Only GPS data (coordinates, accuracy, altitude, speed, bearing, battery status, timestamp) to your configured server. Nothing else. No analytics, no telemetry.
+Only GPS data to your configured server: coordinates, accuracy, altitude, speed, bearing, battery status and timestamp, plus any [custom fields](/docs/configuration/field-mapping) you add yourself. The only other outbound traffic is map tile requests to the tile server set in **Settings → Appearance**.
 
 ### Is this compatible with Google Timeline?
 
-No, but you can use [Dawarich](/docs/integrations/dawarich) or a custom backend for similar functionality.
+You can import your Google Timeline history into Colota, both the legacy Takeout `Records.json` and the new on-device export from Android Settings (see [Data Import](/docs/guides/data-import)), and browse it in the app under **History** on the Map and Trips tabs, but Colota has no web interface and never sends anything back to Google, so pair it with one of the [supported backends](/docs/integrations/overview) if you want a browser view.
 
 ### Does this work without Google Play Services?
 
@@ -40,15 +40,19 @@ To ensure modifications stay open source, especially server-side components.
 
 ### How accurate is the tracking?
 
-3-10 meters in open sky, 10-50 meters in urban areas. The [accuracy filter](/docs/configuration/gps-settings#accuracy-filter) helps remove poor fixes.
+3-10 meters in open sky, 10-50 meters in urban areas. The [accuracy filter](/docs/configuration/tracking-settings#accuracy-filter) helps remove poor fixes.
 
 ### Can I use maps without internet?
 
-Yes. Go to **Settings > Offline Maps** to download map areas to your device. Pan and zoom the map to frame the area you want, give it a name, and tap **Download Area**. Downloaded tiles persist across app restarts and work without any network connection. See [Offline Maps](/docs/guides/offline-maps) for details.
+Yes. Go to **Settings → Offline Maps** to download map areas to your device. Pan and zoom the map to frame the area you want, give it a name, and tap **Download**. Downloaded tiles persist across app restarts and work without any network connection. See [Offline Maps](/docs/guides/offline-maps) for details.
 
 ### Can I export my location history?
 
-Yes. Tap **Export** on the Dashboard to export in CSV, GeoJSON, GPX, or KML. See [Data Export](/docs/guides/data-export) for details.
+Yes. Go to **Settings → Export Locations** to export in CSV, GeoJSON, GPX or KML, or export a single day's trips from the **History** tab. **Settings → Auto-Export** writes the same formats to a folder you pick on a daily, weekly or monthly schedule. See [Data Export](/docs/guides/data-export) for details.
+
+### Can I import location history from another app?
+
+Yes. Go to **Settings → Import Locations** and pick a file. Colota reads GeoJSON, Google Timeline (both the legacy Takeout export and the new on-device one), GPX, KML and CSV, detects the format itself, and shows a preview with the duplicate and invalid counts before anything is written. Imports are additive and duplicates are skipped, so re-importing the same file changes nothing. See [Data Import](/docs/guides/data-import) for details.
 
 ### Can I back up everything and move to a new device?
 
@@ -64,7 +68,11 @@ Yes. Restore is replace-everything: locations, settings, geofences and credentia
 
 ### What happens when the phone restarts?
 
-Colota resumes tracking after a restart if tracking was active before it. There is no setting for this. If it does not resume, see [Troubleshooting](guides/troubleshooting.md).
+Colota resumes tracking after a restart if tracking was active before it. There is no setting for this. If it does not resume, see [Troubleshooting](/docs/guides/troubleshooting).
+
+### Why does tracking stop when the screen is off?
+
+Android is suspending the app to save power. Exempt Colota from battery optimization (the app prompts for this during setup), and on Samsung, Xiaomi, Huawei, Oppo, Vivo and OnePlus devices also allow it to run in the background in the manufacturer's own power menu, which is separate from the Android setting. See [Battery Optimization](/docs/guides/battery-optimization) and [Troubleshooting](/docs/guides/troubleshooting) for the per-manufacturer steps.
 
 ### How much battery does it use?
 
@@ -93,10 +101,10 @@ On Android 17+, apps need the Local Network Access permission to connect to loca
 
 ### Does Colota support mutual TLS (mTLS)?
 
-Yes. Import a PKCS12 (`.p12` / `.pfx`) bundle in **Settings -> Connection -> Authentication & Headers -> Client Certificate (mTLS)**. The private key is stored in the OS keystore and the password isn't saved. For self-signed server certificates, import a CA in the same screen so trust is scoped to Colota only - no need to install a CA at the OS level. See the [mTLS guide](/docs/configuration/mtls) for details.
+Yes. Import a PKCS12 (`.p12` / `.pfx`) bundle in **Settings → Connection → Authentication & Headers → Client Certificate (mTLS)**. The private key is stored in the OS keystore and the password isn't saved. For self-signed server certificates, import a CA in the same screen so trust is scoped to Colota only - no need to install a CA at the OS level. See the [mTLS guide](/docs/configuration/mtls) for details.
 
 ### I was using a CA installed in Android Settings for Colota - does it still work?
 
-No, not anymore. As of this release, Colota only trusts system CAs and an optional CA you import in-app via mTLS Settings - user-installed device CAs are deliberately ignored. If sync starts failing with `Server certificate is not trusted...` after upgrading, you'll need to re-import your CA through the new in-app screen.
+No, not since 1.9.0. Colota only trusts system CAs and an optional CA you import in-app via mTLS Settings - user-installed device CAs are deliberately ignored. If sync starts failing with `Server certificate is not trusted...` after upgrading, you'll need to re-import your CA through the new in-app screen.
 
-The migration is one-time: open Colota -> Settings -> Connection -> Authentication & Headers -> Client Certificate (mTLS) -> Trusted Server CA -> Import CA. The same `.crt` / `.pem` you originally installed in Android Settings works. See [Migrating from earlier behavior](/docs/configuration/mtls#trusting-a-privateinternal-server-ca) for the full walkthrough.
+The migration is one-time: open Colota → Settings → Connection → Authentication & Headers → Client Certificate (mTLS) → Trusted Server CA → Import CA. The same `.crt` / `.pem` you originally installed in Android Settings works. See [Migrating from earlier behavior](/docs/configuration/mtls#trusting-a-privateinternal-server-ca) for the full walkthrough.

--- a/apps/docs/docs/getting-started/quick-start.md
+++ b/apps/docs/docs/getting-started/quick-start.md
@@ -21,7 +21,7 @@ The app works completely offline. Server setup is optional.
 
 ## Next Steps
 
-- [Configure GPS settings](/docs/configuration/gps-settings) to adjust tracking intervals
+- [Configure tracking settings](/docs/configuration/tracking-settings) to adjust tracking intervals
 - [Set up a server](/docs/configuration/server-settings) to sync location data
 - [Create geofences](/docs/guides/geofencing) to save battery at home or work
 - [Battery optimization tips](/docs/guides/battery-optimization) to reduce power usage

--- a/apps/docs/docs/guides/data-export.md
+++ b/apps/docs/docs/guides/data-export.md
@@ -25,14 +25,17 @@ Data Export produces shareable, human-readable formats (CSV, GeoJSON, GPX, KML) 
 
 ### Bulk Export
 
-1. Go to **Data Management**
-2. Tap **Export Data**
-3. Select the format
-4. Share the exported file via Android's share menu
+1. Go to **Settings → Export Locations**
+2. Select a format
+3. Tap **Export** and share the file via Android's share menu
+
+Bulk export always covers your full history. To export a subset, use the trip export below.
+
+For exports on a schedule instead of on demand, see [Scheduled Export](#scheduled-export-auto-export).
 
 ### Trip Export
 
-Go to **Location History** -> **Trips** tab. There are two ways to export:
+Go to the **History** tab → **Trips**. There are two ways to export:
 
 - **All trips for the day** - tap **Export All** in the header, pick a format, share.
 - **A custom selection** - long-press any trip card to enter selection mode. Tap additional cards to add or remove them. Use **Select all** to grab every trip. Tap the share icon in the selection header, pick a format, share. Works for a single trip too.
@@ -53,7 +56,7 @@ Automatically export your location data on a schedule without opening the app.
 
 ### Setup
 
-1. Go to **Settings > Auto-Export**
+1. Go to **Settings → Auto-Export**
 2. Select an export directory (files are saved there via Android's Storage Access Framework)
 3. Choose a format (CSV, GeoJSON, GPX, or KML)
 4. Set the frequency: **Daily**, **Weekly**, or **Monthly**

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -59,6 +59,7 @@ const config: Config = {
       {
         redirects: [
           { from: "/docs/guides/app-shortcuts", to: "/docs/guides/automation" },
+          { from: "/docs/configuration/gps-settings", to: "/docs/configuration/tracking-settings" },
           // Short, shareable install URL. The docs page is the single source for install channels.
           { from: "/download", to: "/docs/getting-started/installation" }
         ]

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -17,7 +17,7 @@ const sidebars: SidebarsConfig = {
       label: "Configuration",
       items: [
         "configuration/sync-presets",
-        "configuration/gps-settings",
+        "configuration/tracking-settings",
         "configuration/server-settings",
         "configuration/field-mapping",
         "configuration/authentication",


### PR DESCRIPTION
The FAQ pointed at a  Dashboard export button and a Data Management export step that neither existed anymore, said Google Timeline was unsupported when import has handled both schemas since 1.9.0, and dated the CA trust change to "this release". Field mapping named a screen called API Settings.

The GPS Settings page is renamed to Tracking Settings to match Settings -> Tracking & Sync -> Tracking Configuration in the app, its Range column is dropped because no upper bound is enforced anywhere, and it now says that an active tracking profile supplies its own interval and movement threshold. Old URL keeps working via a client redirect.

Adds FAQ entries for import and for tracking stopping under battery optimization.