### PR TITLE
chore(icons): lucide provider, size floor, alias normalisation, header shadow

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -7,8 +7,9 @@ import { NavigationContainer, NavigationContainerRef } from "@react-navigation/n
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { View, StatusBar, Platform, StyleSheet } from "react-native"
+import { LucideProvider } from "lucide-react-native"
 import { ThemeProvider, useTheme } from "./src/hooks/useTheme"
-import { fonts } from "./src/styles/typography"
+import { text } from "./src/styles/typography"
 import { TrackingProvider } from "./src/contexts/TrackingProvider"
 import { ErrorBoundary } from "./src/components/ui/ErrorBoundary"
 import type { RootStackParamList, RootStackRoute } from "./src/types/navigation"
@@ -51,6 +52,10 @@ loadDisplayPreferences()
 registerTileServerUserAgent()
 
 const Stack = createNativeStackNavigator<RootStackParamList>()
+
+// One weight for the whole set. absoluteStrokeWidth keeps it 1.5 device pixels at every
+// size, so a 16 badge and a 24 tab glyph read the same rather than the 16 reading heavier.
+const ICON_STROKE_WIDTH = 1.5
 
 type ScreenConfig = { name: RootStackRoute; component: React.ComponentType<any>; title: string }
 
@@ -190,14 +195,12 @@ function AppNavigator() {
   const screenOptions = useMemo(
     () => ({
       headerStyle: {
-        backgroundColor: colors.background,
-        elevation: 0,
-        shadowOpacity: 0
+        backgroundColor: colors.background
       },
+      headerShadowVisible: false,
       headerTintColor: colors.text,
       headerTitleStyle: {
-        ...fonts.bold,
-        fontSize: 18,
+        ...text.title,
         color: colors.text
       },
       headerTitleAlign: "left" as const,
@@ -211,11 +214,9 @@ function AppNavigator() {
   const statusBarConfig = useMemo(
     () => ({
       barStyle: isDark ? ("light-content" as const) : ("dark-content" as const),
-      backgroundColor: colors.background,
-      translucent: false,
       animated: true
     }),
-    [colors.background, isDark]
+    [isDark]
   )
   const linking = useMemo(
     () => ({
@@ -274,13 +275,15 @@ export default function App() {
   // pads itself with the bottom inset, so the provider has to sit above them.
   return (
     <SafeAreaProvider>
-      <ThemeProvider>
-        <ErrorBoundary>
-          <TrackingProvider>
-            <AppNavigator />
-          </TrackingProvider>
-        </ErrorBoundary>
-      </ThemeProvider>
+      <LucideProvider strokeWidth={ICON_STROKE_WIDTH} absoluteStrokeWidth>
+        <ThemeProvider>
+          <ErrorBoundary>
+            <TrackingProvider>
+              <AppNavigator />
+            </TrackingProvider>
+          </ErrorBoundary>
+        </ThemeProvider>
+      </LucideProvider>
     </SafeAreaProvider>
   )
 }

--- a/apps/mobile/__tests__/App.test.tsx
+++ b/apps/mobile/__tests__/App.test.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { StatusBar } from "react-native"
+import { render } from "@testing-library/react-native"
+import { lightColors } from "@colota/shared"
+
+const mockNavigatorProps: Record<string, any>[] = []
+
+jest.mock("@react-navigation/native", () => ({
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => children
+}))
+
+jest.mock("@react-navigation/native-stack", () => ({
+  createNativeStackNavigator: () => ({
+    Navigator: (props: Record<string, any>) => {
+      mockNavigatorProps.push(props)
+      return null
+    },
+    Screen: () => null
+  })
+}))
+
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+jest.mock("../src/hooks/useTheme", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+  useTheme: () => ({ mode: "light", isDark: false, colors: require("@colota/shared").lightColors })
+}))
+
+jest.mock("../src/contexts/TrackingProvider", () => ({
+  TrackingProvider: ({ children }: { children: React.ReactNode }) => children
+}))
+
+jest.mock("../src/components/ui/ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => children
+}))
+
+jest.mock("../src/components", () => ({ BottomTabBar: () => null }))
+
+jest.mock("../src/screens/", () => new Proxy({}, { get: () => () => null }))
+
+jest.mock("../src/i18n", () => ({}))
+jest.mock("../src/utils/geo", () => ({ loadDisplayPreferences: jest.fn() }))
+jest.mock("../src/utils/tileHeaders", () => ({ registerTileServerUserAgent: jest.fn() }))
+
+import App from "../App"
+
+describe("App chrome", () => {
+  beforeEach(() => {
+    mockNavigatorProps.length = 0
+  })
+
+  // One provider is what makes the icon set one weight. absoluteStrokeWidth is the half
+  // that matters at the 16 floor: without it a 1.5 stroke scales down with the box and a
+  // badge reads lighter than the tab glyph above it.
+  it("mounts one Lucide provider carrying the absolute stroke", () => {
+    const { getAllByTestId } = render(<App />)
+
+    const providers = getAllByTestId("icon-LucideProvider")
+    expect(providers).toHaveLength(1)
+    expect(providers[0].props.strokeWidth).toBe(1.5)
+    expect(providers[0].props.absoluteStrokeWidth).toBe(true)
+  })
+
+  // The hairline under every header comes from headerShadowVisible being unset, not from
+  // the elevation and shadowOpacity that used to sit in headerStyle: native-stack ignores
+  // both, so removing them alone would have left the line exactly where it was.
+  it("turns the header shadow off rather than styling it away", () => {
+    render(<App />)
+
+    const { screenOptions } = mockNavigatorProps[0]
+    expect(screenOptions.headerShadowVisible).toBe(false)
+    expect(screenOptions.headerStyle).toEqual({ backgroundColor: lightColors.background })
+  })
+
+  // RN's Android StatusBar module exposes only setStyle and setHidden, so backgroundColor
+  // and translucent reached nothing. barStyle is the one prop that still does something.
+  it("drives the status bar by bar style alone", () => {
+    const { UNSAFE_getByType } = render(<App />)
+
+    const bar = UNSAFE_getByType(StatusBar)
+    expect(bar.props.barStyle).toBe("dark-content")
+    expect(bar.props.backgroundColor).toBeUndefined()
+    expect(bar.props.translucent).toBeUndefined()
+  })
+})

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,7 +25,7 @@
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "i18next": "^26.4.2",
-    "lucide-react-native": "^1.17.0",
+    "lucide-react-native": "^1.31.0",
     "react": "19.2.8",
     "react-native": "0.87.0",
     "react-native-safe-area-context": "^5.8.0",

--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -12,6 +12,7 @@ import { useTracking } from "../../../contexts/TrackingProvider"
 import { ServerStatus, ConnectionStatusProps } from "../../../types/global"
 import { fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
+import { size } from "../../../constants"
 
 export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps) {
   const { colors } = useTheme()
@@ -96,7 +97,7 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
         {isOffline ? "Offline Mode" : displayUrl || "Server"}
       </Text>
       {!isOffline && <Text style={[styles.status, { color: config.color }]}>{config.label}</Text>}
-      <ChevronRight size={16} color={colors.textLight} />
+      <ChevronRight size={size.icon.sm} color={colors.textLight} />
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -5,13 +5,13 @@
 
 import React, { useRef, useEffect, useMemo, useCallback, useState } from "react"
 import { View, StyleSheet, Text, ActivityIndicator, DeviceEventEmitter, Image, Pressable } from "react-native"
-import { AlertTriangle } from "lucide-react-native"
+import { TriangleAlert } from "lucide-react-native"
 import { LocationCoords } from "../../../types/global"
 import { useTheme } from "../../../hooks/useTheme"
 import { useCoords } from "../../../contexts/TrackingProvider"
 import { fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
-import { MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM } from "../../../constants"
+import { size, MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM } from "../../../constants"
 import { MapCenterButton } from "../map/MapCenterButton"
 import { TrackToggleButton } from "../map/TrackToggleButton"
 import { ColotaMapView, ColotaMapRef } from "../map/ColotaMapView"
@@ -184,7 +184,7 @@ export function DashboardMap({
           ]}
         >
           <View style={[styles.iconCircle, { backgroundColor: colors.warning + "20" }]}>
-            <AlertTriangle size={32} color={colors.warning} />
+            <TriangleAlert size={size.icon.lg} color={colors.warning} />
           </View>
           <Text style={[styles.stateTitle, { color: colors.warning }]}>Location Services Off</Text>
           <Text style={[styles.stateSubtext, { color: colors.textSecondary }]}>

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -10,6 +10,7 @@ import { Settings, ThemeColors } from "../../../types/global"
 import { useTracking } from "../../../contexts/TrackingProvider"
 import { fonts } from "../../../styles/typography"
 import { Card } from "../../ui/Card"
+import { size } from "../../../constants"
 
 interface WelcomeCardProps {
   settings: Settings
@@ -42,7 +43,7 @@ function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps
           }
         ]}
       >
-        {completed && <Check size={13} color={colors.success} />}
+        {completed && <Check size={size.icon.sm} color={colors.success} />}
       </View>
       <Text
         style={[
@@ -53,7 +54,7 @@ function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps
       >
         {label}
       </Text>
-      {onPress && !completed && <ChevronRight size={18} color={colors.textLight} />}
+      {onPress && !completed && <ChevronRight size={size.icon.md} color={colors.textLight} />}
     </View>
   )
 

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -10,7 +10,7 @@ import { ThemeColors } from "../../../types/global"
 import { fonts } from "../../../styles/typography"
 import { formatDistance } from "../../../utils/geo"
 import { pad2 } from "../../../utils/format"
-import { HIT_SLOP_LG } from "../../../constants"
+import { size, HIT_SLOP_LG } from "../../../constants"
 
 interface CalendarPickerProps {
   date: Date
@@ -166,7 +166,7 @@ export function CalendarPicker({
           hitSlop={HIT_SLOP_LG}
           style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
         >
-          <ChevronLeft size={22} color={colors.primary} />
+          <ChevronLeft size={size.icon.md} color={colors.primary} />
         </Pressable>
 
         <Pressable
@@ -180,7 +180,7 @@ export function CalendarPicker({
                 <Text style={[styles.todayBadgeText, { color: colors.primary }]}>Today</Text>
               </View>
             )}
-            <Calendar size={14} color={colors.textSecondary} style={styles.calendarIcon} />
+            <Calendar size={size.icon.sm} color={colors.textSecondary} style={styles.calendarIcon} />
           </View>
           <Text style={[styles.countText, { color: colors.textSecondary }]}>
             {locationCount} {locationCount === 1 ? "location" : "locations"}
@@ -194,7 +194,7 @@ export function CalendarPicker({
           style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
           disabled={isToday}
         >
-          <ChevronRight size={22} color={isToday ? colors.textDisabled : colors.primary} />
+          <ChevronRight size={size.icon.md} color={isToday ? colors.textDisabled : colors.primary} />
         </Pressable>
       </View>
 
@@ -222,7 +222,7 @@ export function CalendarPicker({
               hitSlop={HIT_SLOP_LG}
               style={({ pressed }) => [styles.monthNav, pressed && { opacity: colors.pressedOpacity }]}
             >
-              <ChevronLeft size={18} color={colors.primary} />
+              <ChevronLeft size={size.icon.md} color={colors.primary} />
             </Pressable>
             <Text style={[styles.monthLabel, { color: colors.text }]}>{monthLabel}</Text>
             <Pressable
@@ -231,7 +231,7 @@ export function CalendarPicker({
               style={({ pressed }) => [styles.monthNav, pressed && { opacity: colors.pressedOpacity }]}
               disabled={isFutureMonth}
             >
-              <ChevronRight size={18} color={isFutureMonth ? colors.textDisabled : colors.primary} />
+              <ChevronRight size={size.icon.md} color={isFutureMonth ? colors.textDisabled : colors.primary} />
             </Pressable>
           </View>
 

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -21,7 +21,7 @@ import {
   type TrackLocation
 } from "../map/mapUtils"
 import { getSpeedUnit } from "../../../utils/geo"
-import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS } from "../../../constants"
+import { size, DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS } from "../../../constants"
 
 const HAS_NOTE = ["!=", ["get", "note"], ""]
 const trackPointStyle: any = {
@@ -297,7 +297,7 @@ export function TrackMap({
       {isEmpty && (
         <View style={[styles.emptyOverlay, { backgroundColor: colors.card, borderRadius: colors.borderRadius }]}>
           <View style={[styles.iconCircle, { backgroundColor: colors.border }]}>
-            <MapPinOff size={32} color={colors.textSecondary} />
+            <MapPinOff size={size.icon.lg} color={colors.textSecondary} />
           </View>
           <Text style={[styles.emptyTitle, { color: colors.text }]}>No Locations</Text>
           <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>No tracked locations for this day.</Text>
@@ -320,7 +320,7 @@ export function TrackMap({
                   accessibilityRole="button"
                   accessibilityLabel="Start a new trip at this point"
                 >
-                  <Split size={16} color={colors.text} />
+                  <Split size={size.icon.sm} color={colors.text} />
                 </Pressable>
               )}
               {onPointDelete && popup.id >= 0 && (
@@ -332,7 +332,7 @@ export function TrackMap({
                   accessibilityRole="button"
                   accessibilityLabel="Delete this point"
                 >
-                  <Trash2 size={16} color={colors.error} />
+                  <Trash2 size={size.icon.sm} color={colors.error} />
                 </Pressable>
               )}
               <Pressable
@@ -343,7 +343,7 @@ export function TrackMap({
                 hitSlop={HIT_SLOP_MD}
                 style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
               >
-                <X size={16} color={colors.textSecondary} />
+                <X size={size.icon.sm} color={colors.textSecondary} />
               </Pressable>
             </View>
           </View>
@@ -385,7 +385,7 @@ export function TrackMap({
                       hitSlop={HIT_SLOP_MD}
                       style={({ pressed }) => [styles.noteSaveBtn, pressed && { opacity: colors.pressedOpacity }]}
                     >
-                      <Check size={18} color={colors.primary} />
+                      <Check size={size.icon.md} color={colors.primary} />
                     </Pressable>
                   )}
                 </View>

--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -12,7 +12,7 @@ import { formatDistance, formatDuration, formatSpeed, formatTime } from "../../.
 import type { Trip, ThemeColors } from "../../../types/global"
 import { getTripColor, computeTripStats, type TripStats } from "../../../utils/trips"
 import { EXPORT_FORMATS, EXPORT_FORMAT_KEYS, type ExportFormat } from "../../../utils/exportConverters"
-import { HIT_SLOP_SM } from "../../../constants"
+import { size, HIT_SLOP_SM } from "../../../constants"
 
 interface TripListProps {
   trips: Trip[]
@@ -83,28 +83,28 @@ const TripRow = React.memo(function TripRow({
 
       <View style={styles.tripStats}>
         <View style={styles.stat}>
-          <Route size={13} color={colors.textSecondary} />
+          <Route size={size.icon.sm} color={colors.textSecondary} />
           <Text style={[styles.statText, { color: colors.text }]}>{formatDistance(trip.distance)}</Text>
         </View>
         <View style={styles.stat}>
-          <Clock size={13} color={colors.textSecondary} />
+          <Clock size={size.icon.sm} color={colors.textSecondary} />
           <Text style={[styles.statText, { color: colors.text }]}>{formatDuration(duration)}</Text>
         </View>
         {stats && stats.avgSpeed > 0 && (
           <View style={styles.stat}>
-            <Gauge size={13} color={colors.textSecondary} />
+            <Gauge size={size.icon.sm} color={colors.textSecondary} />
             <Text style={[styles.statText, { color: colors.text }]}>{formatSpeed(stats.avgSpeed)}</Text>
           </View>
         )}
         {stats && stats.elevationGain > 0 && (
           <View style={styles.stat}>
-            <TrendingUp size={13} color={colors.textSecondary} />
+            <TrendingUp size={size.icon.sm} color={colors.textSecondary} />
             <Text style={[styles.statText, { color: colors.text }]}>{Math.round(stats.elevationGain)}m</Text>
           </View>
         )}
         {stats && stats.elevationLoss > 0 && (
           <View style={styles.stat}>
-            <TrendingDown size={13} color={colors.textSecondary} />
+            <TrendingDown size={size.icon.sm} color={colors.textSecondary} />
             <Text style={[styles.statText, { color: colors.text }]}>{Math.round(stats.elevationLoss)}m</Text>
           </View>
         )}
@@ -245,7 +245,7 @@ export function TripList({
   if (trips.length === 0) {
     return (
       <View style={styles.emptyContainer}>
-        <Route size={40} color={colors.textDisabled} />
+        <Route size={size.icon.lg} color={colors.textDisabled} />
         <Text style={[styles.emptyText, { color: colors.textSecondary }]}>No trips for this day</Text>
         <Text style={[styles.emptyHint, { color: colors.textDisabled }]}>Need at least 2 points to form a trip</Text>
       </View>
@@ -264,7 +264,7 @@ export function TripList({
               accessibilityRole="button"
               accessibilityLabel="Cancel selection"
             >
-              <X size={18} color={colors.text} />
+              <X size={size.icon.md} color={colors.text} />
             </Pressable>
             <Text style={[styles.cabSummary, { color: colors.text }]}>{selected.size} selected</Text>
           </View>
@@ -289,7 +289,7 @@ export function TripList({
                 accessibilityLabel="Export selected trips"
                 accessibilityState={{ expanded: showExport }}
               >
-                <Share size={18} color={showExport ? colors.primary : colors.text} />
+                <Share size={size.icon.md} color={showExport ? colors.primary : colors.text} />
               </Pressable>
             )}
             {onMerge && trips.length >= 2 && (
@@ -303,7 +303,7 @@ export function TripList({
                 accessibilityHint={isAdjacentSelection ? undefined : "Select two or more adjacent trips to merge them"}
                 accessibilityState={{ disabled: !isAdjacentSelection }}
               >
-                <Merge size={18} color={isAdjacentSelection ? colors.text : colors.textDisabled} />
+                <Merge size={size.icon.md} color={isAdjacentSelection ? colors.text : colors.textDisabled} />
               </Pressable>
             )}
             {onDelete && (
@@ -314,7 +314,7 @@ export function TripList({
                 accessibilityRole="button"
                 accessibilityLabel="Delete selected trips"
               >
-                <Trash2 size={18} color={colors.error} />
+                <Trash2 size={size.icon.md} color={colors.error} />
               </Pressable>
             )}
           </View>
@@ -332,7 +332,7 @@ export function TripList({
               accessibilityLabel="Export all trips"
               accessibilityState={{ expanded: showExport }}
             >
-              <Share size={14} color={showExport ? colors.primary : colors.textSecondary} />
+              <Share size={size.icon.sm} color={showExport ? colors.primary : colors.textSecondary} />
               <Text style={[styles.exportAllLabel, { color: showExport ? colors.primary : colors.textSecondary }]}>
                 Export All
               </Text>

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -11,7 +11,7 @@ import type { NativeSyntheticEvent } from "react-native"
 import { Compass, Info, X } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
-import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_LIGHT, MAP_STYLE_URL_DARK } from "../../../constants"
+import { size, DEFAULT_MAP_ZOOM, MAP_STYLE_URL_LIGHT, MAP_STYLE_URL_DARK } from "../../../constants"
 import { fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
@@ -196,7 +196,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
       {showCompass && (
         <MapActionButton onPress={handleCompassPress} style={[mapActionStyles.right, styles.compassPosition]}>
           <View style={{ transform: [{ rotate: `${-heading}deg` }] }}>
-            <Compass size={20} color={colors.textLight} />
+            <Compass size={size.icon.md} color={colors.textLight} />
           </View>
         </MapActionButton>
       )}
@@ -210,7 +210,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
             accessibilityRole="button"
             accessibilityLabel="Show map attribution"
           >
-            <Info size={20} color={colors.textLight} />
+            <Info size={size.icon.md} color={colors.textLight} />
           </MapActionButton>
 
           <Modal
@@ -232,7 +232,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
                   accessibilityLabel="Close"
                   style={({ pressed }) => [styles.attributionClose, pressed && { opacity: colors.pressedOpacity }]}
                 >
-                  <X size={20} color={colors.textLight} />
+                  <X size={size.icon.md} color={colors.textLight} />
                 </Pressable>
                 {attributionLinks.map((link) => (
                   <Pressable

--- a/apps/mobile/src/components/features/map/MapCenterButton.tsx
+++ b/apps/mobile/src/components/features/map/MapCenterButton.tsx
@@ -8,6 +8,7 @@ import { ViewStyle, StyleProp, StyleSheet } from "react-native"
 import { LocateFixed } from "lucide-react-native"
 import { useTheme } from "../../../hooks/useTheme"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
+import { size } from "../../../constants"
 
 interface Props {
   onPress: () => void
@@ -22,7 +23,7 @@ export const MapCenterButton: React.FC<Props> = ({ onPress, visible, style }) =>
 
   return (
     <MapActionButton onPress={onPress} style={[mapActionStyles.right, styles.position, style]}>
-      <LocateFixed size={20} color={colors.textLight} />
+      <LocateFixed size={size.icon.md} color={colors.textLight} />
     </MapActionButton>
   )
 }

--- a/apps/mobile/src/components/features/map/TrackToggleButton.tsx
+++ b/apps/mobile/src/components/features/map/TrackToggleButton.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { Route } from "lucide-react-native"
 import { useTheme } from "../../../hooks/useTheme"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
+import { size } from "../../../constants"
 
 interface Props {
   onPress: () => void
@@ -18,7 +19,7 @@ export function TrackToggleButton({ onPress, active }: Props) {
 
   return (
     <MapActionButton onPress={onPress} style={mapActionStyles.left}>
-      <Route size={20} color={active ? colors.primary : colors.textLight} />
+      <Route size={size.icon.md} color={active ? colors.primary : colors.textLight} />
     </MapActionButton>
   )
 }

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useCallback, useEffect, useRef } from "react"
 import { Text, StyleSheet, TextInput, View, Pressable } from "react-native"
-import { CheckCircle, ChevronRight } from "lucide-react-native"
+import { CircleCheckBig, ChevronRight } from "lucide-react-native"
 import { Settings, ThemeColors } from "../../../types/global"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { isEndpointAllowed } from "../../../utils/settingsValidation"
@@ -15,7 +15,7 @@ import { fonts } from "../../../styles/typography"
 import { SettingRow } from "../../ui/SettingRow"
 import { Toggle } from "../../ui/Toggle"
 import { useTimeout } from "../../../hooks/useTimeout"
-import { TEST_RESULT_DISPLAY_MS } from "../../../constants"
+import { size, TEST_RESULT_DISPLAY_MS } from "../../../constants"
 import { logger } from "../../../utils/logger"
 import { Button, Card, SectionTitle, Divider, FieldMessage } from "../../index"
 import { showChoice } from "../../../services/modalService"
@@ -274,7 +274,7 @@ export function ConnectionSettings({
                   }
                 ]}
               >
-                {!testError && <CheckCircle size={16} color={colors.success} />}
+                {!testError && <CircleCheckBig size={size.icon.sm} color={colors.success} />}
                 <Text style={[styles.responseText, { color: testError ? colors.error : colors.success }]}>
                   {testResponse}
                 </Text>
@@ -293,7 +293,7 @@ export function ConnectionSettings({
                   Basic auth, bearer tokens, custom headers
                 </Text>
               </View>
-              <ChevronRight size={20} color={colors.textLight} />
+              <ChevronRight size={size.icon.md} color={colors.textLight} />
             </Pressable>
           </>
         )}

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -4,13 +4,13 @@
  */
 import React from "react"
 import { View, Text, StyleSheet, Pressable } from "react-native"
-import { AlertTriangle, ChevronRight } from "lucide-react-native"
+import { TriangleAlert, ChevronRight } from "lucide-react-native"
 import { useTracking } from "../../../contexts/TrackingProvider"
 import { useTheme } from "../../../hooks/useTheme"
 import { getQueueColor } from "../../../utils/queueStatus"
 import { formatCount } from "../../../utils/format"
 import { fonts } from "../../../styles/typography"
-import { HIGH_QUEUE_THRESHOLD, CRITICAL_QUEUE_THRESHOLD } from "../../../constants"
+import { size, HIGH_QUEUE_THRESHOLD, CRITICAL_QUEUE_THRESHOLD } from "../../../constants"
 
 interface StatsCardProps {
   queueCount: number
@@ -148,7 +148,7 @@ export function StatsCard({ queueCount, sentCount, todayCount, interval, onManag
             onPress={onManageClick}
           >
             <View style={styles.warningContent}>
-              <AlertTriangle size={20} color={warningLevel === "critical" ? colors.error : colors.warning} />
+              <TriangleAlert size={size.icon.md} color={warningLevel === "critical" ? colors.error : colors.warning} />
               <View style={styles.warningText}>
                 <Text
                   style={[
@@ -163,7 +163,7 @@ export function StatsCard({ queueCount, sentCount, todayCount, interval, onManag
                 <Text style={[styles.warningHint, { color: colors.textSecondary }]}>Tap to manage data</Text>
               </View>
             </View>
-            <ChevronRight size={20} color={warningLevel === "critical" ? colors.error : colors.warning} />
+            <ChevronRight size={size.icon.md} color={warningLevel === "critical" ? colors.error : colors.warning} />
           </Pressable>
         </View>
       )}

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -8,7 +8,13 @@ import { Text, StyleSheet, View, Pressable, TextInput, AppState } from "react-na
 import { Lightbulb, ChevronDown, ChevronUp } from "lucide-react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
 import { fonts, fontSizes } from "../../../styles/typography"
-import { SYNC_INTERVAL_PRESETS, SYNC_INTERVAL_LABELS, OVERLAND_BATCH_MIN, OVERLAND_BATCH_MAX } from "../../../constants"
+import {
+  size,
+  SYNC_INTERVAL_PRESETS,
+  SYNC_INTERVAL_LABELS,
+  OVERLAND_BATCH_MIN,
+  OVERLAND_BATCH_MAX
+} from "../../../constants"
 import { SectionTitle, Card, Divider, NumericInput, SettingRow, Toggle } from "../../index"
 import { PresetOption } from "./PresetOption"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
@@ -166,9 +172,9 @@ export function SyncStrategySettings({
         >
           <Text style={[styles.advancedText, { color: colors.text }]}>Advanced Settings</Text>
           {showAdvanced ? (
-            <ChevronUp size={20} color={colors.textLight} />
+            <ChevronUp size={size.icon.md} color={colors.textLight} />
           ) : (
-            <ChevronDown size={20} color={colors.textLight} />
+            <ChevronDown size={size.icon.md} color={colors.textLight} />
           )}
         </Pressable>
 
@@ -177,7 +183,7 @@ export function SyncStrategySettings({
             {settings.syncPreset === "custom" && (
               <View style={[styles.customBanner, { backgroundColor: colors.info + "15" }]}>
                 <View style={styles.bannerRow}>
-                  <Lightbulb size={14} color={colors.info} />
+                  <Lightbulb size={size.icon.sm} color={colors.info} />
                   <Text style={[styles.customBannerText, { color: colors.info }]}>Using custom configuration</Text>
                 </View>
               </View>

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -46,7 +46,7 @@ jest.mock("lucide-react-native", () => {
   const R = require("react")
   const { View } = require("react-native")
   return {
-    CheckCircle: () => R.createElement(View, null),
+    CircleCheckBig: () => R.createElement(View, null),
     ChevronRight: () => R.createElement(View, null)
   }
 })

--- a/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
@@ -23,7 +23,7 @@ jest.mock("lucide-react-native", () => {
   const R = require("react")
   const { View } = require("react-native")
   return {
-    AlertTriangle: () => R.createElement(View, null),
+    TriangleAlert: () => R.createElement(View, null),
     ChevronRight: () => R.createElement(View, null)
   }
 })

--- a/apps/mobile/src/components/icons/RouteHistory.tsx
+++ b/apps/mobile/src/components/icons/RouteHistory.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import React from "react"
+import Svg, { Circle, Path } from "react-native-svg"
+import { useLucideContext } from "lucide-react-native"
+
+const VIEW_BOX = 24
+const DEFAULT_SIZE = 24
+const DEFAULT_STROKE_WIDTH = 2
+
+type RouteHistoryProps = {
+  size?: number
+  color?: string
+  strokeWidth?: number
+  absoluteStrokeWidth?: boolean
+}
+
+/**
+ * The History tab's own mark: a travelled route ending in one terminal ring, drawn on
+ * Lucide's 24 grid inside its 2..22 live area with round caps and joins so it reads as a
+ * member of the set rather than a guest. Stroke and the absolute-width rule come from the
+ * same `LucideProvider` every Lucide glyph reads, so this one cannot drift from them.
+ *
+ * The provider is unreachable under the lucide Proxy mock in `jest.setup.js`, where the
+ * hook resolves to a component, so the defaults below are what a test sees.
+ */
+export function RouteHistory({
+  size = DEFAULT_SIZE,
+  color = "currentColor",
+  strokeWidth,
+  absoluteStrokeWidth
+}: RouteHistoryProps) {
+  const context = useLucideContext() ?? {}
+  const width = strokeWidth ?? context.strokeWidth ?? DEFAULT_STROKE_WIDTH
+  const absolute = absoluteStrokeWidth ?? context.absoluteStrokeWidth ?? false
+  const stroke = absolute ? (width * VIEW_BOX) / size : width
+
+  return (
+    <Svg
+      testID="icon-RouteHistory"
+      width={size}
+      height={size}
+      viewBox={`0 0 ${VIEW_BOX} ${VIEW_BOX}`}
+      fill="none"
+      stroke={color}
+      strokeWidth={stroke}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <Circle cx={6} cy={19} r={3} fill="none" stroke={color} strokeWidth={stroke} />
+      <Path
+        d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H18"
+        fill="none"
+        stroke={color}
+        strokeWidth={stroke}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}

--- a/apps/mobile/src/components/icons/__tests__/RouteHistory.test.tsx
+++ b/apps/mobile/src/components/icons/__tests__/RouteHistory.test.tsx
@@ -1,0 +1,89 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+// jest.setup.js mocks the whole of lucide with a Proxy that hands back a component for
+// every property, so useLucideContext resolves to a component there and the provider is
+// unreachable. Swapping in the library's real context module is what makes "this glyph
+// cannot drift from the provider" an assertion rather than a device check. It has to be
+// the CJS build reached by file path: the ESM barrel is untransformed, which is why the
+// global mock exists at all, and the package's exports map hides every deep subpath.
+jest.mock("lucide-react-native", () =>
+  jest.requireActual("../../../../../../node_modules/lucide-react-native/dist/cjs/context.js")
+)
+
+const { LucideProvider } = require("lucide-react-native")
+const { RouteHistory } = require("../RouteHistory")
+
+const glyph = (tree: { getByTestId: (id: string) => { props: Record<string, unknown> } }) =>
+  tree.getByTestId("icon-RouteHistory").props
+
+describe("RouteHistory", () => {
+  // Lucide's own construction rules: the 24 box, no fill, round terminals. A glyph drawn
+  // to a different grid sits beside the set instead of inside it, which is the whole
+  // reason the tab bar draws this one by hand rather than borrowing a near-miss.
+  it("is drawn on Lucide's grid with open, round-terminated strokes", () => {
+    const props = glyph(render(<RouteHistory color="#123456" />))
+
+    expect(props.viewBox).toBe("0 0 24 24")
+    expect(props.fill).toBe("none")
+    expect(props.stroke).toBe("#123456")
+    expect(props.strokeLinecap).toBe("round")
+    expect(props.strokeLinejoin).toBe("round")
+  })
+
+  // The provider is the single weight for the whole icon set. If this glyph read a
+  // constant instead, the tab bar would drift the moment the provider's value moved.
+  it("takes its stroke from the provider", () => {
+    const props = glyph(
+      render(
+        <LucideProvider strokeWidth={1.5}>
+          <RouteHistory size={24} />
+        </LucideProvider>
+      )
+    )
+
+    expect(props.strokeWidth).toBe(1.5)
+  })
+
+  // absoluteStrokeWidth is what keeps a 16 badge and a 24 tab glyph the same weight on
+  // screen: the viewBox stroke has to grow as the box shrinks, 1.5 * 24 / 16 = 2.25.
+  it("scales the viewBox stroke so the painted weight holds at every size", () => {
+    const at24 = glyph(
+      render(
+        <LucideProvider strokeWidth={1.5} absoluteStrokeWidth>
+          <RouteHistory size={24} />
+        </LucideProvider>
+      )
+    )
+    const at16 = glyph(
+      render(
+        <LucideProvider strokeWidth={1.5} absoluteStrokeWidth>
+          <RouteHistory size={16} />
+        </LucideProvider>
+      )
+    )
+
+    expect(at24.strokeWidth).toBe(1.5)
+    expect(at16.strokeWidth).toBe(2.25)
+  })
+
+  // The active tab is carried by weight, so a per-icon strokeWidth has to beat the
+  // provider the same way it does for every Lucide glyph.
+  it("lets a per-icon strokeWidth override the provider", () => {
+    const props = glyph(
+      render(
+        <LucideProvider strokeWidth={1.5} absoluteStrokeWidth>
+          <RouteHistory size={24} strokeWidth={2.25} />
+        </LucideProvider>
+      )
+    )
+
+    expect(props.strokeWidth).toBe(2.25)
+  })
+
+  // Without a provider the glyph still has to render, because that is what every test in
+  // the tree sees under the Proxy mock, and Lucide's own default is a 2 unit stroke.
+  it("falls back to Lucide's default weight with no provider above it", () => {
+    expect(glyph(render(<RouteHistory size={24} />)).strokeWidth).toBe(2)
+  })
+})

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -5,26 +5,29 @@
 import React from "react"
 import { View, Pressable, Text, StyleSheet } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { Settings, LucideIcon, House, MapPinHouse, Waypoints } from "lucide-react-native"
+import { CircleDotDashed, House, Settings } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fonts, text } from "../../styles/typography"
 import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+import { RouteHistory } from "../icons/RouteHistory"
 
 // The set has no filled variants, so the active tab is carried by weight instead.
 const ACTIVE_STROKE_WIDTH = 2.25
 const RIPPLE_RADIUS = 20
 
+type TabIcon = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
+
 interface Tab {
   name: string
   label: string
-  icon: LucideIcon
+  icon: TabIcon
   route: string
 }
 
 const TABS: Tab[] = [
   { name: "dashboard", label: "Dashboard", icon: House, route: "Dashboard" },
-  { name: "history", label: "History", icon: Waypoints, route: "Location History" },
-  { name: "geofences", label: "Geofences", icon: MapPinHouse, route: "Geofences" },
+  { name: "history", label: "History", icon: RouteHistory, route: "Location History" },
+  { name: "geofences", label: "Geofences", icon: CircleDotDashed, route: "Geofences" },
   { name: "settings", label: "Settings", icon: Settings, route: "Settings" }
 ]
 

--- a/apps/mobile/src/components/ui/__tests__/BottomTabBar.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/BottomTabBar.test.tsx
@@ -39,13 +39,25 @@ describe("BottomTabBar", () => {
   it("thickens the active glyph and its label", () => {
     const { getByTestId, getByText } = render(<BottomTabBar currentRoute="Geofences" onNavigate={jest.fn()} />)
 
-    expect(getByTestId("icon-MapPinHouse").props.strokeWidth).toBe(2.25)
+    expect(getByTestId("icon-CircleDotDashed").props.strokeWidth).toBe(2.25)
     expect(getByTestId("icon-House").props.strokeWidth).toBeUndefined()
 
     const active = flatten(getByText("Geofences").props.style)
     expect(active.color).toBe(lightColors.primary)
     expect(active.fontFamily).toBe(`${fontFamily}-SemiBold`)
     expect(flatten(getByText("Dashboard").props.style).color).toBe(lightColors.textSecondary)
+  })
+
+  // History is the one route Lucide has no honest glyph for, so the bar draws its own.
+  // A Lucide export slipping back in here would silently undo that identity.
+  it("draws History with the app's own route mark and every other tab from Lucide", () => {
+    const { getByTestId } = render(<BottomTabBar currentRoute="Location History" onNavigate={jest.fn()} />)
+
+    expect(getByTestId("icon-RouteHistory")).toBeTruthy()
+    expect(getByTestId("icon-RouteHistory").props.strokeWidth).toBe(2.25)
+    expect(getByTestId("icon-House")).toBeTruthy()
+    expect(getByTestId("icon-CircleDotDashed")).toBeTruthy()
+    expect(getByTestId("icon-Settings")).toBeTruthy()
   })
 
   // The label grows with the font scale instead of being clipped to one line, so the bar

--- a/apps/mobile/src/components/ui/__tests__/Notice.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Notice.test.tsx
@@ -19,7 +19,7 @@ describe("Notice", () => {
     )
 
     expect(flatten(getByTestId("notice-rule").props.style).backgroundColor).toBe(lightColors.warning)
-    expect(getByTestId("icon-AlertTriangle").props.color).toBe(lightColors.warning)
+    expect(getByTestId("icon-TriangleAlert").props.color).toBe(lightColors.warning)
     expect(flatten(getByText("Queue is filling up").props.style).color).toBe(lightColors.text)
     expect(flatten(getByText("128 points are waiting").props.style).color).toBe(lightColors.textSecondary)
   })

--- a/apps/mobile/src/components/ui/semantic.ts
+++ b/apps/mobile/src/components/ui/semantic.ts
@@ -3,16 +3,16 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import { Info, AlertCircle, AlertTriangle, CheckCircle } from "lucide-react-native"
+import { Info, CircleAlert, TriangleAlert, CircleCheckBig } from "lucide-react-native"
 import type { ThemeColors } from "../../types/global"
 
 export type SemanticVariant = "info" | "success" | "warning" | "error"
 
 export const SEMANTIC_ICONS = {
   info: Info,
-  success: CheckCircle,
-  warning: AlertTriangle,
-  error: AlertCircle
+  success: CircleCheckBig,
+  warning: TriangleAlert,
+  error: CircleAlert
 } as const
 
 export function semanticColor(variant: SemanticVariant, colors: ThemeColors): string {

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -13,7 +13,7 @@ import { Card, Container, Divider, SectionTitle, Footer } from "../components"
 import { useTimeout } from "../hooks/useTimeout"
 import NativeLocationService from "../services/NativeLocationService"
 import icon from "../assets/icons/icon.png"
-import { REPO_URL, ISSUES_URL, PRIVACY_POLICY_URL, TILE_SERVER_DOCS_URL } from "../constants"
+import { size, REPO_URL, ISSUES_URL, PRIVACY_POLICY_URL, TILE_SERVER_DOCS_URL } from "../constants"
 import { logger } from "../utils/logger"
 
 // Helper function to map SDK to Android version
@@ -67,12 +67,12 @@ const LinkRow = ({
     style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
     onPress={() => onOpenURL(url)}
   >
-    <Icon size={20} color={colors.textLight} />
+    <Icon size={size.icon.md} color={colors.textLight} />
     <View style={styles.linkTextContainer}>
       <Text style={[styles.linkTitle, { color: colors.text }]}>{title}</Text>
       <Text style={[styles.linkSubtitle, { color: colors.textLight }]}>{subtitle}</Text>
     </View>
-    <ExternalLink size={18} color={colors.textLight} />
+    <ExternalLink size={size.icon.md} color={colors.textLight} />
   </Pressable>
 )
 
@@ -268,7 +268,7 @@ export function AboutScreen({}: ScreenProps) {
                 pressed && { opacity: colors.pressedOpacity }
               ]}
             >
-              <Bug size={14} color={colors.warning} />
+              <Bug size={size.icon.sm} color={colors.warning} />
               <Text style={[styles.debugText, { color: colors.warning }]}>Debug Mode (tap to hide)</Text>
             </Pressable>
           )}
@@ -327,7 +327,7 @@ export function AboutScreen({}: ScreenProps) {
                   Self-hosted map tile server - configure your own
                 </Text>
               </View>
-              <ExternalLink size={18} color={colors.textLight} />
+              <ExternalLink size={size.icon.md} color={colors.textLight} />
             </Pressable>
             <Divider />
             <Pressable
@@ -340,7 +340,7 @@ export function AboutScreen({}: ScreenProps) {
                   Map data by OpenStreetMap contributors
                 </Text>
               </View>
-              <ExternalLink size={18} color={colors.textLight} />
+              <ExternalLink size={size.icon.md} color={colors.textLight} />
             </Pressable>
           </Card>
         </View>
@@ -369,7 +369,11 @@ export function AboutScreen({}: ScreenProps) {
                 ]}
                 onPress={handleCopyDebugInfo}
               >
-                {copied ? <Check size={16} color={colors.success} /> : <Copy size={16} color={colors.primaryDark} />}
+                {copied ? (
+                  <Check size={size.icon.sm} color={colors.success} />
+                ) : (
+                  <Copy size={size.icon.sm} color={colors.primaryDark} />
+                )}
                 <Text style={[styles.copyButtonText, { color: copied ? colors.success : colors.primaryDark }]}>
                   {copied ? "Copied!" : "Copy Debug Info"}
                 </Text>

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -26,6 +26,7 @@ import { logger, LOG_LEVELS, type LogLevel } from "../utils/logger"
 import { getMergedLogs, exportLogs, MergedLogEntry } from "../utils/logExport"
 import NativeLocationService from "../services/NativeLocationService"
 import { ScreenProps } from "../types/global"
+import { size } from "../constants"
 
 type FilterLevel = LogLevel
 
@@ -111,7 +112,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
           {exporting ? (
             <ActivityIndicator size={18} color={colors.primary} />
           ) : (
-            <Share2 size={20} color={colors.primary} />
+            <Share2 size={size.icon.md} color={colors.primary} />
           )}
         </Pressable>
       </View>
@@ -204,7 +205,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
       {tabBar}
       <View style={styles.filterBar}>
         <View style={[styles.searchContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
-          <Search size={16} color={colors.textLight} />
+          <Search size={size.icon.sm} color={colors.textLight} />
           <TextInput
             style={[styles.searchInput, { color: colors.text }]}
             placeholder="Filter logs..."
@@ -216,7 +217,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
           />
           {searchQuery.length > 0 && (
             <Pressable onPress={() => setSearchQuery("")}>
-              <X size={16} color={colors.textLight} />
+              <X size={size.icon.sm} color={colors.textLight} />
             </Pressable>
           )}
         </View>
@@ -296,7 +297,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
           onPress={scrollToEnd}
           style={[styles.scrollEndButton, { backgroundColor: colors.primary, bottom: insets.bottom + 24 }]}
         >
-          <ArrowDown size={20} color={colors.textOnPrimary} />
+          <ArrowDown size={size.icon.md} color={colors.textOnPrimary} />
         </Pressable>
       ) : filteredLogs.length > 0 ? (
         <View style={[styles.followingBadge, { backgroundColor: colors.primary + "20", bottom: insets.bottom + 24 }]}>

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -15,6 +15,7 @@ import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
 import type { UnitSystem, TimeFormat } from "../utils/geo"
+import { size } from "../constants"
 
 export function AppearanceScreen({}: ScreenProps) {
   const { mode, toggleTheme, colors } = useTheme()
@@ -167,9 +168,9 @@ export function AppearanceScreen({}: ScreenProps) {
               <Text style={[styles.linkSub, { color: colors.textSecondary }]}>{t("appearance.mapStyle.subtitle")}</Text>
             </View>
             {showMapTileServer ? (
-              <ChevronUp size={20} color={colors.textLight} />
+              <ChevronUp size={size.icon.md} color={colors.textLight} />
             ) : (
-              <ChevronDown size={20} color={colors.textLight} />
+              <ChevronDown size={size.icon.md} color={colors.textLight} />
             )}
           </Pressable>
 

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -15,6 +15,7 @@ import { SectionTitle, Toast, Container, Card, Divider, ChipGroup } from "../com
 import NativeLocationService from "../services/NativeLocationService"
 import { logger } from "../utils/logger"
 import { findDuplicates } from "../utils/settingsValidation"
+import { size } from "../constants"
 
 const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
   { value: "none", label: "None" },
@@ -352,7 +353,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
                   Authenticate to servers that require a client certificate
                 </Text>
               </View>
-              <ChevronRight size={20} color={colors.textLight} />
+              <ChevronRight size={size.icon.md} color={colors.textLight} />
             </Pressable>
           </Card>
         </View>

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -6,7 +6,7 @@
 import { useState, useCallback, useEffect } from "react"
 import { useFocusEffect } from "@react-navigation/native"
 import { Text, StyleSheet, View, ScrollView, Pressable, DeviceEventEmitter, TextInput } from "react-native"
-import { FolderOpen, CheckCircle, Share2, AlertTriangle } from "lucide-react-native"
+import { FolderOpen, CircleCheckBig, Share2, TriangleAlert } from "lucide-react-native"
 import {
   Container,
   Card,
@@ -39,7 +39,7 @@ import { fonts } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { formatExportDateTime, formatBytes } from "../utils/format"
 import { showAlert } from "../services/modalService"
-import { SAVE_SUCCESS_DISPLAY_MS } from "../constants"
+import { size, SAVE_SUCCESS_DISPLAY_MS } from "../constants"
 
 type ExportInterval = "daily" | "weekly" | "monthly"
 type ExportMode = "all" | "incremental"
@@ -411,7 +411,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               style={({ pressed }) => [styles.directoryRow, pressed && { opacity: colors.pressedOpacity }]}
               onPress={handlePickDirectory}
             >
-              <FolderOpen size={22} color={colors.primary} />
+              <FolderOpen size={size.icon.md} color={colors.primary} />
               <View style={styles.directoryContent}>
                 <Text style={[styles.settingLabel, { color: colors.text }]}>
                   {directoryUri ? "Directory Selected" : "Select Directory"}
@@ -422,7 +422,7 @@ export function AutoExportScreen(_props: ScreenProps) {
                     : "Tap to choose where files are saved"}
                 </Text>
               </View>
-              {directoryUri && <CheckCircle size={18} color={colors.success} />}
+              {directoryUri && <CircleCheckBig size={size.icon.md} color={colors.success} />}
             </Pressable>
           </Card>
         </View>
@@ -590,7 +590,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               <>
                 <Divider />
                 <View style={styles.errorRow}>
-                  <AlertTriangle size={14} color={colors.error} />
+                  <TriangleAlert size={size.icon.sm} color={colors.error} />
                   <Text style={[styles.errorText, { color: colors.error }]} numberOfLines={2}>
                     {lastError}
                   </Text>
@@ -651,7 +651,7 @@ export function AutoExportScreen(_props: ScreenProps) {
                       style={({ pressed }) => [styles.shareButton, pressed && { opacity: 0.5 }]}
                       onPress={() => handleShareFile(file)}
                     >
-                      <Share2 size={18} color={colors.primary} />
+                      <Share2 size={size.icon.md} color={colors.primary} />
                     </Pressable>
                   </View>
                 </View>

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -19,6 +19,7 @@ import { logger } from "../utils/logger"
 import { fonts } from "../styles/typography"
 import { fontSizes } from "@colota/shared"
 import type { ThemeColors } from "../types/global"
+import { size } from "../constants"
 
 type Props = RootScreenProps<"Backup & Restore">
 
@@ -92,7 +93,7 @@ function PasswordField({ value, onChangeText, placeholder, editable, autoComplet
         style={styles.eyeButton}
         accessibilityLabel="Hold to show password"
       >
-        <Icon size={20} color={colors.textSecondary} />
+        <Icon size={size.icon.md} color={colors.textSecondary} />
       </Pressable>
     </View>
   )

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -24,7 +24,7 @@ import { fonts, fontSizes } from "../styles/typography"
 import NativeLocationService from "../services/NativeLocationService"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Button, SectionTitle, Card, Container, Divider, Toast } from "../components"
-import { STATS_REFRESH_FAST, SAVE_SUCCESS_DISPLAY_MS } from "../constants"
+import { size, STATS_REFRESH_FAST, SAVE_SUCCESS_DISPLAY_MS } from "../constants"
 import { useTimeout } from "../hooks/useTimeout"
 import { showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -402,7 +402,7 @@ export function DataManagementScreen({}: ScreenProps) {
                   Reclaim unused space and improve performance
                 </Text>
                 <View style={styles.hintRow}>
-                  <Lightbulb size={12} color={colors.textLight} />
+                  <Lightbulb size={size.icon.sm} color={colors.textLight} />
                   <Text style={[styles.actionHint, { color: colors.textLight }]}>
                     Run after large deletions to reclaim space
                   </Text>

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -14,6 +14,7 @@ import { EXPORT_FORMATS, ExportFormat } from "../utils/exportConverters"
 import { logger } from "../utils/logger"
 import { showAlert } from "../services/modalService"
 import { ScreenProps } from "../types/global"
+import { size } from "../constants"
 
 export function ExportLocationsScreen({}: ScreenProps) {
   const { colors } = useTheme()
@@ -82,7 +83,7 @@ export function ExportLocationsScreen({}: ScreenProps) {
         {totalLocations === 0 ? (
           <Card style={styles.emptyCard}>
             <View style={styles.emptyState}>
-              <MapPinOff size={40} color={colors.textLight} />
+              <MapPinOff size={size.icon.lg} color={colors.textLight} />
               <Text style={[styles.emptyTitle, { color: colors.text }]}>No Locations</Text>
               <Text style={[styles.emptySubtitle, { color: colors.textLight }]}>
                 Start tracking to record locations that can be exported.

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -14,6 +14,7 @@ import { fonts } from "../styles/typography"
 import { ChevronRight, Wifi, PersonStanding, MapPinHouse, Share2 } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
 import {
+  size,
   DEFAULT_MAP_ZOOM,
   WORLD_MAP_ZOOM,
   GEOFENCE_ZOOM_PADDING,
@@ -251,7 +252,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
             hitSlop={HIT_SLOP_MD}
             style={({ pressed }) => [styles.zoomBtn, pressed && { opacity: colors.pressedOpacity }]}
           >
-            <MapPinHouse size={20} color={colors.textSecondary} />
+            <MapPinHouse size={size.icon.md} color={colors.textSecondary} />
           </Pressable>
           <Pressable
             testID={`edit-geofence-${item.id}`}
@@ -264,11 +265,11 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
                 <Text style={[styles.radius, { color: colors.textSecondary }]}>
                   {formatShortDistance(item.radius)} radius
                 </Text>
-                {item.pauseOnWifi && <Wifi size={12} color={colors.textSecondary} />}
-                {item.pauseOnMotionless && <PersonStanding size={12} color={colors.textSecondary} />}
+                {item.pauseOnWifi && <Wifi size={size.icon.sm} color={colors.textSecondary} />}
+                {item.pauseOnMotionless && <PersonStanding size={size.icon.sm} color={colors.textSecondary} />}
               </View>
             </View>
-            <ChevronRight size={20} color={colors.textSecondary} />
+            <ChevronRight size={size.icon.md} color={colors.textSecondary} />
           </Pressable>
         </View>
       </Card>
@@ -368,7 +369,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [styles.shareBtn, pressed && { opacity: colors.pressedOpacity }]}
                 >
-                  <Share2 size={20} color={colors.textSecondary} />
+                  <Share2 size={size.icon.md} color={colors.textSecondary} />
                 </Pressable>
               </View>
             )}

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -16,6 +16,7 @@ import { logger } from "../utils/logger"
 import { FILE_FORMATS, IMPORT_FORMAT_ORDER, importDescription } from "../utils/fileFormats"
 import { ScreenProps } from "../types/global"
 import type { ThemeColors } from "../types/global"
+import { size } from "../constants"
 
 const IMPORT_FORMAT_LABELS = Object.fromEntries(
   (Object.keys(FILE_FORMATS) as ImportFormat[]).map((k) => [k, FILE_FORMATS[k].label])
@@ -83,7 +84,7 @@ const FormatRow = ({ entry, colors }: { entry: (typeof SUPPORTED_FORMATS)[number
   const Icon = entry.icon
   return (
     <View style={styles.formatRow}>
-      <Icon size={22} color={colors.textLight} />
+      <Icon size={size.icon.md} color={colors.textLight} />
       <View style={styles.formatTextContent}>
         <View style={styles.formatTitleRow}>
           <Text style={[styles.formatTitle, { color: colors.text }]}>{entry.title}</Text>

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffe
 import { View, Text, StyleSheet, Pressable } from "react-native"
 import { useFocusEffect } from "@react-navigation/native"
 import { fonts } from "../styles/typography"
-import { BarChart2 } from "lucide-react-native"
+import { ChartNoAxesColumn } from "lucide-react-native"
 import { Container } from "../components"
 import { Tab } from "../components/ui/Tab"
 import { useTheme } from "../hooks/useTheme"
@@ -31,6 +31,7 @@ import {
 import { EXPORT_FORMATS, type ExportFormat } from "../utils/exportConverters"
 import { showAlert, showConfirm } from "../services/modalService"
 import type { RootScreenProps } from "../types/navigation"
+import { size } from "../constants"
 
 type TabType = "map" | "trips" | "data"
 
@@ -90,7 +91,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         onPress={() => navigation.navigate("Location Summary")}
         style={({ pressed }) => [styles.headerBtn, pressed && { opacity: colors.pressedOpacity }]}
       >
-        <BarChart2 size={20} color={colors.text} />
+        <ChartNoAxesColumn size={size.icon.md} color={colors.text} />
       </Pressable>
     ),
     [navigation, colors]

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -25,6 +25,7 @@ import NativeLocationService from "../services/NativeLocationService"
 import { formatDistance, formatDuration, startOfDaySec } from "../utils/geo"
 import { fonts } from "../styles/typography"
 import { logger } from "../utils/logger"
+import { size } from "../constants"
 
 type Period = "week" | "month" | "30days"
 
@@ -159,7 +160,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
             <Text style={[styles.dayLabel, { color: colors.text }]}>{formatDayLabel(item.day)}</Text>
             <View style={styles.dayHeaderRight}>
               <Text style={[styles.dayDistance, { color: colors.primary }]}>{formatDistance(item.distanceMeters)}</Text>
-              <ChevronRight size={14} color={colors.textDisabled} />
+              <ChevronRight size={size.icon.sm} color={colors.textDisabled} />
             </View>
           </View>
           <View style={styles.dayStats}>
@@ -181,7 +182,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
     () => (
       <View style={styles.summaryGrid}>
         <Card style={styles.summaryCard}>
-          <Route size={16} color={colors.primary} />
+          <Route size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.totalDistance}
             format={(n) => formatDistance(n)}
@@ -191,7 +192,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
         </Card>
 
         <Card style={styles.summaryCard}>
-          <MapPin size={16} color={colors.primary} />
+          <MapPin size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.totalTrips}
             format={(n) => String(n)}
@@ -201,7 +202,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
         </Card>
 
         <Card style={styles.summaryCard}>
-          <Calendar size={16} color={colors.primary} />
+          <Calendar size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.activeDays}
             format={(n) => String(n)}
@@ -211,7 +212,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
         </Card>
 
         <Card style={styles.summaryCard}>
-          <TrendingUp size={16} color={colors.primary} />
+          <TrendingUp size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.avgDistance}
             format={(n) => formatDistance(n)}

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -12,10 +12,10 @@ import { showAlert, showConfirm } from "../services/modalService"
 import { ScreenProps } from "../types/global"
 import { useCoords } from "../contexts/TrackingProvider"
 import { fonts } from "../styles/typography"
-import { X, CheckCircle, RefreshCw, AlertTriangle } from "lucide-react-native"
+import { X, CircleCheckBig, RefreshCw, TriangleAlert } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
-import { DEFAULT_MAP_ZOOM, WORLD_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT } from "../constants"
+import { size, DEFAULT_MAP_ZOOM, WORLD_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { logger } from "../utils/logger"
@@ -699,12 +699,12 @@ export function OfflineMapsScreen({}: ScreenProps) {
               disabled={item.isActive}
             >
               <View style={styles.nameRow}>
-                {item.isComplete && <CheckCircle size={14} color={colors.success} />}
+                {item.isComplete && <CircleCheckBig size={size.icon.sm} color={colors.success} />}
                 {item.isActive && <ActivityIndicator size="small" color={colors.primary} />}
                 <Text style={[styles.areaName, { color: colors.text }]}>{item.name}</Text>
                 {isStale && (
                   <View testID={`stale-indicator-${item.name}`}>
-                    <AlertTriangle size={13} color={colors.warning} />
+                    <TriangleAlert size={size.icon.sm} color={colors.warning} />
                   </View>
                 )}
               </View>
@@ -750,7 +750,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
                     {isRefreshing ? (
                       <ActivityIndicator size="small" color={colors.primary} />
                     ) : (
-                      <RefreshCw size={14} color={colors.primary} />
+                      <RefreshCw size={size.icon.sm} color={colors.primary} />
                     )}
                   </Pressable>
                 )}
@@ -767,7 +767,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
                   {isDeleting ? (
                     <ActivityIndicator size="small" color={colors.error} />
                   ) : (
-                    <X size={16} color={colors.error} />
+                    <X size={size.icon.sm} color={colors.error} />
                   )}
                 </Pressable>
               </View>

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -16,6 +16,7 @@ import { Check } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
 import {
+  size,
   MS_TO_KMH,
   PROFILE_CONDITIONS,
   SYNC_INTERVAL_PRESETS,
@@ -243,7 +244,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                   ]}
                   onPress={() => setConditionType(opt.type)}
                 >
-                  <Icon size={20} color={selected ? colors.primary : colors.textSecondary} />
+                  <Icon size={size.icon.md} color={selected ? colors.primary : colors.textSecondary} />
                   <Text style={[styles.conditionLabel, { color: selected ? colors.primary : colors.text }]}>
                     {opt.label}
                   </Text>
@@ -482,7 +483,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
           onPress={handleSave}
           disabled={saving}
         >
-          <Check size={20} color={colors.textOnPrimary} />
+          <Check size={size.icon.md} color={colors.textOnPrimary} />
           <Text style={[styles.saveBtnText, { color: colors.textOnPrimary }]}>
             {saving ? "Saving..." : isEditing ? "Save Changes" : "Create Profile"}
           </Text>

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -7,10 +7,10 @@ import React, { useState, useMemo } from "react"
 import { View, Text, ScrollView, StyleSheet } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
-import { space } from "../constants"
+import { size, space } from "../constants"
 import { Container, Card, Button, SectionTitle, Toggle } from "../components"
 import { fonts } from "../styles/typography"
-import { CircleAlert, CircleCheck, Import } from "lucide-react-native"
+import { CircleAlert, CircleCheckBig, Import } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -165,7 +165,7 @@ export function SetupImportScreen({ route, navigation }: any) {
         <ScrollView contentContainerStyle={styles.content}>
           <Card style={styles.headerCard}>
             <View style={styles.headerRow}>
-              <CircleAlert size={28} color={colors.error} />
+              <CircleAlert size={size.icon.lg} color={colors.error} />
               <View style={styles.headerText}>
                 <Text style={[styles.title, { color: colors.text }]}>Invalid Configuration</Text>
                 <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{result.error}</Text>
@@ -184,7 +184,7 @@ export function SetupImportScreen({ route, navigation }: any) {
       <ScrollView contentContainerStyle={styles.content}>
         <Card style={styles.headerCard}>
           <View style={styles.headerRow}>
-            <Import size={28} color={colors.primary} />
+            <Import size={size.icon.lg} color={colors.primary} />
             <View style={styles.headerText}>
               <Text style={[styles.title, { color: colors.text }]}>Import Configuration</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
@@ -232,7 +232,7 @@ export function SetupImportScreen({ route, navigation }: any) {
             title="Apply Configuration"
             onPress={handleApply}
             variant="primary"
-            icon={CircleCheck}
+            icon={CircleCheckBig}
             loading={applying}
             disabled={applying}
           />

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -15,6 +15,7 @@ import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
 import { buildSetupConfig, buildSetupLink, type SetupShareParts, type SetupShareSelection } from "../utils/setupLink"
 import { DEFAULT_AUTH_CONFIG, type AuthConfig, type Geofence, type TrackingProfile } from "../types/global"
+import { size } from "../constants"
 
 type ShareCategory = keyof SetupShareSelection
 
@@ -124,7 +125,7 @@ export function ShareSetupScreen() {
       <ScrollView contentContainerStyle={styles.content}>
         <Card style={styles.headerCard}>
           <View style={styles.headerRow}>
-            <Share2 size={28} color={colors.primary} />
+            <Share2 size={size.icon.lg} color={colors.primary} />
             <View style={styles.headerText}>
               <Text style={[styles.title, { color: colors.text }]}>Share Setup</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
@@ -169,7 +170,7 @@ export function ShareSetupScreen() {
           <View style={styles.section}>
             <Card style={[styles.warningCard, { borderColor: colors.error }]}>
               <View style={styles.headerRow}>
-                <TriangleAlert size={20} color={colors.error} />
+                <TriangleAlert size={size.icon.md} color={colors.error} />
                 <Text style={[styles.warningText, { color: colors.text }]}>
                   This link will contain your {credentialFields.join(", ")} in plain text. Anyone who sees the link can
                   read them - only share it over a trusted channel.

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -15,7 +15,7 @@ import { Container, SectionTitle, Card, Toggle } from "../components"
 import { Plus, X, Zap, Share2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { buildProfilesLink } from "../utils/setupLink"
-import { PROFILE_CONDITIONS, MS_TO_KMH, HIT_SLOP_MD } from "../constants"
+import { size, PROFILE_CONDITIONS, MS_TO_KMH, HIT_SLOP_MD } from "../constants"
 
 function formatCondition(profile: SavedTrackingProfile): string {
   const condition = PROFILE_CONDITIONS.find((c) => c.type === profile.condition.type)
@@ -118,7 +118,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
             onPress={() => navigation.navigate("Profile Editor", { profileId: item.id })}
           >
             <View style={[styles.iconWrap, { backgroundColor: colors.primary + "15" }]}>
-              <ConditionIcon size={18} color={colors.primary} />
+              <ConditionIcon size={size.icon.md} color={colors.primary} />
             </View>
 
             <View style={styles.info}>
@@ -156,7 +156,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
                   pressed && { opacity: colors.pressedOpacity }
                 ]}
               >
-                <X size={16} color={colors.error} />
+                <X size={size.icon.sm} color={colors.error} />
               </Pressable>
             </View>
           </Pressable>
@@ -190,7 +190,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
               ]}
               onPress={() => navigation.navigate("Profile Editor", {})}
             >
-              <Plus size={20} color={colors.textOnPrimary} />
+              <Plus size={size.icon.md} color={colors.textOnPrimary} />
               <Text style={[styles.createBtnText, { color: colors.textOnPrimary }]}>Create Profile</Text>
             </Pressable>
 
@@ -203,7 +203,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [styles.shareBtn, pressed && { opacity: colors.pressedOpacity }]}
                 >
-                  <Share2 size={20} color={colors.textSecondary} />
+                  <Share2 size={size.icon.md} color={colors.textSecondary} />
                 </Pressable>
               </View>
             )}

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -27,7 +27,7 @@ import { InteractiveLineChart } from "../components/features/inspector/Interacti
 import { getTripColor, computeTripStats, buildBoundaryOverrideMap, splitBlockedReason } from "../utils/trips"
 import { formatDate, formatDistance, formatDuration, formatSpeed, formatTime } from "../utils/geo"
 import { EXPORT_FORMATS, EXPORT_FORMAT_KEYS, type ExportFormat } from "../utils/exportConverters"
-import { HIT_SLOP_LG } from "../constants"
+import { size, HIT_SLOP_LG } from "../constants"
 import { showAlert, showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
 import NativeLocationService from "../services/NativeLocationService"
@@ -217,7 +217,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
         hitSlop={8}
         style={({ pressed }) => [styles.headerBtn, (pressed || deleting) && { opacity: colors.pressedOpacity }]}
       >
-        <Trash2 size={20} color={colors.error} />
+        <Trash2 size={size.icon.md} color={colors.error} />
       </Pressable>
     ),
     [handleDelete, deleting, colors.error, colors.pressedOpacity]
@@ -271,7 +271,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               hitSlop={HIT_SLOP_LG}
               style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
             >
-              <ChevronLeft size={24} color={prevTrip ? colors.primary : colors.textDisabled} />
+              <ChevronLeft size={size.icon.lg} color={prevTrip ? colors.primary : colors.textDisabled} />
             </Pressable>
             <View style={styles.headerTitleCenter}>
               <View style={styles.headerTitleLine}>
@@ -288,7 +288,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               hitSlop={HIT_SLOP_LG}
               style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
             >
-              <ChevronRight size={24} color={nextTrip ? colors.primary : colors.textDisabled} />
+              <ChevronRight size={size.icon.lg} color={nextTrip ? colors.primary : colors.textDisabled} />
             </Pressable>
           </View>
         </View>
@@ -385,7 +385,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               pressed && { opacity: 0.8 }
             ]}
           >
-            <Share size={16} color={colors.textOnPrimary} />
+            <Share size={size.icon.sm} color={colors.textOnPrimary} />
             <Text style={[styles.exportBtnText, { color: colors.textOnPrimary }]}>Export Trip</Text>
           </Pressable>
 
@@ -425,7 +425,7 @@ function StatCard({
 }) {
   return (
     <Card style={styles.statCard}>
-      <Icon size={16} color={colors.primary} />
+      <Icon size={size.icon.sm} color={colors.primary} />
       <Text style={[styles.statValue, { color: colors.text }]}>{value}</Text>
       <Text style={[styles.statLabel, { color: colors.textSecondary }]}>{label}</Text>
     </Card>

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -198,9 +198,9 @@ jest.mock("lucide-react-native", () => {
   const stub = (name: any) => () => R.createElement(RN.Text, null, name)
   return {
     FolderOpen: stub("FolderOpen"),
-    CheckCircle: stub("CheckCircle"),
+    CircleCheckBig: stub("CircleCheckBig"),
     Share2: stub("Share2"),
-    AlertTriangle: stub("AlertTriangle")
+    TriangleAlert: stub("TriangleAlert")
   }
 })
 

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -61,7 +61,7 @@ jest.mock("lucide-react-native", () => {
   const { Text } = require("react-native")
   const stub = (name: string) => (_props: any) => R.createElement(Text, null, name)
   return {
-    BarChart2: stub("BarChart2")
+    ChartNoAxesColumn: stub("ChartNoAxesColumn")
   }
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
         "i18next": "^26.4.2",
-        "lucide-react-native": "^1.17.0",
+        "lucide-react-native": "^1.31.0",
         "react": "19.2.8",
         "react-native": "0.87.0",
         "react-native-safe-area-context": "^5.8.0",


### PR DESCRIPTION
Raise lucide-react-native to ^1.31.0, the floor that carries LucideProvider, and mount one provider at strokeWidth 1.5 with absoluteStrokeWidth so a 16 badge and a 24 tab glyph hold the same weight on screen.

Collapse the size ladder to 16 / 20 / 24 through size.icon: 43 sites move, 18 of them off the sub-16 floor where an absolute stroke closes the counters of Zap, Lightbulb, Calendar and RefreshCw. The other 46 sites keep their value and take the token.

Normalise the retired lucide aliases to TriangleAlert, CircleAlert, CircleCheckBig and ChartNoAxesColumn, and settle on CircleCheckBig app-wide.

Give History its own route mark on react-native-svg, drawn on Lucide's grid inside the 2..22 live area and reading the provider so it cannot drift from the set; Geofences takes Lucide's own CircleDotDashed.

Turn the header seam off with headerShadowVisible, which is what draws it, and drop the elevation, shadowOpacity, StatusBar backgroundColor and translucent keys that reach nothing.
