### PR TITLE
feat(ui): borderless Card, Divider inset, SectionTitle, ListItem, SettingRow

### DIFF
--- a/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
+++ b/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
@@ -37,7 +37,7 @@ export function CoordinateDisplay() {
 
   return (
     <>
-      <SectionTitle>CURRENT LOCATION DATA</SectionTitle>
+      <SectionTitle>Current location data</SectionTitle>
       <View style={styles.container}>
         {/* First Row: Latitude and Longitude */}
         <View style={styles.row}>

--- a/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
+++ b/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
@@ -25,7 +25,7 @@ export const DatabaseStatistics = React.memo(function DatabaseStatistics({ stats
     <>
       {/* Database Statistics */}
       <View style={styles.metricsSection}>
-        <SectionTitle>DATABASE STATISTICS</SectionTitle>
+        <SectionTitle>Database statistics</SectionTitle>
         {!isOfflineMode ? (
           <View style={styles.statsGrid}>
             <Card variant="elevated" style={styles.statCard}>

--- a/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
@@ -46,7 +46,7 @@ describe("DatabaseStatistics", () => {
   it("shows section title", () => {
     const { getByText } = render(<DatabaseStatistics stats={baseStats} />)
 
-    expect(getByText("DATABASE STATISTICS")).toBeTruthy()
+    expect(getByText("Database statistics")).toBeTruthy()
   })
 
   describe("online mode (default)", () => {

--- a/apps/mobile/src/components/features/settings/MtlsSection.tsx
+++ b/apps/mobile/src/components/features/settings/MtlsSection.tsx
@@ -209,7 +209,7 @@ export function MtlsSection() {
       </View>
 
       <View style={styles.section}>
-        <SectionTitle>Trusted Server CA</SectionTitle>
+        <SectionTitle>Trusted server CA</SectionTitle>
         <Card>
           {caInfo.configured ? (
             <CertCard

--- a/apps/mobile/src/components/features/settings/__tests__/MtlsSection.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/MtlsSection.test.tsx
@@ -226,7 +226,7 @@ describe("MtlsSection", () => {
     it("renders the empty-state Import CA button + helper text", async () => {
       const { getByText } = render(<MtlsSection />)
       await waitFor(() => {
-        expect(getByText("Trusted Server CA")).toBeTruthy()
+        expect(getByText("Trusted server CA")).toBeTruthy()
         expect(getByText("Import CA (.crt / .pem)")).toBeTruthy()
       })
     })

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -5,17 +5,19 @@
 
 import React from "react"
 import { View, Pressable, StyleSheet, ViewStyle, StyleProp, AccessibilityRole, AccessibilityState } from "react-native"
+import { radius } from "@colota/shared"
 import { useTheme } from "../../hooks/useTheme"
+import { elevation, space, STATE_LAYER_ALPHA } from "../../constants"
 
-type CardVariant = "default" | "elevated" | "outlined" | "interactive"
+type CardVariant = "sheet" | "floating" | "default" | "elevated" | "outlined" | "interactive" | "danger"
 
 type CardProps = {
   children: React.ReactNode
   style?: StyleProp<ViewStyle>
-  danger?: boolean
   variant?: CardVariant
   onPress?: () => void
   onLongPress?: () => void
+  testID?: string
   accessibilityRole?: AccessibilityRole
   accessibilityLabel?: string
   accessibilityHint?: string
@@ -25,86 +27,73 @@ type CardProps = {
 export function Card({
   children,
   style,
-  danger = false,
   variant = "default",
   onPress,
   onLongPress,
+  testID,
   accessibilityRole,
   accessibilityLabel,
   accessibilityHint,
   accessibilityState
 }: CardProps) {
-  const { colors } = useTheme()
+  const { colors, mode } = useTheme()
 
-  const getVariantStyles = (): ViewStyle => {
-    if (danger) {
-      return {
-        backgroundColor: colors.error + "12",
-        borderColor: colors.error,
-        borderWidth: 2
-      }
-    }
-
+  const surfaceStyle = (): ViewStyle => {
     switch (variant) {
+      case "floating":
+        return {
+          backgroundColor: colors.cardElevated,
+          borderRadius: radius.lg,
+          elevation: mode === "dark" ? 0 : elevation.floating
+        }
+      // The bordered legacy surface, kept until the screens that group with it compose
+      // headed lists: dropping the stroke here strips it from screens this PR does not touch.
       case "default":
         return {
           backgroundColor: colors.card,
-          borderColor: colors.border,
-          borderWidth: 1
+          borderRadius: radius.lg,
+          borderWidth: 1,
+          borderColor: colors.border
         }
+      case "sheet":
       case "elevated":
-        return {
-          backgroundColor: colors.cardElevated,
-          borderColor: "transparent",
-          borderWidth: 0,
-          elevation: 1,
-          shadowColor: "#000",
-          shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.15,
-          shadowRadius: 6
-        }
       case "outlined":
-        return {
-          backgroundColor: "transparent",
-          borderColor: colors.border,
-          borderWidth: 1.5
-        }
       case "interactive":
-        return {
-          backgroundColor: colors.card,
-          borderColor: colors.border,
-          borderWidth: 1
-        }
+      case "danger":
+        return { backgroundColor: colors.card, borderRadius: 0 }
     }
   }
 
-  const cardView = <View style={[styles.card, getVariantStyles(), style]}>{children}</View>
+  const surface = [styles.card, surfaceStyle(), style]
 
-  if (variant === "interactive" && (onPress || onLongPress)) {
+  if (onPress || onLongPress) {
     return (
       <Pressable
+        testID={testID}
         onPress={onPress}
         onLongPress={onLongPress}
         accessibilityRole={accessibilityRole}
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
         accessibilityState={accessibilityState}
-        style={({ pressed }) => ({ opacity: pressed ? colors.pressedOpacity : 1 })}
+        android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
       >
-        {cardView}
+        <View style={surface}>{children}</View>
       </Pressable>
     )
   }
 
-  return cardView
+  return (
+    <View testID={testID} style={surface}>
+      {children}
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({
   card: {
     flex: 1,
-    padding: 16,
-    borderRadius: 12,
-    borderWidth: 1,
+    padding: space.lg,
     width: "100%"
   }
 })

--- a/apps/mobile/src/components/ui/Divider.tsx
+++ b/apps/mobile/src/components/ui/Divider.tsx
@@ -5,16 +5,32 @@
 
 import { View, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
+import { space } from "../../constants"
 
-export const Divider = () => {
+type DividerProps = {
+  inset?: number
+  tight?: boolean
+  testID?: string
+}
+
+export const Divider = ({ inset = 0, tight = false, testID }: DividerProps) => {
   const { colors } = useTheme()
 
-  return <View style={[styles.divider, { backgroundColor: colors.divider }]} />
+  return (
+    <View
+      testID={testID}
+      style={[styles.divider, { backgroundColor: colors.border, marginStart: inset }, tight && styles.tight]}
+    />
+  )
 }
 
 const styles = StyleSheet.create({
   divider: {
-    height: 1,
-    marginVertical: 16
+    height: StyleSheet.hairlineWidth,
+    // The 55 call sites that predate the row spacing still lean on this margin.
+    marginVertical: space.lg
+  },
+  tight: {
+    marginVertical: 0
   }
 })

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -4,60 +4,104 @@
  */
 
 import React from "react"
-import { Text, StyleSheet, View, Pressable } from "react-native"
+import { Text, StyleSheet, View, Pressable, type StyleProp, type ViewStyle } from "react-native"
 import { ChevronRight } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { text } from "../../styles/typography"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+import { Divider } from "./Divider"
 
 type IconComponent = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
 
 type ListItemProps = {
   label: string
   sub?: string
+  value?: string
   icon?: IconComponent
-  trailingIcon?: IconComponent
-  onPress: () => void
+  trailingIcon?: IconComponent | null
+  trailing?: React.ReactNode
+  onPress?: () => void
+  divider?: boolean
+  style?: StyleProp<ViewStyle>
   testID?: string
   accessibilityRole?: "button" | "link"
+  accessibilityLabel?: string
   accessibilityHint?: string
 }
 
 export function ListItem({
   label,
   sub,
+  value,
   icon: Icon,
-  trailingIcon: TrailingIcon = ChevronRight,
+  trailingIcon,
+  trailing,
   onPress,
+  divider = false,
+  style,
   testID,
   accessibilityRole = "button",
+  accessibilityLabel,
   accessibilityHint
 }: ListItemProps) {
   const { colors } = useTheme()
-  return (
+
+  const TrailingIcon = trailingIcon === undefined && onPress ? ChevronRight : trailingIcon
+  const composedLabel = accessibilityLabel ?? [label, sub, value].filter(Boolean).join(", ")
+
+  const trailingSlot =
+    trailing ??
+    (value ? (
+      <Text style={[styles.value, { color: colors.text }]} importantForAccessibility="no">
+        {value}
+      </Text>
+    ) : null)
+
+  const body = (
+    <>
+      {Icon ? (
+        <View style={styles.iconColumn} importantForAccessibility="no">
+          <Icon size={size.icon.md} color={colors.textSecondary} />
+        </View>
+      ) : null}
+      <View style={styles.content} accessible={!onPress} accessibilityLabel={onPress ? undefined : composedLabel}>
+        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+        {sub ? <Text style={[styles.sub, { color: colors.textSecondary }]}>{sub}</Text> : null}
+      </View>
+      {trailingSlot}
+      {TrailingIcon ? (
+        <View importantForAccessibility="no">
+          <TrailingIcon size={size.icon.md} color={colors.textLight} />
+        </View>
+      ) : null}
+    </>
+  )
+
+  const row = onPress ? (
     <Pressable
       testID={testID}
       accessibilityRole={accessibilityRole}
-      accessibilityLabel={label}
+      accessibilityLabel={composedLabel}
       accessibilityHint={accessibilityHint ?? `Opens ${label}`}
-      android_ripple={{ color: colors.border }}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
       onPress={onPress}
-      style={({ pressed }) => [styles.row, pressed && { opacity: colors.pressedOpacity }]}
+      style={[styles.row, style]}
     >
-      {Icon && (
-        <View style={styles.icon}>
-          <Icon size={22} color={colors.textLight} />
-        </View>
-      )}
-      <View style={styles.content}>
-        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
-        {sub ? (
-          <Text style={[styles.sub, { color: colors.textSecondary }]} numberOfLines={1}>
-            {sub}
-          </Text>
-        ) : null}
-      </View>
-      <TrailingIcon size={20} color={colors.textLight} />
+      {body}
     </Pressable>
+  ) : (
+    <View testID={testID} style={[styles.row, style]}>
+      {body}
+    </View>
+  )
+
+  if (!divider) return row
+
+  return (
+    <View>
+      {row}
+      <Divider tight inset={Icon ? size.iconColumn : 0} />
+    </View>
   )
 }
 
@@ -65,23 +109,23 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     alignItems: "center",
-    minHeight: 56,
-    paddingVertical: 10
+    minHeight: size.row,
+    paddingVertical: space.md
   },
-  icon: {
-    marginRight: 16
+  iconColumn: {
+    width: size.iconColumn
   },
   content: {
     flex: 1,
-    paddingRight: 8
+    paddingEnd: space.md
   },
   label: {
-    fontSize: 16,
-    ...fonts.semiBold,
-    marginBottom: 2
+    ...text.bodyStrong
   },
   sub: {
-    fontSize: 13,
-    ...fonts.regular
+    ...text.label
+  },
+  value: {
+    ...text.figureInline
   }
 })

--- a/apps/mobile/src/components/ui/SectionTitle.tsx
+++ b/apps/mobile/src/components/ui/SectionTitle.tsx
@@ -4,33 +4,70 @@
  */
 
 import React from "react"
-import { View, StyleSheet, ViewStyle, StyleProp, Text } from "react-native"
+import { View, StyleSheet, ViewStyle, StyleProp, Text, Pressable } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { text } from "../../styles/typography"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+
+type SectionTitleAction = {
+  label: string
+  onPress: () => void
+  testID?: string
+}
 
 type SectionTitleProps = {
   children: React.ReactNode
   style?: StyleProp<ViewStyle>
-  color?: string
+  first?: boolean
+  action?: SectionTitleAction
+  testID?: string
 }
 
-export function SectionTitle({ children, style, color }: SectionTitleProps) {
+export function SectionTitle({ children, style, first = false, action, testID }: SectionTitleProps) {
   const { colors } = useTheme()
 
   return (
-    <View style={style}>
-      <Text style={[styles.sectionTitle, { color: color ? color : colors.primary }]}>{children}</Text>
+    <View testID={testID} style={[styles.container, first && styles.first, style]}>
+      <Text accessibilityRole="header" style={[styles.title, { color: colors.text }]}>
+        {children}
+      </Text>
+      {action ? (
+        <Pressable
+          testID={action.testID}
+          onPress={action.onPress}
+          accessibilityRole="button"
+          accessibilityLabel={action.label}
+          android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA }}
+          style={styles.action}
+        >
+          <Text style={[styles.actionLabel, { color: colors.primaryDark }]}>{action.label}</Text>
+        </Pressable>
+      ) : null}
     </View>
   )
 }
 
 const styles = StyleSheet.create({
-  sectionTitle: {
-    fontSize: 11,
-    textTransform: "uppercase",
-    ...fonts.bold,
-    letterSpacing: 1.2,
-    marginBottom: 12,
-    paddingHorizontal: 4
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: space.xxl,
+    marginBottom: space.sm
+  },
+  first: {
+    marginTop: 0
+  },
+  title: {
+    ...text.heading,
+    flexShrink: 1
+  },
+  action: {
+    minHeight: size.touch,
+    justifyContent: "center",
+    paddingStart: space.md
+  },
+  actionLabel: {
+    ...text.bodyStrong
   }
 })

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -4,49 +4,18 @@
  */
 
 import React from "react"
-import { View, Text, StyleSheet, type StyleProp, type ViewStyle } from "react-native"
-import { fonts } from "../../styles/typography"
-import { useTheme } from "../../hooks/useTheme"
+import { type StyleProp, type ViewStyle } from "react-native"
+import { ListItem } from "./ListItem"
 
 interface SettingRowProps {
   label: string
   hint?: string
   children: React.ReactNode
+  divider?: boolean
   style?: StyleProp<ViewStyle>
+  testID?: string
 }
 
-export function SettingRow({ label, hint, children, style }: SettingRowProps) {
-  const { colors } = useTheme()
-  return (
-    <View style={[styles.settingRow, style]}>
-      <View style={styles.settingContent}>
-        <Text style={[styles.settingLabel, { color: colors.text }]}>{label}</Text>
-        {hint && <Text style={[styles.settingHint, { color: colors.textSecondary }]}>{hint}</Text>}
-      </View>
-      {children}
-    </View>
-  )
+export function SettingRow({ label, hint, children, divider = false, style, testID }: SettingRowProps) {
+  return <ListItem label={label} sub={hint} trailing={children} divider={divider} style={style} testID={testID} />
 }
-
-const styles = StyleSheet.create({
-  settingRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: 4
-  },
-  settingContent: {
-    flex: 1,
-    marginRight: 16
-  },
-  settingLabel: {
-    fontSize: 16,
-    ...fonts.semiBold,
-    marginBottom: 2
-  },
-  settingHint: {
-    fontSize: 13,
-    ...fonts.regular,
-    lineHeight: 18
-  }
-})

--- a/apps/mobile/src/components/ui/__tests__/Card.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import { Text, StyleSheet, processColor, type StyleProp, type ViewStyle } from "react-native"
+import { render, fireEvent } from "@testing-library/react-native"
+import { darkColors, lightColors, radius } from "@colota/shared"
+import { Card } from "../Card"
+import { elevation, STATE_LAYER_ALPHA } from "../../../constants"
+
+// The app ships Android only, but the jest preset resolves Platform to iOS,
+// where Pressable drops android_ripple before it reaches the host view.
+jest.mock("react-native/Libraries/Utilities/Platform", () => ({
+  __esModule: true,
+  default: { OS: "android", select: (spec: Record<string, unknown>) => spec.android ?? spec.default }
+}))
+
+let mockMode: "light" | "dark" = "light"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({
+    mode: mockMode,
+    colors: mockMode === "dark" ? require("@colota/shared").darkColors : require("@colota/shared").lightColors
+  })
+}))
+
+type StyledElement = { props: { style?: StyleProp<ViewStyle> } }
+
+const surfaceOf = (element?: StyledElement | null): ViewStyle => StyleSheet.flatten(element?.props.style) ?? {}
+
+describe("Card", () => {
+  beforeEach(() => {
+    mockMode = "light"
+  })
+
+  it("draws the sheet without a stroke or a radius, because it meets the map flush", () => {
+    const { getByTestId } = render(
+      <Card testID="card" variant="sheet">
+        <Text>Body</Text>
+      </Card>
+    )
+
+    const surface = surfaceOf(getByTestId("card"))
+    expect(surface.borderWidth).toBeUndefined()
+    expect(surface.borderRadius).toBe(0)
+    expect(surface.backgroundColor).toBe(lightColors.card)
+  })
+
+  it("floats on the elevated surface with a shadow in light", () => {
+    const { getByTestId } = render(
+      <Card testID="card" variant="floating">
+        <Text>Body</Text>
+      </Card>
+    )
+
+    const surface = surfaceOf(getByTestId("card"))
+    expect(surface.borderWidth).toBeUndefined()
+    expect(surface.borderRadius).toBe(radius.lg)
+    expect(surface.backgroundColor).toBe(lightColors.cardElevated)
+    expect(surface.elevation).toBe(elevation.floating)
+  })
+
+  it("drops the floating shadow in dark, where the tonal step alone says the surface is above", () => {
+    mockMode = "dark"
+    const { getByTestId } = render(
+      <Card testID="card" variant="floating">
+        <Text>Body</Text>
+      </Card>
+    )
+
+    const surface = surfaceOf(getByTestId("card"))
+    expect(surface.backgroundColor).toBe(darkColors.cardElevated)
+    expect(surface.elevation).toBe(0)
+  })
+
+  it("keeps the default variant bordered, because dropping the stroke here strips it from every unmigrated screen", () => {
+    const { getByTestId } = render(
+      <Card testID="card">
+        <Text>Body</Text>
+      </Card>
+    )
+
+    const surface = surfaceOf(getByTestId("card"))
+    expect(surface.borderWidth).toBe(1)
+    expect(surface.borderColor).toBe(lightColors.border)
+  })
+
+  it("takes an onPress on any variant, so the interactive alias keeps its pressable without keeping its box", () => {
+    const onPress = jest.fn()
+    const { getByTestId } = render(
+      <Card testID="card" variant="interactive" onPress={onPress} accessibilityLabel="Trip 1">
+        <Text>Body</Text>
+      </Card>
+    )
+
+    fireEvent.press(getByTestId("card"))
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it("has no tone: the danger alias paints the plain sheet, because a coloured box is a Notice", () => {
+    const { getByTestId } = render(
+      <Card testID="card" variant="danger">
+        <Text>Body</Text>
+      </Card>
+    )
+
+    const surface = surfaceOf(getByTestId("card"))
+    expect(surface.backgroundColor).toBe(lightColors.card)
+    expect(surface.borderWidth).toBeUndefined()
+    expect(surface.borderColor).toBeUndefined()
+  })
+
+  it("presses through a state layer of its own ink rather than fading the whole surface", () => {
+    const onPress = jest.fn()
+    const { getByTestId } = render(
+      <Card testID="card" variant="sheet" onPress={onPress} accessibilityRole="button" accessibilityLabel="Open trip">
+        <Text>Body</Text>
+      </Card>
+    )
+
+    const pressable = getByTestId("card")
+    expect(pressable.props.nativeBackgroundAndroid).toEqual(
+      expect.objectContaining({ color: processColor(lightColors.text + STATE_LAYER_ALPHA), borderless: false })
+    )
+
+    fireEvent.press(pressable)
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/src/components/ui/__tests__/Divider.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Divider.test.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { StyleSheet, type StyleProp, type ViewStyle } from "react-native"
+import { render } from "@testing-library/react-native"
+import { lightColors } from "@colota/shared"
+import { Divider } from "../Divider"
+import { size, space } from "../../../constants"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+type StyledElement = { props: { style?: StyleProp<ViewStyle> } }
+
+const styleOf = (element?: StyledElement | null): ViewStyle => StyleSheet.flatten(element?.props.style) ?? {}
+
+describe("Divider", () => {
+  it("is a hairline in the line colour, so it separates without drawing a box", () => {
+    const { getByTestId } = render(<Divider testID="rule" />)
+
+    const style = styleOf(getByTestId("rule"))
+    expect(style.height).toBe(StyleSheet.hairlineWidth)
+    expect(style.backgroundColor).toBe(lightColors.border)
+  })
+
+  it("keeps its 16 margin by default, because the screens that space rows with it have not migrated", () => {
+    const { getByTestId } = render(<Divider testID="rule" />)
+
+    expect(styleOf(getByTestId("rule")).marginVertical).toBe(space.lg)
+  })
+
+  it("drops the margin when tight, so a hairline can sit flush between two rows", () => {
+    const { getByTestId } = render(<Divider testID="rule" tight />)
+
+    expect(styleOf(getByTestId("rule")).marginVertical).toBe(0)
+  })
+
+  it("starts at the inset it is given, so the rule begins at the text column and never at the panel edge", () => {
+    const { getByTestId } = render(<Divider testID="rule" inset={size.iconColumn} />)
+
+    expect(styleOf(getByTestId("rule")).marginStart).toBe(size.iconColumn)
+  })
+
+  it("runs full width when no inset is given", () => {
+    const { getByTestId } = render(<Divider testID="rule" />)
+
+    expect(styleOf(getByTestId("rule")).marginStart).toBe(0)
+  })
+})

--- a/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
@@ -1,0 +1,112 @@
+import React from "react"
+import { Pressable, StyleSheet, Text, processColor, type StyleProp, type TextStyle, type ViewStyle } from "react-native"
+import { render, fireEvent } from "@testing-library/react-native"
+import { lightColors } from "@colota/shared"
+import { Bell } from "lucide-react-native"
+import { ListItem } from "../ListItem"
+import { size, space, STATE_LAYER_ALPHA } from "../../../constants"
+import { text } from "../../../styles/typography"
+
+// The app ships Android only, but the jest preset resolves Platform to iOS,
+// where Pressable drops android_ripple before it reaches the host view.
+jest.mock("react-native/Libraries/Utilities/Platform", () => ({
+  __esModule: true,
+  default: { OS: "android", select: (spec: Record<string, unknown>) => spec.android ?? spec.default }
+}))
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+type StyledElement = { props: { style?: StyleProp<ViewStyle & TextStyle> } }
+
+const styleOf = (element?: StyledElement | null): ViewStyle & TextStyle =>
+  StyleSheet.flatten(element?.props.style) ?? {}
+
+describe("ListItem", () => {
+  it("reads label, sub line and value as one node, because labelling from the label alone loses the sub line", () => {
+    const { getByTestId } = render(
+      <ListItem testID="row" label="Auto-Export" sub="Every day at 03:00" value="12" onPress={jest.fn()} />
+    )
+
+    expect(getByTestId("row").props.accessibilityLabel).toBe("Auto-Export, Every day at 03:00, 12")
+  })
+
+  it("keeps the trailing value out of the reading, so it is not announced twice", () => {
+    const { getByText } = render(<ListItem label="Interval" value="30 s" />)
+
+    const value = getByText("30 s")
+    expect(value.props.importantForAccessibility).toBe("no")
+    expect(styleOf(value).fontSize).toBe(text.figureInline.fontSize)
+  })
+
+  it("leaves a trailing control reachable, because a row that groups it would hide the switch from TalkBack", () => {
+    const onToggle = jest.fn()
+    const { getByTestId, getByLabelText } = render(
+      <ListItem
+        label="Dark mode"
+        sub="Follow the system theme"
+        trailing={<Pressable testID="dark-mode-toggle" onPress={onToggle} />}
+      />
+    )
+
+    expect(getByLabelText("Dark mode, Follow the system theme")).toBeTruthy()
+
+    fireEvent.press(getByTestId("dark-mode-toggle"))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows the chevron only when the row goes somewhere", () => {
+    const { queryByTestId, rerender } = render(<ListItem label="Interval" value="30 s" />)
+    expect(queryByTestId("icon-ChevronRight")).toBeNull()
+
+    rerender(<ListItem label="Connection" onPress={jest.fn()} />)
+    expect(queryByTestId("icon-ChevronRight")).toBeTruthy()
+  })
+
+  it("presses through a bounded state layer of its own ink, not an opacity fade of the whole row", () => {
+    const onPress = jest.fn()
+    const { getByTestId } = render(<ListItem testID="row" label="Connection" onPress={onPress} />)
+
+    const row = getByTestId("row")
+    expect(row.props.nativeBackgroundAndroid).toEqual(
+      expect.objectContaining({ color: processColor(lightColors.text + STATE_LAYER_ALPHA), borderless: false })
+    )
+
+    fireEvent.press(row)
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it("gives the row a full touch target", () => {
+    const { getByTestId } = render(<ListItem testID="row" label="Connection" onPress={jest.fn()} />)
+
+    const style = styleOf(getByTestId("row"))
+    expect(style.minHeight).toBe(size.row)
+    expect(style.paddingVertical).toBe(space.md)
+  })
+
+  it("starts the hairline at the text column, so the rule never closes a shape around the group", () => {
+    const { UNSAFE_getByProps } = render(
+      <ListItem testID="row" icon={Bell} label="Notifications" divider onPress={jest.fn()} />
+    )
+
+    expect(UNSAFE_getByProps({ tight: true }).props.inset).toBe(size.iconColumn)
+  })
+
+  it("runs the hairline to the row edge when there is no icon column to align to", () => {
+    const { UNSAFE_getByProps } = render(<ListItem label="Offline mode" divider trailing={<Text>Off</Text>} />)
+
+    expect(UNSAFE_getByProps({ tight: true }).props.inset).toBe(0)
+  })
+
+  it("hides the leading icon from the reading, because it repeats what the label already says", () => {
+    const { getByTestId } = render(<ListItem icon={Bell} label="Notifications" onPress={jest.fn()} />)
+
+    const icon = getByTestId("icon-Bell")
+    expect(icon.props.color).toBe(lightColors.textSecondary)
+    expect(icon.props.size).toBe(size.icon.md)
+    const column = icon.parent?.parent
+    expect(column?.props.importantForAccessibility).toBe("no")
+    expect(styleOf(column).width).toBe(size.iconColumn)
+  })
+})

--- a/apps/mobile/src/components/ui/__tests__/SectionTitle.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/SectionTitle.test.tsx
@@ -1,0 +1,89 @@
+import React from "react"
+import { StyleSheet, processColor, type StyleProp, type TextStyle, type ViewStyle } from "react-native"
+import { render, fireEvent } from "@testing-library/react-native"
+import { lightColors } from "@colota/shared"
+import { SectionTitle } from "../SectionTitle"
+import { size, space, STATE_LAYER_ALPHA } from "../../../constants"
+import { text } from "../../../styles/typography"
+
+// The app ships Android only, but the jest preset resolves Platform to iOS,
+// where Pressable drops android_ripple before it reaches the host view.
+jest.mock("react-native/Libraries/Utilities/Platform", () => ({
+  __esModule: true,
+  default: { OS: "android", select: (spec: Record<string, unknown>) => spec.android ?? spec.default }
+}))
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+type StyledElement = { props: { style?: StyleProp<ViewStyle & TextStyle> } }
+
+const styleOf = (element?: StyledElement | null): ViewStyle & TextStyle =>
+  StyleSheet.flatten(element?.props.style) ?? {}
+
+describe("SectionTitle", () => {
+  it("is a header, so TalkBack can jump from group to group instead of reading every row", () => {
+    const { getByText } = render(<SectionTitle>Export range</SectionTitle>)
+
+    expect(getByText("Export range").props.accessibilityRole).toBe("header")
+  })
+
+  it("does not shout: the heading role carries the emphasis, not a caps transform", () => {
+    const { getByText } = render(<SectionTitle>Export range</SectionTitle>)
+
+    const style = styleOf(getByText("Export range"))
+    expect(style.textTransform).toBeUndefined()
+    expect(style.fontSize).toBe(text.heading.fontSize)
+    expect(style.color).toBe(lightColors.text)
+  })
+
+  it("opens a gap above itself, because whitespace is what groups the rows below", () => {
+    const { getByTestId } = render(<SectionTitle testID="title">Export range</SectionTitle>)
+
+    expect(styleOf(getByTestId("title")).marginTop).toBe(space.xxl)
+    expect(styleOf(getByTestId("title")).marginBottom).toBe(space.sm)
+  })
+
+  it("drops the top margin when it is first, so a screen does not open on empty space", () => {
+    const { getByTestId } = render(
+      <SectionTitle testID="title" first>
+        Export range
+      </SectionTitle>
+    )
+
+    expect(styleOf(getByTestId("title")).marginTop).toBe(0)
+  })
+
+  it("fires its action and announces it by its visible words", () => {
+    const onPress = jest.fn()
+    const { getByTestId } = render(
+      <SectionTitle action={{ label: "Clear", onPress, testID: "clear-btn" }}>Entries</SectionTitle>
+    )
+
+    const action = getByTestId("clear-btn")
+    expect(action.props.accessibilityLabel).toBe("Clear")
+    expect(action.props.accessibilityRole).toBe("button")
+
+    fireEvent.press(action)
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it("gives the action a full touch target and its own state layer, not the heading's", () => {
+    const { getByTestId } = render(
+      <SectionTitle action={{ label: "Clear", onPress: jest.fn(), testID: "clear-btn" }}>Entries</SectionTitle>
+    )
+
+    const action = getByTestId("clear-btn")
+    expect(styleOf(action).minHeight).toBe(size.touch)
+    expect(action.props.nativeBackgroundAndroid).toEqual(
+      expect.objectContaining({ color: processColor(lightColors.primaryDark + STATE_LAYER_ALPHA) })
+    )
+  })
+
+  it("renders no action slot when none is given", () => {
+    const { queryByRole } = render(<SectionTitle>Entries</SectionTitle>)
+
+    expect(queryByRole("button")).toBeNull()
+  })
+})

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -50,6 +50,9 @@ export const motion = {
 
 export const elevation = { floating: 2 } as const
 
+// M3 interaction-state layer: the primitive's own content colour over its container at 10 percent.
+export const STATE_LAYER_ALPHA = "1A"
+
 // Map
 export const DEFAULT_MAP_ZOOM = 17
 export const WORLD_MAP_ZOOM = 2

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -349,13 +349,13 @@ export function AboutScreen({}: ScreenProps) {
         {showDebugInfo && (
           <>
             <View style={styles.section}>
-              <SectionTitle>BUILD</SectionTitle>
+              <SectionTitle>Build</SectionTitle>
               <InfoCard rows={debugRows} />
             </View>
 
             {deviceRows.length > 0 && (
               <View style={styles.section}>
-                <SectionTitle>DEVICE</SectionTitle>
+                <SectionTitle>Device</SectionTitle>
                 <InfoCard rows={deviceRows} />
               </View>
             )}

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -472,7 +472,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
 
         {/* Template Selector */}
         <View style={styles.section}>
-          <SectionTitle>BACKEND TEMPLATE</SectionTitle>
+          <SectionTitle>Backend template</SectionTitle>
           <ChipGroup
             options={TEMPLATE_OPTIONS}
             selected={localTemplate}
@@ -490,7 +490,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Overland template is POST-only by spec; no need to expose the choice */}
         {localTemplate !== "overland" && (
           <View style={styles.section}>
-            <SectionTitle>HTTP METHOD</SectionTitle>
+            <SectionTitle>HTTP method</SectionTitle>
             <ChipGroup
               options={HTTP_METHOD_OPTIONS}
               selected={localHttpMethod}
@@ -508,7 +508,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Dawarich Mode Selector (Dawarich template only) */}
         {showDawarichChip && (
           <View style={styles.section}>
-            <SectionTitle>DAWARICH MODE</SectionTitle>
+            <SectionTitle>Dawarich mode</SectionTitle>
             <ChipGroup
               options={DAWARICH_MODE_OPTIONS}
               selected={localDawarichMode}
@@ -537,7 +537,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Field Mapping Section */}
         <View style={styles.fieldsSection}>
           <View style={styles.sectionHeader}>
-            <SectionTitle>FIELD MAPPINGS</SectionTitle>
+            <SectionTitle>Field mappings</SectionTitle>
             {hasModifications && (
               <Pressable
                 onPress={handleResetAll}
@@ -621,7 +621,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Custom Fields Section */}
         <View style={styles.fieldsSection}>
           <View style={styles.sectionHeader}>
-            <SectionTitle>CUSTOM FIELDS</SectionTitle>
+            <SectionTitle>Custom fields</SectionTitle>
           </View>
 
           <View style={[styles.fieldsCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
@@ -710,7 +710,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
 
         {/* Example payload preview */}
         <View style={styles.exampleSection}>
-          <SectionTitle>{localHttpMethod === "GET" ? "EXAMPLE REQUEST" : "EXAMPLE PAYLOAD"}</SectionTitle>
+          <SectionTitle>{localHttpMethod === "GET" ? "Example request" : "Example payload"}</SectionTitle>
           <View
             style={[
               styles.exampleCard,

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -409,7 +409,7 @@ export function AutoExportScreen(_props: ScreenProps) {
 
         {/* Export Directory */}
         <View style={styles.section}>
-          <SectionTitle>Export Directory</SectionTitle>
+          <SectionTitle>Export directory</SectionTitle>
           <Card>
             <Pressable
               style={({ pressed }) => [styles.directoryRow, pressed && { opacity: colors.pressedOpacity }]}
@@ -631,7 +631,7 @@ export function AutoExportScreen(_props: ScreenProps) {
         {/* Export History */}
         {exportFiles.length > 0 && (
           <View style={styles.section}>
-            <SectionTitle>Export History</SectionTitle>
+            <SectionTitle>Export history</SectionTitle>
             <Card>
               {exportFiles.map((file, i) => (
                 <View key={file.name}>

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -277,7 +277,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
           {/* Stats */}
           <View style={styles.section}>
-            <SectionTitle>DATABASE STATISTICS</SectionTitle>
+            <SectionTitle>Database statistics</SectionTitle>
             <Card>
               {[
                 ["Total Locations", stats.total.toLocaleString(), colors.text],
@@ -304,7 +304,7 @@ export function DataManagementScreen({}: ScreenProps) {
           {/* Queue Actions */}
           {!isOfflineMode && (
             <View style={styles.section}>
-              <SectionTitle>QUEUE ACTIONS</SectionTitle>
+              <SectionTitle>Queue actions</SectionTitle>
               <Card>
                 <Button onPress={handleManualFlush} disabled={isProcessing || stats.queued === 0} title="Sync Now" />
                 <Text style={[styles.hint, { color: colors.textLight }]}>
@@ -318,7 +318,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
           {/* Cleanup Actions */}
           <View style={styles.section}>
-            <SectionTitle>CLEANUP ACTIONS</SectionTitle>
+            <SectionTitle>Cleanup actions</SectionTitle>
             <Card>
               {!isOfflineMode ? (
                 <>
@@ -414,7 +414,7 @@ export function DataManagementScreen({}: ScreenProps) {
           {/* Dev Tools */}
           {debugMode && (
             <View style={styles.section}>
-              <SectionTitle>DEV TOOLS</SectionTitle>
+              <SectionTitle>Dev tools</SectionTitle>
               <Card>
                 <View style={styles.actionColumn}>
                   <Text style={[styles.actionLabel, { color: colors.text }]}>Insert Dummy Data</Text>

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -105,7 +105,7 @@ export function ExportLocationsScreen({}: ScreenProps) {
 
             {/* Format Selection */}
             <View style={styles.section}>
-              <SectionTitle>Select Format</SectionTitle>
+              <SectionTitle>Select format</SectionTitle>
               <Card>
                 <FormatSelector selectedFormat={selectedFormat} onSelectFormat={setSelectedFormat} />
               </Card>

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -136,7 +136,7 @@ export function ShareSetupScreen() {
         </Card>
 
         <View style={styles.section}>
-          <SectionTitle>INCLUDE</SectionTitle>
+          <SectionTitle>Include</SectionTitle>
           <Card>
             {rows.map((row, i) => (
               <View

--- a/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
@@ -153,7 +153,7 @@ describe("AboutScreen", () => {
     })
   })
 
-  it("shows BUILD section with SDK info when debug enabled", async () => {
+  it("shows the build section with SDK info when debug enabled", async () => {
     const { getByText } = renderScreen()
 
     const versionText = getByText("Version 1.3.0")
@@ -162,7 +162,7 @@ describe("AboutScreen", () => {
     }
 
     await waitFor(() => {
-      expect(getByText("BUILD")).toBeTruthy()
+      expect(getByText("Build")).toBeTruthy()
     })
 
     expect(getByText("FOSS")).toBeTruthy()

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -205,7 +205,7 @@ describe("ApiSettingsScreen", () => {
 
       fireEvent.press(getByText(/^GET$/))
 
-      expect(getByText("EXAMPLE REQUEST")).toBeTruthy()
+      expect(getByText("Example request")).toBeTruthy()
     })
   })
 

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -724,7 +724,7 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Export History")).toBeTruthy()
+      expect(getByText("Export history")).toBeTruthy()
       expect(getByText("colota_export_2026-03-10.geojson")).toBeTruthy()
       expect(getByText("colota_export_2026-03-09.geojson")).toBeTruthy()
     })
@@ -736,7 +736,7 @@ describe("AutoExportScreen", () => {
     const { queryByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(queryByText("Export History")).toBeNull()
+      expect(queryByText("Export history")).toBeNull()
     })
   })
 

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -229,24 +229,24 @@ describe("DataManagementScreen", () => {
     })
   })
 
-  it("shows DEV TOOLS section when debug mode enabled", async () => {
+  it("shows the dev tools section when debug mode enabled", async () => {
     mockGetSetting.mockResolvedValue("true")
 
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("DEV TOOLS")).toBeTruthy()
+      expect(getByText("Dev tools")).toBeTruthy()
       expect(getByText("Insert Dummy Data")).toBeTruthy()
     })
   })
 
-  it("hides DEV TOOLS section when debug mode disabled", async () => {
+  it("hides the dev tools section when debug mode disabled", async () => {
     mockGetSetting.mockResolvedValue("false")
 
     const { queryByText } = renderScreen()
 
     await waitFor(() => {
-      expect(queryByText("DEV TOOLS")).toBeNull()
+      expect(queryByText("Dev tools")).toBeNull()
       expect(queryByText("Insert Dummy Data")).toBeNull()
     })
   })
@@ -294,7 +294,7 @@ describe("DataManagementScreen", () => {
         expect(getByText("Data Management")).toBeTruthy()
       })
 
-      expect(queryByText("QUEUE ACTIONS")).toBeNull()
+      expect(queryByText("Queue actions")).toBeNull()
       expect(queryByText("Sync Now")).toBeNull()
     })
 

--- a/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
@@ -203,7 +203,7 @@ describe("ExportLocationsScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Select Format")).toBeTruthy()
+      expect(getByText("Select format")).toBeTruthy()
     })
   })
 

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -2,4 +2,3 @@
 - Auto-export now deletes old files on storage providers that rename them
 - Unplugging at a low battery no longer restarts tracking in a loop
 - Pause zones no longer take hours to engage when a tracking profile is active
-- A calmer colour palette across the app in both light and dark

--- a/fastlane/metadata/android/en-US/changelogs/50.txt
+++ b/fastlane/metadata/android/en-US/changelogs/50.txt
@@ -1,1 +1,2 @@
 - A calmer colour palette across the app in both light and dark
+- Calmer section headings, and list rows no longer cut off their description


### PR DESCRIPTION
The surface and row primitives of the design rework. Card gets the two real
surfaces, sheet (L1, radius 0 because it meets the map flush) and floating (L2,
elevation in light only, the tonal step carrying it in dark); every other variant
stays in the union as a migration alias that PR 15 deletes. Only default keeps a
border, because dropping it here would strip 62 strokes from screens this PR does
not touch.

SectionTitle stops shouting: heading role in ink, sentence case, an optional
action button, and the header role so TalkBack can jump between groups. The
all-caps source strings are recased with it. ListItem owns the row spec, takes a
trailing control, value or chevron, and composes label, sub and value into one
accessible node, because it labelled from the label alone and never read the sub
line. A row without onPress groups only its text, so a trailing switch stays
reachable. SettingRow is that row without the icon. Divider becomes a hairline
with inset and tight, keeping its 16 margin for the call sites that space rows
with it.

Rows press through the M3 state layer rather than fading the whole row, and the
primitive tests mock Platform to android because the jest preset resolves it to
iOS, where Pressable drops android_ripple before it reaches the view.
