### PR TITLE
feat(theme): tonal palette, radius, spacing, motion and type roles

### DIFF
--- a/apps/docs/src/components/DeepLinkGenerator.module.css
+++ b/apps/docs/src/components/DeepLinkGenerator.module.css
@@ -113,7 +113,7 @@
 
 .removeBtn:hover {
   opacity: 1;
-  color: #e53e3e;
+  color: var(--colota-error);
 }
 
 .addBtn {
@@ -221,7 +221,7 @@
 
 .copyBtn {
   background: var(--ifm-color-primary);
-  color: #fff;
+  color: var(--colota-on-primary);
 }
 
 .copyBtn:hover {
@@ -242,8 +242,8 @@
   display: flex;
   justify-content: center;
   padding: 1rem;
-  background: #fff;
-  border-radius: 8px;
+  background: var(--colota-card-bg);
+  border-radius: var(--colota-card-radius);
   margin-top: 0.75rem;
 }
 

--- a/apps/docs/src/theme/Root.tsx
+++ b/apps/docs/src/theme/Root.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react"
-import { lightColors, darkColors, fontFamily } from "@colota/shared"
+import { lightColors, darkColors, fontFamily, radius } from "@colota/shared"
 import type { ThemeColors } from "@colota/shared"
 
 function colorVars(colors: ThemeColors) {
@@ -14,9 +14,6 @@ function colorVars(colors: ThemeColors) {
     --ifm-color-primary-dark: ${colors.primaryDark};
     --ifm-color-primary-darker: ${colors.primaryDark};
     --ifm-color-primary-darkest: ${colors.primaryDark};
-    --ifm-color-primary-light: ${colors.primaryLight};
-    --ifm-color-primary-lighter: ${colors.primaryLight};
-    --ifm-color-primary-lightest: ${colors.primaryLight};
     --ifm-background-color: ${colors.background};
     --ifm-font-color-base: ${colors.text};
     --ifm-font-color-secondary: ${colors.textSecondary};
@@ -24,8 +21,11 @@ function colorVars(colors: ThemeColors) {
     --ifm-font-family-base: '${fontFamily}', system-ui, -apple-system, sans-serif;
     --colota-card-bg: ${colors.card};
     --colota-card-elevated-bg: ${colors.cardElevated};
+    --colota-well: ${colors.well};
     --colota-border: ${colors.border};
-    --colota-card-radius: 12px;
+    --colota-error: ${colors.error};
+    --colota-on-primary: ${colors.textOnPrimary};
+    --colota-card-radius: ${radius.sm}px;
     --colota-card-padding: 16px;
   `
 }

--- a/apps/mobile/src/components/features/dashboard/__tests__/ConnectionStatus.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/ConnectionStatus.test.tsx
@@ -4,17 +4,7 @@ import { DeviceEventEmitter } from "react-native"
 
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      success: "#22c55e",
-      error: "#ef4444",
-      warning: "#f59e0b",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      text: "#000",
-      card: "#fff",
-      border: "#e5e7eb",
-      pressedOpacity: 0.6
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
@@ -21,22 +21,7 @@ jest.mock("@react-navigation/native", () => ({
 
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#d1d5db",
-      card: "#fff",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      background: "#fff",
-      border: "#e5e7eb",
-      borderRadius: 12,
-      success: "#22c55e",
-      error: "#ef4444",
-      link: "#0d9488",
-      textLight: "#9ca3af"
-    },
+    colors: require("@colota/shared").lightColors,
     mode: "light"
   })
 }))

--- a/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
@@ -11,17 +11,7 @@ jest.mock("../../../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      success: "#22c55e",
-      info: "#3b82f6",
-      card: "#fff",
-      border: "#e5e7eb"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/features/inspector/__tests__/LocationTable.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/LocationTable.test.tsx
@@ -9,10 +9,6 @@ jest.mock("../../../../utils/geo", () => ({
   getSpeedUnit: jest.fn(() => ({ factor: 3.6, unit: "km/h" }))
 }))
 
-jest.mock("../../../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
-}))
-
 import { LocationTable } from "../LocationTable"
 
 const mockColors = {

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -62,10 +62,6 @@ jest.mock("../../map/MapCenterButton", () => ({
   MapCenterButton: () => null
 }))
 
-jest.mock("../../../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
-}))
-
 jest.mock("../../../../utils/geo", () => ({
   getSpeedUnit: () => ({ factor: 3.6, unit: "km/h" })
 }))

--- a/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
@@ -15,10 +15,6 @@ jest.mock("../../../../utils/trips", () => ({
   computeTripStats: () => ({ avgSpeed: 0, elevationGain: 0, elevationLoss: 0 })
 }))
 
-jest.mock("../../../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
-}))
-
 jest.mock("../../../../utils/exportConverters", () => ({
   EXPORT_FORMATS: {
     csv: { label: "CSV" },
@@ -31,17 +27,7 @@ jest.mock("../../../../utils/exportConverters", () => ({
 
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#9ca3af",
-      border: "#e5e7eb",
-      card: "#fff",
-      cardElevated: "#f9fafb",
-      error: "#ef4444",
-      pressedOpacity: 0.7
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/features/map/__tests__/mapUtils.test.ts
+++ b/apps/mobile/src/components/features/map/__tests__/mapUtils.test.ts
@@ -9,14 +9,7 @@ import {
   darkifyStyle
 } from "../mapUtils"
 import { haversine as haversineDistance } from "../../../../utils/geo"
-
-// Only the color keys used by mapUtils functions
-const colors = {
-  success: "#2E7D32",
-  warning: "#C2410C",
-  error: "#D32F2F",
-  info: "#1976D2"
-} as any
+import { lightColors as colors } from "@colota/shared"
 
 // ============================================================================
 // lerpColor

--- a/apps/mobile/src/components/features/settings/__tests__/MtlsSection.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/MtlsSection.test.tsx
@@ -20,18 +20,7 @@ jest.mock("../../../index", () => {
 
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      text: "#000",
-      textSecondary: "#666",
-      textLight: "#999",
-      background: "#fff",
-      border: "#ddd",
-      placeholder: "#999",
-      error: "#f00",
-      warning: "#f80",
-      success: "#0a0",
-      pressedOpacity: 0.7
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/features/settings/__tests__/PresetOption.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/PresetOption.test.tsx
@@ -4,16 +4,7 @@ import { TRACKING_PRESETS } from "../../../../types/global"
 
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      success: "#22c55e",
-      warning: "#f59e0b",
-      border: "#e5e7eb"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
@@ -11,17 +11,7 @@ jest.mock("../../../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      success: "#22c55e",
-      warning: "#f59e0b",
-      error: "#ef4444",
-      info: "#3b82f6",
-      card: "#fff",
-      border: "#e5e7eb"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
@@ -4,16 +4,7 @@ import { Text } from "react-native"
 
 jest.mock("../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      overlay: "rgba(0,0,0,0.5)",
-      cardElevated: "#fff",
-      borderRadius: 12,
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#666",
-      border: "#e5e7eb",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/ui/__tests__/ErrorBoundary.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ErrorBoundary.test.tsx
@@ -4,13 +4,7 @@ import { Text } from "react-native"
 
 jest.mock("../../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      background: "#fff",
-      text: "#000",
-      textSecondary: "#666",
-      primary: "#0d9488",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/components/ui/__tests__/FieldMessage.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/FieldMessage.test.tsx
@@ -1,12 +1,9 @@
 import React from "react"
 import { render } from "@testing-library/react-native"
+import { lightColors } from "@colota/shared"
 import { FieldMessage } from "../FieldMessage"
 
-const mockColors = {
-  textSecondary: "#6b7280",
-  warning: "#f59e0b",
-  error: "#ef4444"
-} as any
+const mockColors = lightColors
 
 jest.mock("../../../hooks/useTheme", () => ({
   useTheme: () => ({ colors: mockColors })

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -3,6 +3,8 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
+import { Easing } from "react-native"
+
 import type { ProfileConditionType } from "../types/global"
 import { Zap, Car, ArrowUp, ArrowDown, Pause } from "lucide-react-native"
 
@@ -22,6 +24,31 @@ export const SETTINGS_READ_RETRY_DELAY_MS = 150
 export const HIT_SLOP_SM = { top: 6, right: 6, bottom: 6, left: 6 } as const
 export const HIT_SLOP_MD = { top: 8, right: 8, bottom: 8, left: 8 } as const
 export const HIT_SLOP_LG = { top: 12, right: 12, bottom: 12, left: 12 } as const
+
+// Spacing scale. A screen writes space.lg, never a number.
+export const space = { xs: 4, sm: 8, md: 12, lg: 16, xl: 24, xxl: 32 } as const
+
+// Sizes are not spacing: these are the painted or touchable extents of a control.
+export const size = {
+  touch: 48,
+  row: 56,
+  pill: 52,
+  mapControl: 44,
+  chip: 36,
+  iconColumn: 40,
+  column: 560,
+  icon: { sm: 16, md: 20, lg: 24 }
+} as const
+
+// Material 3 standard set. Nothing animates on a literal duration or a bare Easing.bezier.
+export const motion = {
+  enter: { duration: 250, easing: Easing.bezier(0, 0, 0, 1) },
+  exit: { duration: 200, easing: Easing.bezier(0.3, 0, 1, 1) },
+  control: { duration: 200, easing: Easing.bezier(0.2, 0, 0, 1) },
+  onScreen: { duration: 300, easing: Easing.bezier(0.2, 0, 0, 1) }
+} as const
+
+export const elevation = { floating: 2 } as const
 
 // Map
 export const DEFAULT_MAP_ZOOM = 17

--- a/apps/mobile/src/hooks/__tests__/useTheme.test.tsx
+++ b/apps/mobile/src/hooks/__tests__/useTheme.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { renderHook, act, waitFor } from "@testing-library/react-native"
 import { Appearance } from "react-native"
+import { lightColors, darkColors } from "@colota/shared"
 
 import NativeLocationService from "../../services/NativeLocationService"
 import { ThemeProvider, useTheme } from "../useTheme"
@@ -153,14 +154,18 @@ describe("useTheme", () => {
   it("provides different color objects for light and dark modes", () => {
     const { result } = renderHook(() => useTheme(), { wrapper })
 
-    const lightColors = result.current.colors
+    expect(result.current.colors).toBe(lightColors)
 
     act(() => {
       result.current.toggleTheme()
     })
 
-    const darkColors = result.current.colors
+    expect(result.current.colors).toBe(darkColors)
+  })
 
-    expect(lightColors).not.toBe(darkColors)
+  // Every screen reads one object for both modes, so a token added to one palette
+  // and forgotten in the other renders as undefined in that mode only.
+  it("carries the same token keys in both palettes", () => {
+    expect(Object.keys(darkColors).sort()).toEqual(Object.keys(lightColors).sort())
   })
 })

--- a/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
@@ -10,19 +10,7 @@ jest.mock("@react-navigation/native", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      card: "#fff",
-      warning: "#f59e0b",
-      border: "#e5e7eb",
-      textLight: "#9ca3af",
-      success: "#22c55e",
-      primaryDark: "#0d9488",
-      textOnPrimary: "#fff",
-      background: "#fff"
-    },
+    colors: require("@colota/shared").lightColors,
     mode: "light"
   })
 }))

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -18,22 +18,7 @@ jest.mock("../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
@@ -9,18 +9,7 @@ jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
     mode: "light",
     toggleTheme: mockToggleTheme,
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
@@ -27,21 +27,7 @@ jest.mock("../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -4,24 +4,7 @@ import { DeviceEventEmitter } from "react-native"
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      card: "#fff",
-      border: "#e5e7eb",
-      background: "#fff",
-      backgroundElevated: "#f9fafb",
-      success: "#22c55e",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      error: "#ef4444",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff",
-      overlay: "rgba(0,0,0,0.5)"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
@@ -31,22 +31,7 @@ jest.mock("../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -9,24 +9,7 @@ jest.mock("@react-navigation/native", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      card: "#fff",
-      border: "#e5e7eb",
-      background: "#fff",
-      backgroundElevated: "#f9fafb",
-      success: "#22c55e",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      error: "#ef4444",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff",
-      overlay: "rgba(0,0,0,0.5)"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
@@ -5,24 +5,7 @@ import { render, fireEvent, waitFor } from "@testing-library/react-native"
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      card: "#fff",
-      border: "#e5e7eb",
-      background: "#fff",
-      backgroundElevated: "#f9fafb",
-      success: "#22c55e",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      error: "#ef4444",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff",
-      overlay: "rgba(0,0,0,0.5)"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
@@ -34,24 +34,7 @@ jest.mock("react-native/Libraries/EventEmitter/NativeEventEmitter")
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#0d9488",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#d1d5db",
-      textLight: "#9ca3af",
-      textOnPrimary: "#fff",
-      background: "#fff",
-      card: "#fff",
-      error: "#ef4444",
-      warning: "#f59e0b",
-      success: "#22c55e",
-      placeholder: "#9ca3af",
-      borderRadius: 12,
-      pressedOpacity: 0.7
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
@@ -24,28 +24,7 @@ jest.mock("@react-navigation/native", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#d1d5db",
-      card: "#fff",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      background: "#fff",
-      border: "#e5e7eb",
-      borderRadius: 12,
-      success: "#22c55e",
-      error: "#ef4444",
-      link: "#0d9488",
-      textLight: "#9ca3af",
-      textOnPrimary: "#fff",
-      placeholder: "#d1d5db",
-      primaryDark: "#0d9488",
-      backgroundElevated: "#f9fafb",
-      surface: "#fff",
-      overlay: "rgba(0,0,0,0.5)"
-    },
+    colors: require("@colota/shared").lightColors,
     mode: "light"
   })
 }))

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -52,22 +52,7 @@ jest.mock("../../services/modalService", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      surface: "#fff",
-      backgroundElevated: "#f9fafb",
-      textOnPrimary: "#fff",
-      borderRadius: 8
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 
@@ -172,10 +157,6 @@ jest.mock("../../components/features/inspector/LocationTable", () => {
     LocationTable: (_props: any) => R.createElement(View, { testID: "LocationTable" })
   }
 })
-
-jest.mock("../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
-}))
 
 jest.mock("../../utils/logger", () => ({
   logger: { error: jest.fn(), info: jest.fn(), debug: jest.fn() }

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -32,24 +32,7 @@ jest.mock("@react-navigation/native", () => ({
 // --- Theme ---
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#111",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      warning: "#f59e0b",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff",
-      link: "#0d9488"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -57,21 +57,7 @@ jest.mock("../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -25,22 +25,7 @@ jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
     mode: "light",
     toggleTheme: jest.fn(),
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
@@ -45,22 +45,7 @@ jest.mock("../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      textOnPrimary: "#fff",
-      textDisabled: "#d1d5db",
-      borderRadius: 12
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/ShareSetupScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ShareSetupScreen.test.tsx
@@ -28,28 +28,7 @@ jest.mock("@maplibre/maplibre-react-native", () => {
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#d1d5db",
-      textOnPrimary: "#fff",
-      textLight: "#9ca3af",
-      card: "#fff",
-      surface: "#fff",
-      background: "#fff",
-      backgroundElevated: "#f9fafb",
-      border: "#e5e7eb",
-      borderRadius: 12,
-      success: "#22c55e",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      error: "#ef4444",
-      link: "#0d9488",
-      placeholder: "#d1d5db",
-      overlay: "rgba(0,0,0,0.5)"
-    },
+    colors: require("@colota/shared").lightColors,
     mode: "light"
   })
 }))

--- a/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
@@ -63,19 +63,7 @@ jest.mock("../../contexts/TrackingProvider", () => ({
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      textOnPrimary: "#fff"
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
@@ -82,19 +82,7 @@ jest.mock("../../components/ui/Card", () => {
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#9ca3af",
-      textOnPrimary: "#fff",
-      border: "#e5e7eb",
-      card: "#fff",
-      background: "#fff",
-      error: "#ef4444",
-      pressedOpacity: 0.7,
-      borderRadius: 8
-    }
+    colors: require("@colota/shared").lightColors
   })
 }))
 

--- a/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
+++ b/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
@@ -1,4 +1,5 @@
 jest.mock("react-native", () => ({
+  Easing: jest.requireActual("react-native").Easing,
   NativeModules: {
     LocationServiceModule: {
       startService: jest.fn().mockResolvedValue(undefined),

--- a/apps/mobile/src/styles/__tests__/contrast.test.ts
+++ b/apps/mobile/src/styles/__tests__/contrast.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import { lightColors, darkColors } from "@colota/shared"
+import type { ThemeColors } from "@colota/shared"
+
+// WCAG 2.x relative luminance and contrast ratio, computed from the tokens so an
+// edit to a hex value fails here instead of shipping an unreadable screen.
+function luminance(hex: string): number {
+  const h = hex.replace("#", "")
+  const channels = [0, 2, 4]
+    .map((i) => parseInt(h.slice(i, i + 2), 16) / 255)
+    .map((v) => (v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)))
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+}
+
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+type Pair = [keyof ThemeColors, keyof ThemeColors]
+
+// AA for text: anything the user reads at body size or smaller.
+const TEXT_PAIRS: Pair[] = [
+  ["text", "background"],
+  ["text", "card"],
+  ["textSecondary", "background"],
+  ["textSecondary", "cardElevated"],
+  ["textLight", "background"],
+  ["primary", "background"],
+  ["link", "background"],
+  ["success", "background"],
+  ["warning", "background"],
+  ["error", "background"],
+  ["info", "background"],
+  ["textOnPrimary", "primary"],
+  ["textOnPrimary", "error"],
+  ["onPrimaryContainer", "primaryContainer"],
+  ["inverseOnSurface", "inverseSurface"]
+]
+
+// AA for non-text: a boundary the user has to see to work the control.
+const COMPONENT_PAIRS: Pair[] = [
+  ["outline", "background"],
+  ["outline", "well"],
+  ["primary", "primaryContainer"]
+]
+
+const THEMES: [string, ThemeColors][] = [
+  ["light", lightColors],
+  ["dark", darkColors]
+]
+
+describe("token contrast", () => {
+  describe.each(THEMES)("%s", (_mode, colors) => {
+    it.each(TEXT_PAIRS)("%s on %s clears 4.5:1, the AA floor for readable text", (fg, bg) => {
+      expect(contrast(colors[fg] as string, colors[bg] as string)).toBeGreaterThanOrEqual(4.5)
+    })
+
+    it.each(COMPONENT_PAIRS)("%s on %s clears 3:1, the AA floor for a control boundary", (fg, bg) => {
+      expect(contrast(colors[fg] as string, colors[bg] as string)).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  // textDisabled is exempt by design: WCAG excludes disabled controls, and lifting it
+  // to AA would make a disabled row indistinguishable from an enabled one.
+  it("keeps textDisabled below the enabled text contrast so disabled still reads as disabled", () => {
+    for (const [, colors] of THEMES) {
+      expect(contrast(colors.textDisabled, colors.background)).toBeLessThan(
+        contrast(colors.textSecondary, colors.background)
+      )
+    }
+  })
+
+  it("holds the surfaces to a tonal step, never a step that carries meaning on its own", () => {
+    for (const [, colors] of THEMES) {
+      for (const surface of ["card", "cardElevated", "well"] as const) {
+        const step = contrast(colors[surface], colors.background)
+        expect(step).toBeGreaterThan(1)
+        expect(step).toBeLessThan(1.5)
+      }
+    }
+  })
+})

--- a/apps/mobile/src/styles/__tests__/typography.test.ts
+++ b/apps/mobile/src/styles/__tests__/typography.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import { type } from "@colota/shared"
+import type { TypeRoleName } from "@colota/shared"
+import { text, fonts } from "../typography"
+
+const roleNames = Object.keys(type) as TypeRoleName[]
+
+describe("text roles", () => {
+  it("composes every shared role, so a role added upstream cannot be missing here", () => {
+    expect(Object.keys(text).sort()).toEqual([...roleNames].sort())
+  })
+
+  it.each(roleNames)("%s carries the size, line height and variants of its shared role", (name) => {
+    const role = type[name]
+    expect(text[name]).toMatchObject({
+      fontSize: role.fontSize,
+      lineHeight: role.lineHeight,
+      letterSpacing: role.letterSpacing,
+      fontVariant: role.fontVariant
+    })
+  })
+
+  it("resolves the weight name to a real Inter face rather than a numeric fontWeight", () => {
+    expect(text.body.fontFamily).toBe(fonts.regular.fontFamily)
+    expect(text.bodyStrong.fontFamily).toBe(fonts.medium.fontFamily)
+    expect(text.title.fontFamily).toBe(fonts.semiBold.fontFamily)
+    expect(text.body.fontWeight).toBeUndefined()
+  })
+
+  it("keeps mono off the Inter family, because Inter has no monospace face", () => {
+    expect(text.mono.fontFamily).toBe("monospace")
+  })
+
+  it("gives the figure roles tabular figures so numbers do not shift as they update", () => {
+    for (const name of ["display", "figureInline", "coord"] as const) {
+      expect(text[name].fontVariant).toContain("tabular-nums")
+    }
+  })
+
+  it("copies fontVariant so a StyleSheet consumer cannot mutate the shared token", () => {
+    expect(text.coord.fontVariant).not.toBe(type.coord.fontVariant)
+  })
+})

--- a/apps/mobile/src/styles/typography.ts
+++ b/apps/mobile/src/styles/typography.ts
@@ -2,14 +2,22 @@
  * Copyright (C) 2026 Max Dietrich
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  *
- * Re-exports typography from @colota/shared — the single source of truth.
+ * Re-exports typography from @colota/shared - the single source of truth.
  * Platform-specific font variants (Regular, Medium, etc.) are derived here.
  */
 
 import { TextStyle } from "react-native"
-import { fontFamily } from "@colota/shared"
+import { fontFamily, type } from "@colota/shared"
+import type { FontWeightName, TypeRoleName } from "@colota/shared"
 
 export { fontSizes } from "@colota/shared"
+
+const WEIGHT_SUFFIX: Record<FontWeightName, string> = {
+  regular: "Regular",
+  medium: "Medium",
+  semiBold: "SemiBold",
+  bold: "Bold"
+}
 
 export const fonts: Record<string, Pick<TextStyle, "fontFamily">> = {
   regular: { fontFamily: `${fontFamily}-Regular` },
@@ -17,3 +25,22 @@ export const fonts: Record<string, Pick<TextStyle, "fontFamily">> = {
   semiBold: { fontFamily: `${fontFamily}-SemiBold` },
   bold: { fontFamily: `${fontFamily}-Bold` }
 }
+
+function roleStyle(name: TypeRoleName): TextStyle {
+  const role = type[name]
+  return {
+    fontFamily: name === "mono" ? "monospace" : `${fontFamily}-${WEIGHT_SUFFIX[role.weight]}`,
+    fontSize: role.fontSize,
+    lineHeight: role.lineHeight,
+    letterSpacing: role.letterSpacing,
+    fontVariant: [...role.fontVariant]
+  }
+}
+
+export const text = (Object.keys(type) as TypeRoleName[]).reduce(
+  (acc, name) => {
+    acc[name] = roleStyle(name)
+    return acc
+  },
+  {} as Record<TypeRoleName, TextStyle>
+)

--- a/apps/mobile/src/utils/__tests__/queueStatus.test.ts
+++ b/apps/mobile/src/utils/__tests__/queueStatus.test.ts
@@ -1,11 +1,5 @@
 import { getQueueColor } from "../queueStatus"
-import { ThemeColors } from "../../types/global"
-
-const mockColors = {
-  text: "#202124",
-  warning: "#FF9800",
-  error: "#D32F2F"
-} as ThemeColors
+import { lightColors as mockColors } from "@colota/shared"
 
 describe("getQueueColor", () => {
   it("returns text color for zero items", () => {

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -2,3 +2,4 @@
 - Auto-export now deletes old files on storage providers that rename them
 - Unplugging at a low battery no longer restarts tracking in a loop
 - Pause zones no longer take hours to engage when a tracking profile is active
+- A calmer colour palette across the app in both light and dark

--- a/fastlane/metadata/android/en-US/changelogs/50.txt
+++ b/fastlane/metadata/android/en-US/changelogs/50.txt
@@ -1,0 +1,1 @@
+- A calmer colour palette across the app in both light and dark

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -9,168 +9,129 @@
 export type ThemeMode = "light" | "dark"
 
 export interface ThemeColors {
-  // Primary colors
+  // Brand
   primary: string
   primaryDark: string
-  primaryLight: string
+  primaryContainer: string
+  onPrimaryContainer: string
 
-  // Secondary colors
-  secondary: string
-  secondaryDark: string
-  secondaryLight: string
-
-  // Semantic colors
+  // Semantic hues
   success: string
-  successDark: string
-  successLight: string
   warning: string
-  warningDark: string
-  warningLight: string
   error: string
-  errorDark: string
-  errorLight: string
   info: string
-  infoDark: string
-  infoLight: string
 
-  // Surfaces & backgrounds
+  // Surfaces
   background: string
-  backgroundElevated: string
   card: string
   cardElevated: string
-  surface: string
+  well: string
 
-  // Text colors
+  // Text
   text: string
   textSecondary: string
   textLight: string
   textDisabled: string
 
-  // Borders & dividers
+  // Lines
   border: string
-  borderLight: string
-  divider: string
+  outline: string
 
-  // Interactive elements
+  // Inverse pair
+  inverseSurface: string
+  inverseOnSurface: string
+
+  // Interactive
   placeholder: string
   link: string
-  linkVisited: string
-
-  // Utility
   overlay: string
-  shadow: string
-  transparent: string
-  pressedOpacity: number
-  borderRadius: number
   textOnPrimary: string
+  pressedOpacity: number
+
+  // Aliases kept for their remaining consumers; deleted once every screen has migrated.
+  backgroundElevated: string
+  surface: string
+  borderLight: string
+  divider: string
+  borderRadius: number
 }
 
 export const lightColors: ThemeColors = {
-  // Brand (Teal)
-  primary: "#0d9488",
-  primaryDark: "#115E59",
-  primaryLight: "#99F6E4",
-  secondary: "#F59E0B",
-  secondaryDark: "#92400E",
-  secondaryLight: "#FDE68A",
+  primary: "#0A7369",
+  primaryDark: "#084F48",
+  primaryContainer: "#D2EBE6",
+  onPrimaryContainer: "#084F48",
 
-  // Status
-  success: "#2E7D32",
-  successDark: "#1B5E20",
-  successLight: "#A5D6A7",
-  warning: "#C2410C",
-  warningDark: "#9A3412",
-  warningLight: "#FED7AA",
-  error: "#D32F2F",
-  errorDark: "#B71C1C",
-  errorLight: "#FFCDD2",
-  info: "#1976D2",
-  infoDark: "#0D47A1",
-  infoLight: "#BBDEFB",
+  success: "#2E6B34",
+  warning: "#A63E0A",
+  error: "#C0392B",
+  info: "#1F5FA8",
 
-  // UI
-  background: "#f8fafb",
-  backgroundElevated: "#FFFFFF",
+  background: "#F4F4F2",
   card: "#FFFFFF",
   cardElevated: "#FFFFFF",
-  surface: "#FFFFFF",
+  well: "#E6E6E3",
 
-  // Text
-  text: "#202124",
-  textSecondary: "#5F6368",
-  textLight: "#9AA0A6",
-  textDisabled: "#9AA0A6",
+  text: "#1B1B1A",
+  textSecondary: "#52524F",
+  textLight: "#676763",
+  textDisabled: "#A2A29E",
 
-  // Border & divider
-  border: "#e5e7eb",
-  borderLight: "#f3f4f6",
-  divider: "#e5e7eb",
+  border: "#DCDCD8",
+  outline: "#838380",
 
-  // Interactive
-  placeholder: "#9AA0A6",
-  link: "#115E59",
-  linkVisited: "#134E4A",
+  inverseSurface: "#2C2C2A",
+  inverseOnSurface: "#F4F4F2",
+
+  placeholder: "#676763",
+  link: "#084F48",
   overlay: "rgba(0, 0, 0, 0.5)",
-  shadow: "rgba(0, 0, 0, 0.1)",
-
-  // Special
-  transparent: "transparent",
+  textOnPrimary: "#FFFFFF",
   pressedOpacity: 0.7,
-  borderRadius: 8,
-  textOnPrimary: "#FFFFFF"
+
+  backgroundElevated: "#FFFFFF",
+  surface: "#FFFFFF",
+  borderLight: "#DCDCD8",
+  divider: "#DCDCD8",
+  borderRadius: 8
 }
 
 export const darkColors: ThemeColors = {
-  // Brand (Teal)
-  primary: "#2DD4BF",
-  primaryDark: "#0d9488",
-  primaryLight: "#99F6E4",
-  secondary: "#FBBF24",
-  secondaryDark: "#F59E0B",
-  secondaryLight: "#FDE68A",
+  primary: "#2FC4B0",
+  primaryDark: "#1FA895",
+  primaryContainer: "#103F3A",
+  onPrimaryContainer: "#9FE3D8",
 
-  // Status
-  success: "#4CAF50",
-  successDark: "#388E3C",
-  successLight: "#C8E6C9",
-  warning: "#FB923C",
-  warningDark: "#F97316",
-  warningLight: "#FED7AA",
-  error: "#EF5350",
-  errorDark: "#D32F2F",
-  errorLight: "#FFCDD2",
-  info: "#4285F4",
-  infoDark: "#1976D2",
-  infoLight: "#BBDEFB",
+  success: "#7BC47F",
+  warning: "#F0A050",
+  error: "#F07A70",
+  info: "#6FA8E8",
 
-  // UI
-  background: "#121212",
-  backgroundElevated: "#1E1E1E",
-  card: "#2D2D2D",
-  cardElevated: "#3D3D3D",
-  surface: "#1E1E1E",
+  background: "#131313",
+  card: "#1E1E1E",
+  cardElevated: "#282828",
+  well: "#222222",
 
-  // Text
-  text: "#E8EAED",
-  textSecondary: "#AAAAAA",
-  textLight: "#888888",
-  textDisabled: "#666666",
+  text: "#EAEAE7",
+  textSecondary: "#B0B0AC",
+  textLight: "#94948F",
+  textDisabled: "#5E5E5B",
 
-  // Border & divider
-  border: "#424242",
-  borderLight: "#333333",
-  divider: "#333333",
+  border: "#2A2A2A",
+  outline: "#7A7A76",
 
-  // Interactive
-  placeholder: "#AAAAAA",
-  link: "#2DD4BF",
-  linkVisited: "#14B8A6",
-  overlay: "rgba(0, 0, 0, 0.7)",
-  shadow: "rgba(0, 0, 0, 0.3)",
+  inverseSurface: "#EAEAE7",
+  inverseOnSurface: "#131313",
 
-  // Special
-  transparent: "transparent",
+  placeholder: "#94948F",
+  link: "#2FC4B0",
+  overlay: "rgba(0, 0, 0, 0.65)",
+  textOnPrimary: "#121212",
   pressedOpacity: 0.7,
-  borderRadius: 8,
-  textOnPrimary: "#121212"
+
+  backgroundElevated: "#1E1E1E",
+  surface: "#1E1E1E",
+  borderLight: "#2A2A2A",
+  divider: "#2A2A2A",
+  borderRadius: 8
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,4 +5,7 @@
 
 export { lightColors, darkColors } from "./colors"
 export type { ThemeColors, ThemeMode } from "./colors"
-export { fontFamily, fontSizes } from "./typography"
+export { radius } from "./radius"
+export type { RadiusName } from "./radius"
+export { fontFamily, fontSizes, type } from "./typography"
+export type { FontVariantName, FontWeightName, TypeRole, TypeRoleName } from "./typography"

--- a/packages/shared/src/radius.ts
+++ b/packages/shared/src/radius.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ *
+ * Single source of truth for Colota corner radii.
+ * Used by: apps/mobile, apps/docs
+ */
+
+export const radius = {
+  xs: 4,
+  sm: 8,
+  lg: 16,
+  pill: 999
+} as const
+
+export type RadiusName = keyof typeof radius

--- a/packages/shared/src/typography.ts
+++ b/packages/shared/src/typography.ts
@@ -8,7 +8,44 @@
 
 export const fontFamily = "Inter"
 
-export const fontSizes = {
+// Subset of React Native's own fontVariant union. A plain string[] or a readonly
+// tuple is rejected by TextStyle, so the roles below must be typed through this.
+export type FontVariantName = "tabular-nums" | "stylistic-two"
+
+export type FontWeightName = "regular" | "medium" | "semiBold" | "bold"
+
+export interface TypeRole {
+  fontSize: number
+  lineHeight: number
+  weight: FontWeightName
+  letterSpacing: number
+  fontVariant: FontVariantName[]
+}
+
+export type TypeRoleName =
+  "display" | "title" | "heading" | "bodyStrong" | "body" | "label" | "caption" | "figureInline" | "coord" | "mono"
+
+export const type: Record<TypeRoleName, TypeRole> = {
+  display: { fontSize: 32, lineHeight: 40, weight: "medium", letterSpacing: 0, fontVariant: ["tabular-nums"] },
+  title: { fontSize: 20, lineHeight: 26, weight: "semiBold", letterSpacing: 0, fontVariant: [] },
+  heading: { fontSize: 17, lineHeight: 24, weight: "semiBold", letterSpacing: 0, fontVariant: [] },
+  bodyStrong: { fontSize: 15, lineHeight: 22, weight: "medium", letterSpacing: 0, fontVariant: [] },
+  body: { fontSize: 15, lineHeight: 22, weight: "regular", letterSpacing: 0, fontVariant: [] },
+  label: { fontSize: 13, lineHeight: 18, weight: "medium", letterSpacing: 0, fontVariant: [] },
+  caption: { fontSize: 12, lineHeight: 16, weight: "regular", letterSpacing: 0, fontVariant: [] },
+  figureInline: { fontSize: 17, lineHeight: 24, weight: "medium", letterSpacing: 0, fontVariant: ["tabular-nums"] },
+  coord: {
+    fontSize: 15,
+    lineHeight: 20,
+    weight: "regular",
+    letterSpacing: 0,
+    fontVariant: ["tabular-nums", "stylistic-two"]
+  },
+  mono: { fontSize: 13, lineHeight: 18, weight: "regular", letterSpacing: 0, fontVariant: [] }
+}
+
+// Superseded by `type`; kept until every caller has moved off it.
+export const fontSizes = Object.freeze({
   screenTitle: 28,
   statValue: 24,
   cardTitle: 20,
@@ -20,4 +57,4 @@ export const fontSizes = {
   caption: 12,
   small: 11,
   micro: 10
-} as const
+} as const)


### PR DESCRIPTION
The token layer of the design rework. Colours move to the neutral ground with a
tonal surface set, and gain primaryContainer, onPrimaryContainer, well, outline
and the inverse pair. Keys with no consumer are deleted; backgroundElevated,
surface, borderLight, divider and borderRadius stay as aliases so every later PR
ships green until their screens migrate.

New beside them: a radius scale in packages/shared, ten type roles composed onto
the Inter faces in styles/typography, and space, size, motion and elevation in
constants. Nothing consumes them yet, so this PR changes only colour values.

The 28 hand-written useTheme colour mocks now read lightColors from the shared
package, so a token added later cannot render as undefined in a test that never
knew about it. A new contrast test computes the WCAG ratios from the tokens and
fails the build on a pair that drops below AA.
