### PR TITLE
refactor(screens): delete in-screen titles, header owns the title

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -73,17 +73,17 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   {
     name: "API Config",
     component: ApiSettingsScreen,
-    title: "API Config"
+    title: "API field mapping"
   },
   {
     name: "Auth Settings",
     component: AuthSettingsScreen,
-    title: "Auth Settings"
+    title: "Authentication"
   },
   {
     name: "mTLS Settings",
     component: MtlsSettingsScreen,
-    title: "mTLS Settings"
+    title: "Client certificate"
   },
   {
     name: "Geofences",

--- a/apps/mobile/__tests__/App.test.tsx
+++ b/apps/mobile/__tests__/App.test.tsx
@@ -4,6 +4,7 @@ import { render } from "@testing-library/react-native"
 import { lightColors } from "@colota/shared"
 
 const mockNavigatorProps: Record<string, any>[] = []
+const mockScreenProps: Record<string, any>[] = []
 
 jest.mock("@react-navigation/native", () => ({
   NavigationContainer: ({ children }: { children: React.ReactNode }) => children
@@ -13,9 +14,12 @@ jest.mock("@react-navigation/native-stack", () => ({
   createNativeStackNavigator: () => ({
     Navigator: (props: Record<string, any>) => {
       mockNavigatorProps.push(props)
-      return null
+      return props.children
     },
-    Screen: () => null
+    Screen: (props: Record<string, any>) => {
+      mockScreenProps.push(props)
+      return null
+    }
   })
 }))
 
@@ -49,6 +53,7 @@ import App from "../App"
 describe("App chrome", () => {
   beforeEach(() => {
     mockNavigatorProps.length = 0
+    mockScreenProps.length = 0
   })
 
   // One provider is what makes the icon set one weight. absoluteStrokeWidth is the half
@@ -72,6 +77,20 @@ describe("App chrome", () => {
     const { screenOptions } = mockNavigatorProps[0]
     expect(screenOptions.headerShadowVisible).toBe(false)
     expect(screenOptions.headerStyle).toEqual({ backgroundColor: lightColors.background })
+  })
+
+  // Every route but the two map heroes lost its in-screen H1, so the header is the only
+  // place a screen is named and a vague header string leaves the screen unnamed. The route
+  // name is the navigation key: renaming it would break every navigate() call, so the
+  // displayed title moves and the key does not.
+  it("names the screen in the header without renaming the route", () => {
+    render(<App />)
+
+    const titleFor = (name: string) => mockScreenProps.find((s) => s.name === name)?.options.headerTitle
+
+    expect(titleFor("Auth Settings")).toBe("Authentication")
+    expect(titleFor("API Config")).toBe("API field mapping")
+    expect(titleFor("mTLS Settings")).toBe("Client certificate")
   })
 
   // RN's Android StatusBar module exposes only setStyle and setHidden, so backgroundColor

--- a/apps/mobile/src/__tests__/designSystemAllowlist.json
+++ b/apps/mobile/src/__tests__/designSystemAllowlist.json
@@ -65,7 +65,7 @@
   ],
   "screens/ApiSettingsScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "letterSpacing"],
   "screens/AppearanceScreen.tsx": ["borderWidth", "borderRadius", "fontSize"],
-  "screens/AuthSettingsScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "letterSpacing"],
+  "screens/AuthSettingsScreen.tsx": ["borderWidth", "borderRadius", "fontSize"],
   "screens/AutoExportScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "letterSpacing", "textTransform"],
   "screens/BackupRestoreScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "fontWeight"],
   "screens/DataManagementScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "fontStyle"],
@@ -82,7 +82,6 @@
   "screens/ImportLocationsScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "letterSpacing", "textTransform"],
   "screens/LocationInspectorScreen.tsx": ["elevation", "shadowColor", "fontSize", "hexLiteral"],
   "screens/LocationSummaryScreen.tsx": ["fontSize", "textTransform"],
-  "screens/MtlsSettingsScreen.tsx": ["fontSize", "letterSpacing"],
   "screens/OfflineMapsScreen.tsx": [
     "borderWidth",
     "borderRadius",
@@ -94,7 +93,7 @@
   "screens/ProfileEditorScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "letterSpacing", "textTransform"],
   "screens/SetupImportScreen.tsx": ["fontSize"],
   "screens/ShareSetupScreen.tsx": ["borderWidth", "fontSize"],
-  "screens/TrackingProfilesScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "letterSpacing", "textTransform"],
+  "screens/TrackingProfilesScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "textTransform"],
   "screens/TripDetailScreen.tsx": ["borderWidth", "borderRadius", "fontSize", "textTransform"],
   "utils/trips.ts": ["hexLiteral"]
 }

--- a/apps/mobile/src/components/features/settings/MtlsSection.tsx
+++ b/apps/mobile/src/components/features/settings/MtlsSection.tsx
@@ -131,7 +131,6 @@ export function MtlsSection() {
   if (certInfo === null || caInfo === null) {
     return (
       <View style={styles.section}>
-        <SectionTitle>Client Certificate (mTLS)</SectionTitle>
         <Card>
           <Text style={[styles.muted, { color: colors.textSecondary }]}>Loading...</Text>
         </Card>
@@ -142,7 +141,6 @@ export function MtlsSection() {
   return (
     <>
       <View style={styles.section}>
-        <SectionTitle>Client Certificate (mTLS)</SectionTitle>
         <Card>
           {importState.kind === "picked" ? (
             <View>

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -201,11 +201,7 @@ export function AboutScreen({}: ScreenProps) {
   if (!buildConfig) {
     return (
       <Container>
-        <ScrollView contentContainerStyle={styles.scrollContent}>
-          <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.text }]}>Colota</Text>
-          </View>
-        </ScrollView>
+        <ScrollView contentContainerStyle={styles.scrollContent} />
       </Container>
     )
   }
@@ -247,7 +243,6 @@ export function AboutScreen({}: ScreenProps) {
           >
             <Image source={icon} style={styles.appIcon} resizeMode="contain" />
           </Pressable>
-          <Text style={[styles.title, { color: colors.text }]}>Colota</Text>
           <Pressable onPress={handleVersionTap} style={({ pressed }) => pressed && { opacity: 0.8 }}>
             <Text style={[styles.version, { color: colors.textSecondary }]}>Version {buildConfig.VERSION_NAME}</Text>
           </Pressable>
@@ -415,11 +410,6 @@ const styles = StyleSheet.create({
   appIcon: {
     width: 80,
     height: 80
-  },
-  title: {
-    fontSize: 28,
-    ...fonts.bold,
-    marginBottom: 4
   },
   version: {
     fontSize: 13,

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -21,6 +21,7 @@ import { useTimeout } from "../hooks/useTimeout"
 import { useTracking } from "../contexts/TrackingProvider"
 import NativeLocationService from "../services/NativeLocationService"
 import { fonts } from "../styles/typography"
+import { space } from "../constants"
 import { SectionTitle, Toast, Container, Divider, ChipGroup } from "../components"
 import { findDuplicates } from "../utils/settingsValidation"
 import {
@@ -462,13 +463,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
-        {/* Header */}
-        <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>API Field Mapping</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-            Customize field names sent to your server
-          </Text>
-        </View>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>Customize field names sent to your server</Text>
 
         {/* Template Selector */}
         <View style={styles.section}>
@@ -752,21 +747,14 @@ export function ApiSettingsScreen({}: ScreenProps) {
 const styles = StyleSheet.create({
   scrollContent: {
     paddingHorizontal: 16,
+    paddingTop: 16,
     paddingBottom: 40
   },
-  header: {
-    marginTop: 20,
-    marginBottom: 20
-  },
-  title: {
-    fontSize: 28,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    marginBottom: 4
-  },
-  subtitle: {
+  intro: {
     fontSize: 14,
-    lineHeight: 20
+    ...fonts.regular,
+    lineHeight: 20,
+    marginBottom: space.xl
   },
   section: {
     marginBottom: 24

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -15,7 +15,7 @@ import { SectionTitle, Toast, Container, Card, Divider, ChipGroup } from "../com
 import NativeLocationService from "../services/NativeLocationService"
 import { logger } from "../utils/logger"
 import { findDuplicates } from "../utils/settingsValidation"
-import { size } from "../constants"
+import { size, space } from "../constants"
 
 const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
   { value: "none", label: "None" },
@@ -153,11 +153,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {/* Header */}
-        <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>Authentication & Headers</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>Secure your endpoint connection</Text>
-        </View>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>Secure your endpoint connection</Text>
 
         {/* Authentication Section */}
         <View style={styles.section}>
@@ -386,19 +382,11 @@ const styles = StyleSheet.create({
     fontSize: 15,
     ...fonts.regular
   },
-  header: {
-    marginBottom: 20
-  },
-  title: {
-    fontSize: 28,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    marginBottom: 4
-  },
-  subtitle: {
+  intro: {
     fontSize: 14,
     ...fonts.regular,
-    lineHeight: 20
+    lineHeight: 20,
+    marginBottom: space.xl
   },
   section: {
     marginBottom: 24

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -387,12 +387,6 @@ export function AutoExportScreen(_props: ScreenProps) {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-        <View style={styles.header}>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-            Automatically export your location data on a schedule
-          </Text>
-        </View>
-
         {/* Enable Toggle */}
         <Card>
           <SettingRow
@@ -668,15 +662,8 @@ export function AutoExportScreen(_props: ScreenProps) {
 const styles = StyleSheet.create({
   scrollContent: {
     paddingHorizontal: 16,
+    paddingTop: 16,
     paddingBottom: 40
-  },
-  header: {
-    marginTop: 20,
-    marginBottom: 20
-  },
-  subtitle: {
-    fontSize: 14,
-    lineHeight: 20
   },
   section: {
     marginTop: 24

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -270,11 +270,6 @@ export function DataManagementScreen({}: ScreenProps) {
     <Container>
       <KeyboardAvoidingView style={styles.keyboardAvoid} behavior={Platform.OS === "ios" ? "padding" : undefined}>
         <ScrollView contentContainerStyle={styles.scrollContent}>
-          {/* Header */}
-          <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.text }]}>Data Management</Text>
-          </View>
-
           {/* Stats */}
           <View style={styles.section}>
             <SectionTitle>Database statistics</SectionTitle>
@@ -479,16 +474,8 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingHorizontal: 16,
+    paddingTop: 16,
     paddingBottom: 40
-  },
-  header: {
-    marginTop: 20,
-    marginBottom: 24
-  },
-  title: {
-    fontSize: 28,
-    ...fonts.bold,
-    marginBottom: 4
   },
   section: {
     marginBottom: 24

--- a/apps/mobile/src/screens/MtlsSettingsScreen.tsx
+++ b/apps/mobile/src/screens/MtlsSettingsScreen.tsx
@@ -4,10 +4,11 @@
  */
 
 import React from "react"
-import { Text, StyleSheet, View, ScrollView } from "react-native"
+import { Text, StyleSheet, ScrollView } from "react-native"
 import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
-import { fonts } from "../styles/typography"
+import { text } from "../styles/typography"
+import { space } from "../constants"
 import { Container } from "../components"
 import { MtlsSection } from "../components/features/settings/MtlsSection"
 
@@ -21,12 +22,9 @@ export function MtlsSettingsScreen({}: ScreenProps) {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>Client Certificate (mTLS)</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-            For endpoints behind a reverse proxy that requires mutual TLS authentication
-          </Text>
-        </View>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>
+          For endpoints behind a reverse proxy that requires mutual TLS authentication
+        </Text>
 
         <MtlsSection />
       </ScrollView>
@@ -40,18 +38,8 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 40
   },
-  header: {
-    marginBottom: 20
-  },
-  title: {
-    fontSize: 28,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    marginBottom: 4
-  },
-  subtitle: {
-    fontSize: 14,
-    ...fonts.regular,
-    lineHeight: 20
+  intro: {
+    ...text.body,
+    marginBottom: space.xl
   }
 })

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useEffect, useCallback } from "react"
+import React, { useState, useEffect, useCallback, useLayoutEffect } from "react"
 import { View, Text, StyleSheet, ScrollView, TextInput, Pressable } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
@@ -58,6 +58,11 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
   const [activationDelayStr, setActivationDelayStr] = useState("0")
   const [delayStr, setDelayStr] = useState("60")
   const [syncIntervalStr, setSyncIntervalStr] = useState(String(settings.syncInterval))
+
+  // headerTitle, not title: SCREEN_CONFIG sets headerTitle and native-stack prefers it.
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerTitle: isEditing ? "Edit profile" : "New profile" })
+  }, [navigation, isEditing])
 
   useEffect(() => {
     if (!profileId) return
@@ -189,10 +194,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>{isEditing ? "Edit Profile" : "New Profile"}</Text>
-        </View>
-
         {/* Name & Priority */}
         <SectionTitle>Profile</SectionTitle>
         <Card>
@@ -495,8 +496,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
 const styles = StyleSheet.create({
   scrollContent: { paddingHorizontal: 16, paddingTop: 16, paddingBottom: 40 },
-  header: { marginBottom: 20 },
-  title: { fontSize: 28, ...fonts.bold, letterSpacing: -0.5 },
   inputGroup: { marginBottom: 4 },
   label: {
     fontSize: 12,

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -9,8 +9,8 @@ import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { size, space } from "../constants"
 import { Container, Card, Button, SectionTitle, Toggle } from "../components"
-import { fonts } from "../styles/typography"
-import { CircleAlert, CircleCheckBig, Import } from "lucide-react-native"
+import { fonts, text } from "../styles/typography"
+import { CircleAlert, CircleCheckBig } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -182,17 +182,9 @@ export function SetupImportScreen({ route, navigation }: any) {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.content}>
-        <Card style={styles.headerCard}>
-          <View style={styles.headerRow}>
-            <Import size={size.icon.lg} color={colors.primary} />
-            <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.text }]}>Import Configuration</Text>
-              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                A setup link wants to apply {result.entries.length} setting{result.entries.length !== 1 ? "s" : ""}
-              </Text>
-            </View>
-          </View>
-        </Card>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>
+          A setup link wants to apply {result.entries.length} setting{result.entries.length !== 1 ? "s" : ""}
+        </Text>
 
         {renderSection("TRACKING", trackingEntries)}
         {renderSection("API", apiEntries)}
@@ -258,6 +250,10 @@ const styles = StyleSheet.create({
   },
   headerText: {
     flex: 1
+  },
+  intro: {
+    ...text.body,
+    marginBottom: space.lg
   },
   title: {
     fontSize: 18,

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -8,14 +8,14 @@ import { View, Text, ScrollView, StyleSheet, Share } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Container, Card, Button, SectionTitle, Toggle } from "../components"
-import { fonts } from "../styles/typography"
+import { fonts, text } from "../styles/typography"
 import { Share2, TriangleAlert } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
 import { buildSetupConfig, buildSetupLink, type SetupShareParts, type SetupShareSelection } from "../utils/setupLink"
 import { DEFAULT_AUTH_CONFIG, type AuthConfig, type Geofence, type TrackingProfile } from "../types/global"
-import { size } from "../constants"
+import { size, space } from "../constants"
 
 type ShareCategory = keyof SetupShareSelection
 
@@ -123,18 +123,10 @@ export function ShareSetupScreen() {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.content}>
-        <Card style={styles.headerCard}>
-          <View style={styles.headerRow}>
-            <Share2 size={size.icon.lg} color={colors.primary} />
-            <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.text }]}>Share Setup</Text>
-              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                Choose what to bundle into a setup link, then share it. The recipient opens it to apply the same
-                configuration.
-              </Text>
-            </View>
-          </View>
-        </Card>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>
+          Choose what to bundle into a setup link, then share it. The recipient opens it to apply the same
+          configuration.
+        </Text>
 
         <View style={styles.section}>
           <SectionTitle>Include</SectionTitle>
@@ -198,25 +190,14 @@ const styles = StyleSheet.create({
     padding: 16,
     paddingBottom: 40
   },
-  headerCard: {
-    marginBottom: 16
-  },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: 12
   },
-  headerText: {
-    flex: 1
-  },
-  title: {
-    fontSize: 18,
-    ...fonts.bold
-  },
-  subtitle: {
-    fontSize: 13,
-    ...fonts.regular,
-    marginTop: 2
+  intro: {
+    ...text.body,
+    marginBottom: space.lg
   },
   section: {
     marginTop: 8

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -10,12 +10,12 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { ProfileService } from "../services/ProfileService"
 import { showAlert, showConfirm } from "../services/modalService"
 import { SavedTrackingProfile, ScreenProps } from "../types/global"
-import { fonts } from "../styles/typography"
+import { fonts, text } from "../styles/typography"
 import { Container, SectionTitle, Card, Toggle } from "../components"
 import { Plus, X, Zap, Share2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { buildProfilesLink } from "../utils/setupLink"
-import { size, PROFILE_CONDITIONS, MS_TO_KMH, HIT_SLOP_MD } from "../constants"
+import { size, space, PROFILE_CONDITIONS, MS_TO_KMH, HIT_SLOP_MD } from "../constants"
 
 function formatCondition(profile: SavedTrackingProfile): string {
   const condition = PROFILE_CONDITIONS.find((c) => c.type === profile.condition.type)
@@ -175,12 +175,9 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={
           <>
-            <View style={styles.header}>
-              <Text style={[styles.title, { color: colors.text }]}>Tracking Profiles</Text>
-              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                Auto-switch GPS settings based on charging, Android Auto, or speed
-              </Text>
-            </View>
+            <Text style={[styles.intro, { color: colors.textSecondary }]}>
+              Auto-switch GPS settings based on charging, Android Auto, or speed
+            </Text>
 
             <Pressable
               style={({ pressed }) => [
@@ -226,9 +223,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
 
 const styles = StyleSheet.create({
   list: { padding: 16, paddingBottom: 40 },
-  header: { marginBottom: 20 },
-  title: { fontSize: 28, ...fonts.bold, letterSpacing: -0.5, marginBottom: 6 },
-  subtitle: { fontSize: 14, ...fonts.regular, lineHeight: 20 },
+  intro: { ...text.body, marginBottom: space.xl },
   createBtn: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
@@ -109,11 +109,13 @@ describe("AboutScreen", () => {
     return render(<AboutScreen navigation={{} as any} />)
   }
 
-  it("renders app title and version", () => {
-    const { getByText } = renderScreen()
+  // The app name is the navigation header's job now; the screen keeps only the version,
+  // which is also the tap target for debug mode.
+  it("renders the version without repeating the app name", () => {
+    const { getByText, queryByText } = renderScreen()
 
-    expect(getByText("Colota")).toBeTruthy()
     expect(getByText("Version 1.3.0")).toBeTruthy()
+    expect(queryByText("Colota")).toBeNull()
   })
 
   it("shows tap hint after first taps", () => {

--- a/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
@@ -98,7 +98,7 @@ describe("AuthSettingsScreen", () => {
       const { getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Authentication & Headers")).toBeTruthy()
+        expect(getByText("Secure your endpoint connection")).toBeTruthy()
       })
     })
   })

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -233,14 +233,15 @@ describe("AutoExportScreen", () => {
     mockGetExportFiles.mockResolvedValue([])
   })
 
-  it("renders subtitle", async () => {
-    // The "Auto-Export" page title lives in the navigation header, not the screen body
-    // (removed to avoid duplicating the nav-bar title), so we only assert on the subtitle.
-    const { getByText } = render(<AutoExportScreen {...mockProps} />)
+  // The navigation header says "Auto-Export" and the first row says whether it is on, so
+  // the body carries neither the name nor a line restating it.
+  it("opens on the enable row rather than a restated title", async () => {
+    const { getByText, queryByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Automatically export your location data on a schedule")).toBeTruthy()
+      expect(getByText("Enable Auto-Export")).toBeTruthy()
     })
+    expect(queryByText("Automatically export your location data on a schedule")).toBeNull()
   })
 
   it("renders all format options", async () => {
@@ -662,7 +663,7 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Automatically export your location data on a schedule")).toBeTruthy()
+      expect(getByText("Enable Auto-Export")).toBeTruthy()
     })
 
     await waitFor(() => {
@@ -753,7 +754,7 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Automatically export your location data on a schedule")).toBeTruthy()
+      expect(getByText("Enable Auto-Export")).toBeTruthy()
     })
 
     await act(async () => {
@@ -947,7 +948,7 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Automatically export your location data on a schedule")).toBeTruthy()
+      expect(getByText("Enable Auto-Export")).toBeTruthy()
     })
 
     await act(async () => {

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -147,12 +147,14 @@ describe("DataManagementScreen", () => {
     return render(<DataManagementScreen navigation={{} as any} />)
   }
 
-  it("renders Data Management title", async () => {
-    const { getByText } = renderScreen()
+  // The screen name is the navigation header's, so the body starts at the first section.
+  it("renders the first section without repeating the screen name", async () => {
+    const { getByText, queryByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Data Management")).toBeTruthy()
+      expect(getByText("Database statistics")).toBeTruthy()
     })
+    expect(queryByText("Data Management")).toBeNull()
   })
 
   it("shows database statistics with correct values", async () => {
@@ -291,7 +293,7 @@ describe("DataManagementScreen", () => {
       const { queryByText, getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Data Management")).toBeTruthy()
+        expect(getByText("Database statistics")).toBeTruthy()
       })
 
       expect(queryByText("Queue actions")).toBeNull()
@@ -302,7 +304,7 @@ describe("DataManagementScreen", () => {
       const { queryByText, getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Data Management")).toBeTruthy()
+        expect(getByText("Database statistics")).toBeTruthy()
       })
 
       expect(queryByText("Clear Sent History")).toBeNull()

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -82,9 +82,11 @@ jest.mock("../../components", () => {
 })
 
 const mockGoBack = jest.fn()
+const mockSetOptions = jest.fn()
 
 const mockNavigation = {
-  goBack: mockGoBack
+  goBack: mockGoBack,
+  setOptions: mockSetOptions
 }
 
 import { ProfileEditorScreen } from "../ProfileEditorScreen"
@@ -105,9 +107,11 @@ describe("ProfileEditorScreen", () => {
 
   // --- New Profile Mode ---
 
-  it("renders new profile title", () => {
-    const { getByText } = renderNewProfile()
-    expect(getByText("New Profile")).toBeTruthy()
+  // The title is dynamic, so it reaches the header through setOptions rather than a
+  // static SCREEN_CONFIG entry. headerTitle is the key native-stack prefers.
+  it("names the mode in the header for a new profile", () => {
+    renderNewProfile()
+    expect(mockSetOptions).toHaveBeenCalledWith({ headerTitle: "New profile" })
   })
 
   it("shows Create Profile button for new profile", () => {
@@ -209,11 +213,11 @@ describe("ProfileEditorScreen", () => {
 
   // --- Edit Mode ---
 
-  it("renders edit profile title when editing", async () => {
-    const { getByText } = renderEditProfile()
+  it("names the mode in the header when editing", async () => {
+    renderEditProfile()
 
     await waitFor(() => {
-      expect(getByText("Edit Profile")).toBeTruthy()
+      expect(mockSetOptions).toHaveBeenCalledWith({ headerTitle: "Edit profile" })
     })
   })
 

--- a/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
@@ -122,8 +122,8 @@ describe("SetupImportScreen", () => {
     })
 
     it("parses valid endpoint config", () => {
-      const { getByText } = renderScreen(encode({ endpoint: "https://my-server.com/api" }))
-      expect(getByText("Import Configuration")).toBeTruthy()
+      const { getByText, queryByText } = renderScreen(encode({ endpoint: "https://my-server.com/api" }))
+      expect(queryByText("Import Configuration")).toBeNull()
       expect(getByText("Endpoint")).toBeTruthy()
       expect(getByText("https://my-server.com/api")).toBeTruthy()
     })


### PR DESCRIPTION
Screens printed their own name in the body under a header that already carried it. Delete those H1 blocks along with the card-sized repeats in Share Setup and Setup Import and the orphan subtitle in Auto Export, and let SCREEN_CONFIG own the title. Profile Editor keeps setting its own through setOptions, because there the title depends on the profile being edited.

Three header titles are reworded while they are the only copy of the name left: API Config becomes API field mapping, Auth Settings becomes Authentication and mTLS Settings becomes Client certificate.

The guard allowlist loses MtlsSettingsScreen outright and the letterSpacing rule on two more screens, because the deleted titles were what tripped it.
