### PR TITLE
refactor(theme): read spacing, radius and type size from the scales

### DIFF
--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -10,8 +10,10 @@ import { useFocusEffect } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
 import { useTracking } from "../../../contexts/TrackingProvider"
 import { ServerStatus, ConnectionStatusProps } from "../../../types/global"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
+import { space } from "../../../constants"
+import { radius } from "@colota/shared"
 
 export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps) {
   const { colors } = useTheme()
@@ -106,24 +108,24 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     padding: 14,
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 1,
     marginBottom: 22
   },
   dot: {
     width: 8,
     height: 8,
-    borderRadius: 4,
-    marginRight: 12
+    borderRadius: radius.xs,
+    marginRight: space.md
   },
   host: {
     flex: 1,
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.medium
   },
   status: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.medium,
-    marginRight: 8
+    marginRight: space.sm
   }
 })

--- a/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
+++ b/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
@@ -7,9 +7,10 @@ import React from "react"
 import { View, Text, StyleSheet } from "react-native"
 import { useTheme } from "../../../hooks/useTheme"
 import { useCoords } from "../../../contexts/TrackingProvider"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { SectionTitle } from "../../ui/SectionTitle"
 import { Card } from "../../ui/Card"
+import { space } from "../../../constants"
 
 export function CoordinateDisplay() {
   const coords = useCoords()
@@ -64,19 +65,19 @@ const styles = StyleSheet.create({
     gap: 10
   },
   coordLabel: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.semiBold,
-    marginBottom: 4,
+    marginBottom: space.xs,
     letterSpacing: 0.5,
     textTransform: "uppercase"
   },
   coordValue: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.bold,
     letterSpacing: -0.3
   },
   coordUnit: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.medium,
     opacity: 0.6
   }

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -9,9 +9,9 @@ import { AlertTriangle } from "lucide-react-native"
 import { LocationCoords } from "../../../types/global"
 import { useTheme } from "../../../hooks/useTheme"
 import { useCoords } from "../../../contexts/TrackingProvider"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
-import { MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM } from "../../../constants"
+import { MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM, space } from "../../../constants"
 import { MapCenterButton } from "../map/MapCenterButton"
 import { TrackToggleButton } from "../map/TrackToggleButton"
 import { ColotaMapView, ColotaMapRef } from "../map/ColotaMapView"
@@ -257,7 +257,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    padding: 24
+    padding: space.xl
   },
   icon: { width: 64, height: 64 },
   iconCircle: {
@@ -266,14 +266,14 @@ const styles = StyleSheet.create({
     borderRadius: 40,
     justifyContent: "center",
     alignItems: "center",
-    marginBottom: 16
+    marginBottom: space.lg
   },
-  stateTitle: { fontSize: 18, ...fonts.bold, textAlign: "center" },
+  stateTitle: { fontSize: fontSizes.heading, ...fonts.bold, textAlign: "center" },
   stateTitleSpaced: { marginTop: 20 },
   stateSubtext: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     textAlign: "center",
-    marginTop: 8,
+    marginTop: space.sm,
     lineHeight: 20
   },
   statusBar: {
@@ -285,5 +285,5 @@ const styles = StyleSheet.create({
     alignItems: "center",
     zIndex: 5
   },
-  barText: { fontSize: 13, ...fonts.semiBold, color: "#fff" }
+  barText: { fontSize: fontSizes.description, ...fonts.semiBold, color: "#fff" }
 })

--- a/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
+++ b/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
@@ -7,9 +7,10 @@ import { Text, StyleSheet, View } from "react-native"
 import { SectionTitle, Card } from "../.."
 import { useTheme } from "../../../hooks/useTheme"
 import { useTracking } from "../../../contexts/TrackingProvider"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { DatabaseStats } from "../../../types/global"
 import { getQueueColor } from "../../../utils/queueStatus"
+import { space } from "../../../constants"
 
 type DatabaseStatisticsProps = {
   stats: DatabaseStats
@@ -67,31 +68,31 @@ export const DatabaseStatistics = React.memo(function DatabaseStatistics({ stats
 
 const styles = StyleSheet.create({
   metricsSection: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   statsGrid: {
     flexDirection: "row",
-    gap: 12
+    gap: space.md
   },
   statsGridSpaced: {
-    marginTop: 12
+    marginTop: space.md
   },
   statCard: {
     alignItems: "center"
   },
   statUnit: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.medium
   },
   statLabel: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.semiBold,
     marginBottom: 6,
     letterSpacing: 0.5,
     textTransform: "uppercase"
   },
   statValue: {
-    fontSize: 24,
+    fontSize: fontSizes.statValue,
     ...fonts.bold,
     letterSpacing: -0.5,
     marginBottom: 2

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -8,8 +8,10 @@ import { Text, StyleSheet, View, Pressable } from "react-native"
 import { Check, ChevronRight } from "lucide-react-native"
 import { Settings, ThemeColors } from "../../../types/global"
 import { useTracking } from "../../../contexts/TrackingProvider"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { Card } from "../../ui/Card"
+import { space } from "../../../constants"
+import { radius } from "@colota/shared"
 
 interface WelcomeCardProps {
   settings: Settings
@@ -135,21 +137,21 @@ export function WelcomeCard({
 
 const styles = StyleSheet.create({
   container: {
-    marginBottom: 16
+    marginBottom: space.lg
   },
   title: {
-    fontSize: 20,
+    fontSize: fontSizes.cardTitle,
     ...fonts.bold,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   subtitle: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.regular,
-    marginBottom: 16
+    marginBottom: space.lg
   },
   checklist: {
-    gap: 12,
-    marginBottom: 16
+    gap: space.md,
+    marginBottom: space.lg
   },
   checklistItem: {
     flexDirection: "row",
@@ -158,14 +160,14 @@ const styles = StyleSheet.create({
   checkCircle: {
     width: 24,
     height: 24,
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 2,
     justifyContent: "center",
     alignItems: "center",
-    marginRight: 12
+    marginRight: space.md
   },
   checklistLabel: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.medium,
     flex: 1
   },
@@ -174,11 +176,11 @@ const styles = StyleSheet.create({
   },
   linkRow: {
     flexDirection: "row",
-    gap: 16,
-    marginBottom: 16
+    gap: space.lg,
+    marginBottom: space.lg
   },
   link: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   dismissButton: {
@@ -188,7 +190,7 @@ const styles = StyleSheet.create({
     borderWidth: 1.5
   },
   dismissText: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   }
 })

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -7,10 +7,11 @@ import React, { useState, useMemo, useCallback, useRef } from "react"
 import { View, Text, Pressable, StyleSheet, LayoutAnimation } from "react-native"
 import { ChevronLeft, ChevronRight, Calendar } from "lucide-react-native"
 import { ThemeColors } from "../../../types/global"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { formatDistance } from "../../../utils/geo"
 import { pad2 } from "../../../utils/format"
-import { HIT_SLOP_LG } from "../../../constants"
+import { HIT_SLOP_LG, space } from "../../../constants"
+import { radius } from "@colota/shared"
 
 interface CalendarPickerProps {
   date: Date
@@ -305,7 +306,7 @@ export function CalendarPicker({
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: 12,
+    paddingHorizontal: space.md,
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth
   },
@@ -315,7 +316,7 @@ const styles = StyleSheet.create({
     justifyContent: "space-between"
   },
   navBtn: {
-    padding: 8
+    padding: space.sm
   },
   dateContainer: {
     alignItems: "center",
@@ -330,7 +331,7 @@ const styles = StyleSheet.create({
     marginTop: 1
   },
   dateText: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.bold
   },
   todayBadge: {
@@ -339,49 +340,49 @@ const styles = StyleSheet.create({
     borderRadius: 6
   },
   todayBadgeText: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.bold
   },
   countText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     marginTop: 2
   },
   todayBtn: {
     alignSelf: "center",
-    marginTop: 8,
-    paddingHorizontal: 16,
+    marginTop: space.sm,
+    paddingHorizontal: space.lg,
     paddingVertical: 6,
     borderRadius: 14
   },
   todayText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold
   },
   calendarContainer: {
-    marginTop: 12
+    marginTop: space.md
   },
   monthRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    marginBottom: 8
+    marginBottom: space.sm
   },
   monthNav: {
-    padding: 8
+    padding: space.sm
   },
   monthLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   weekdayRow: {
     flexDirection: "row",
-    marginBottom: 4
+    marginBottom: space.xs
   },
   weekdayText: {
     flex: 1,
     textAlign: "center",
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.semiBold
   },
   daysGrid: {
@@ -390,19 +391,19 @@ const styles = StyleSheet.create({
   },
   dayCell: {
     width: "14.28%",
-    paddingVertical: 4,
+    paddingVertical: space.xs,
     alignItems: "center",
     justifyContent: "center"
   },
   dayCircle: {
     width: 32,
     height: 32,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     alignItems: "center",
     justifyContent: "center"
   },
   dayText: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   },
   dayDist: {

--- a/apps/mobile/src/components/features/inspector/LocationTable.tsx
+++ b/apps/mobile/src/components/features/inspector/LocationTable.tsx
@@ -5,9 +5,10 @@
 
 import React, { useCallback, useMemo } from "react"
 import { View, Text, FlatList, ScrollView, StyleSheet } from "react-native"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { LocationCoords, ThemeColors } from "../../../types/global"
 import { formatTime, getSpeedUnit } from "../../../utils/geo"
+import { space } from "../../../constants"
 
 interface Props {
   locations: LocationCoords[]
@@ -167,17 +168,17 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    padding: 32
+    padding: space.xxl
   },
   emptyText: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.regular
   },
   header: {
     borderBottomWidth: 2
   },
   headerText: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.bold,
     textTransform: "uppercase"
   },
@@ -185,11 +186,11 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     height: ROW_HEIGHT,
     alignItems: "center",
-    paddingHorizontal: 8,
+    paddingHorizontal: space.sm,
     borderBottomWidth: StyleSheet.hairlineWidth
   },
   cell: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     paddingHorizontal: 2
   },

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -10,7 +10,7 @@ import type { NativeSyntheticEvent } from "react-native"
 import { MapPinOff, X, Check, Trash2, Split } from "lucide-react-native"
 import { ThemeColors, Trip } from "../../../types/global"
 import { getTripColor } from "../../../utils/trips"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { MapCenterButton } from "../map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../map/ColotaMapView"
 import {
@@ -21,7 +21,8 @@ import {
   type TrackLocation
 } from "../map/mapUtils"
 import { getSpeedUnit } from "../../../utils/geo"
-import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS } from "../../../constants"
+import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, space } from "../../../constants"
+import { radius } from "@colota/shared"
 
 const HAS_NOTE = ["!=", ["get", "note"], ""]
 const trackPointStyle: any = {
@@ -426,7 +427,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     justifyContent: "center",
     alignItems: "center",
-    padding: 24,
+    padding: space.xl,
     zIndex: 20
   },
   iconCircle: {
@@ -435,17 +436,17 @@ const styles = StyleSheet.create({
     borderRadius: 32,
     justifyContent: "center",
     alignItems: "center",
-    marginBottom: 16
+    marginBottom: space.lg
   },
   emptyTitle: {
-    fontSize: 18,
+    fontSize: fontSizes.heading,
     ...fonts.bold,
     textAlign: "center"
   },
   emptySubtext: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     textAlign: "center",
-    marginTop: 8,
+    marginTop: space.sm,
     lineHeight: 20
   },
   popupCard: {
@@ -453,8 +454,8 @@ const styles = StyleSheet.create({
     top: 10,
     left: 10,
     right: 10,
-    padding: 12,
-    borderRadius: 12,
+    padding: space.md,
+    borderRadius: radius.md,
     borderWidth: 1,
     elevation: 6,
     shadowColor: "#000",
@@ -467,7 +468,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 4
+    marginBottom: space.xs
   },
   popupActions: {
     flexDirection: "row",
@@ -477,20 +478,20 @@ const styles = StyleSheet.create({
   },
   popupTime: {
     fontWeight: "600",
-    fontSize: 13
+    fontSize: fontSizes.description
   },
   popupRow: {
     flexDirection: "row",
     justifyContent: "space-between"
   },
   popupLabel: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     textTransform: "uppercase",
     fontWeight: "600"
   },
   popupValue: {
     fontWeight: "500",
-    fontSize: 12
+    fontSize: fontSizes.caption
   },
   noteSection: {
     marginTop: 6,
@@ -501,11 +502,11 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "flex-end",
     gap: 6,
-    marginTop: 4
+    marginTop: space.xs
   },
   noteInput: {
     flex: 1,
-    fontSize: 13,
+    fontSize: fontSizes.description,
     paddingVertical: 2,
     paddingHorizontal: 6,
     borderWidth: 1,
@@ -520,10 +521,10 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 30,
     left: 10,
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 1,
-    padding: 8,
-    gap: 4,
+    padding: space.sm,
+    gap: space.xs,
     elevation: 4,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
@@ -542,7 +543,7 @@ const styles = StyleSheet.create({
     borderRadius: 5
   },
   legendLabel: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     fontWeight: "500"
   }
 })

--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -7,12 +7,13 @@ import React, { useState, useCallback, useMemo, useEffect, useRef } from "react"
 import { View, Text, FlatList, Pressable, StyleSheet, BackHandler } from "react-native"
 import { Clock, Route, Share, TrendingUp, TrendingDown, Gauge, Trash2, X, Merge } from "lucide-react-native"
 import { Card } from "../../ui/Card"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { formatDistance, formatDuration, formatSpeed, formatTime } from "../../../utils/geo"
 import type { Trip, ThemeColors } from "../../../types/global"
 import { getTripColor, computeTripStats, type TripStats } from "../../../utils/trips"
 import { EXPORT_FORMATS, EXPORT_FORMAT_KEYS, type ExportFormat } from "../../../utils/exportConverters"
-import { HIT_SLOP_SM } from "../../../constants"
+import { HIT_SLOP_SM, space } from "../../../constants"
+import { radius } from "@colota/shared"
 
 interface TripListProps {
   trips: Trip[]
@@ -386,7 +387,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingTop: 10,
     paddingBottom: 14,
     minHeight: 54
@@ -394,17 +395,17 @@ const styles = StyleSheet.create({
   cabLeft: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4,
+    gap: space.xs,
     flexShrink: 1
   },
   cabSummary: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold
   },
   cabActions: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4
+    gap: space.xs
   },
   cabIconBtn: {
     minWidth: 48,
@@ -419,47 +420,47 @@ const styles = StyleSheet.create({
     justifyContent: "center"
   },
   cabTextBtnLabel: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold
   },
   summary: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold
   },
   exportAllBtn: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4,
-    paddingHorizontal: 12,
+    gap: space.xs,
+    paddingHorizontal: space.md,
     minHeight: 48
   },
   exportAllLabel: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.semiBold
   },
   exportRow: {
     flexDirection: "row",
-    gap: 8,
-    paddingHorizontal: 16,
+    gap: space.sm,
+    paddingHorizontal: space.lg,
     paddingTop: 10,
-    paddingBottom: 12
+    paddingBottom: space.md
   },
   exportChip: {
     paddingHorizontal: 10,
     paddingVertical: 5,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     borderWidth: 1
   },
   exportChipText: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.bold
   },
   list: {
-    paddingHorizontal: 12,
-    paddingBottom: 16
+    paddingHorizontal: space.md,
+    paddingBottom: space.lg
   },
   tripCard: {
-    marginBottom: 8
+    marginBottom: space.sm
   },
   tripCardSelected: {
     borderWidth: 1.5
@@ -468,53 +469,53 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 8
+    marginBottom: space.sm
   },
   tripTitleRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8
+    gap: space.sm
   },
   tripDot: {
     width: 8,
     height: 8,
-    borderRadius: 4
+    borderRadius: radius.xs
   },
   tripTitle: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.bold
   },
   tripTime: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   },
   tripStats: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 12
+    gap: space.md
   },
   stat: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4
+    gap: space.xs
   },
   statText: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   },
   emptyContainer: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    gap: 8,
+    gap: space.sm,
     paddingTop: 60
   },
   emptyText: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.regular
   },
   emptyHint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/components/features/inspector/__tests__/LocationTable.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/LocationTable.test.tsx
@@ -10,7 +10,10 @@ jest.mock("../../../../utils/geo", () => ({
 }))
 
 jest.mock("../../../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
+  fonts: { regular: {}, bold: {}, semiBold: {} },
+  // The real scale, not stubs: these tests render styles that read a named size, and a
+  // stubbed object would let a renamed key through.
+  fontSizes: jest.requireActual("@colota/shared").fontSizes
 }))
 
 import { LocationTable } from "../LocationTable"

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -63,7 +63,10 @@ jest.mock("../../map/MapCenterButton", () => ({
 }))
 
 jest.mock("../../../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
+  fonts: { regular: {}, bold: {}, semiBold: {} },
+  // The real scale, not stubs: these tests render styles that read a named size, and a
+  // stubbed object would let a renamed key through.
+  fontSizes: jest.requireActual("@colota/shared").fontSizes
 }))
 
 jest.mock("../../../../utils/geo", () => ({

--- a/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
@@ -16,7 +16,10 @@ jest.mock("../../../../utils/trips", () => ({
 }))
 
 jest.mock("../../../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
+  fonts: { regular: {}, bold: {}, semiBold: {} },
+  // The real scale, not stubs: these tests render styles that read a named size, and a
+  // stubbed object would let a renamed key through.
+  fontSizes: jest.requireActual("@colota/shared").fontSizes
 }))
 
 jest.mock("../../../../utils/exportConverters", () => ({

--- a/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
+++ b/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
@@ -13,6 +13,7 @@ import NativeLocationService from "../../../services/NativeLocationService"
 import { logger } from "../../../utils/logger"
 import { showAlert, showChoice } from "../../../services/modalService"
 import { formatBytes } from "../../../utils/format"
+import { space } from "../../../constants"
 
 export function FileLoggingPanel() {
   const { colors } = useTheme()
@@ -161,11 +162,11 @@ export function FileLoggingPanel() {
 
 const styles = StyleSheet.create({
   scroll: {
-    padding: 16,
+    padding: space.lg,
     paddingBottom: 40
   },
   card: {
-    marginBottom: 12
+    marginBottom: space.md
   },
   centered: {
     flex: 1,
@@ -173,41 +174,41 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   intro: {
-    marginBottom: 12,
-    fontSize: 14,
+    marginBottom: space.md,
+    fontSize: fontSizes.body,
     lineHeight: 20
   },
   toggleRow: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 4
+    paddingVertical: space.xs
   },
   toggleLabel: {
     flex: 1,
-    paddingRight: 12
+    paddingRight: space.md
   },
   section: {
-    paddingVertical: 4
+    paddingVertical: space.xs
   },
   label: {
     fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   hint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     lineHeight: 18,
-    marginBottom: 12
+    marginBottom: space.md
   },
   sizeRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 4
+    marginBottom: space.xs
   },
   sizeValue: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.medium,
     fontFamily: "monospace"
   }

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -11,8 +11,8 @@ import type { NativeSyntheticEvent } from "react-native"
 import { Compass, Info, X } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
-import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_LIGHT, MAP_STYLE_URL_DARK } from "../../../constants"
-import { fonts } from "../../../styles/typography"
+import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_DARK, MAP_STYLE_URL_LIGHT, space } from "../../../constants"
+import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
 
@@ -263,17 +263,17 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0, 0, 0, 0.4)",
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: 32
+    paddingHorizontal: space.xxl
   },
   attributionPopup: {
     maxWidth: 320,
     width: "100%",
-    paddingLeft: 16,
+    paddingLeft: space.lg,
     paddingRight: 36,
     paddingVertical: 14,
     borderRadius: 10,
     borderWidth: 1,
-    gap: 8,
+    gap: space.sm,
     elevation: 8,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
@@ -281,12 +281,12 @@ const styles = StyleSheet.create({
     shadowRadius: 6
   },
   attributionPopupText: {
-    fontSize: 13
+    fontSize: fontSizes.description
   },
   attributionClose: {
     position: "absolute",
     top: 6,
     right: 6,
-    padding: 4
+    padding: space.xs
   }
 })

--- a/apps/mobile/src/components/features/map/MapActionButton.tsx
+++ b/apps/mobile/src/components/features/map/MapActionButton.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { Pressable, StyleSheet, ViewStyle, StyleProp, PressableProps } from "react-native"
 import { useTheme } from "../../../hooks/useTheme"
+import { radius } from "@colota/shared"
 
 interface Props {
   onPress: () => void
@@ -43,7 +44,7 @@ const styles = StyleSheet.create({
     bottom: 30,
     width: 40,
     height: 40,
-    borderRadius: 12,
+    borderRadius: radius.md,
     justifyContent: "center",
     alignItems: "center",
     elevation: 5,

--- a/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
+++ b/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
@@ -7,6 +7,7 @@ import React, { useMemo } from "react"
 import { View, StyleSheet } from "react-native"
 import { GeoJSONSource, Layer, Marker } from "@maplibre/maplibre-react-native"
 import type { LocationCoords, ThemeColors } from "../../../types/global"
+import { radius } from "@colota/shared"
 
 /** meters-per-pixel at zoom 0 on the equator (Web Mercator constant) */
 const METERS_PER_PX_Z0 = 156543.03
@@ -83,7 +84,7 @@ const styles = StyleSheet.create({
   markerDot: {
     width: 24,
     height: 24,
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 3,
     borderColor: "white",
     elevation: 4,

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -11,13 +11,14 @@ import NativeLocationService from "../../../services/NativeLocationService"
 import { isEndpointAllowed } from "../../../utils/settingsValidation"
 import { isTraccarJsonFormat, isOverlandFormat } from "../../../utils/apiPayload"
 import { ensureLocalNetworkPermission } from "../../../services/LocationServicePermission"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { SettingRow } from "../../ui/SettingRow"
 import { useTimeout } from "../../../hooks/useTimeout"
-import { TEST_RESULT_DISPLAY_MS } from "../../../constants"
+import { TEST_RESULT_DISPLAY_MS, space } from "../../../constants"
 import { logger } from "../../../utils/logger"
 import { Button, Card, SectionTitle, Divider, FieldMessage } from "../../index"
 import { showChoice } from "../../../services/modalService"
+import { radius } from "@colota/shared"
 
 interface ConnectionSettingsProps {
   settings: Settings
@@ -307,10 +308,10 @@ export function ConnectionSettings({
 
 const styles = StyleSheet.create({
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   inputGroup: {
-    marginBottom: 12
+    marginBottom: space.md
   },
   inputHeader: {
     flexDirection: "row",
@@ -319,61 +320,61 @@ const styles = StyleSheet.create({
     marginBottom: 10
   },
   inputLabel: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.semiBold
   },
   protocolBadge: {
     paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 12
+    paddingVertical: space.xs,
+    borderRadius: radius.md
   },
   protocolText: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.bold
   },
   input: {
     borderWidth: 1.5,
-    padding: 16,
-    borderRadius: 12,
-    fontSize: 15,
+    padding: space.lg,
+    borderRadius: radius.md,
+    fontSize: fontSizes.input,
     ...fonts.regular
   },
   testButton: {
-    marginTop: 12
+    marginTop: space.md
   },
   disabledButton: {
     opacity: 0.5
   },
   responseBox: {
-    marginTop: 12,
+    marginTop: space.md,
     padding: 14,
     borderWidth: 1.5,
-    borderRadius: 12,
+    borderRadius: radius.md,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 8
+    gap: space.sm
   },
   responseText: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   linkRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 12
+    paddingVertical: space.md
   },
   linkContent: {
     flex: 1
   },
   linkLabel: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     marginBottom: 2
   },
   linkSub: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/components/features/settings/MtlsSection.tsx
+++ b/apps/mobile/src/components/features/settings/MtlsSection.tsx
@@ -11,6 +11,8 @@ import { SectionTitle, Card, Divider, Button, FieldMessage } from "../../index"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { ClientCertInfoResult } from "../../../types/global"
 import { logger } from "../../../utils/logger"
+import { space } from "../../../constants"
+import { radius } from "@colota/shared"
 
 const EXPIRY_WARNING_DAYS = 14
 
@@ -328,31 +330,31 @@ function shortenDn(dn: string): string {
 
 const styles = StyleSheet.create({
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   muted: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     lineHeight: 18
   },
   fieldLabel: {
     fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginBottom: 8
+    marginBottom: space.sm
   },
   input: {
     borderWidth: 1.5,
     padding: 14,
-    borderRadius: 12,
-    fontSize: 15
+    borderRadius: radius.md,
+    fontSize: fontSizes.input
   },
   importButton: {
-    marginTop: 12
+    marginTop: space.md
   },
   buttonRow: {
     flexDirection: "row",
-    gap: 8,
-    marginTop: 12,
+    gap: space.sm,
+    marginTop: space.md,
     alignItems: "center"
   },
   flex1: {
@@ -362,12 +364,12 @@ const styles = StyleSheet.create({
     paddingVertical: 10
   },
   detailLabel: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.medium,
     marginBottom: 2
   },
   detailValue: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/components/features/settings/PresetOption.tsx
+++ b/apps/mobile/src/components/features/settings/PresetOption.tsx
@@ -6,9 +6,10 @@ import React from "react"
 import { View, Text, StyleSheet, Pressable } from "react-native"
 import { Zap, Check } from "lucide-react-native"
 import { SelectablePreset, TRACKING_PRESETS } from "../../../types/global"
-import { fonts } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { useTheme } from "../../../hooks/useTheme"
 import { RadioDot } from "../../ui/RadioDot"
+import { space } from "../../../constants"
 
 interface BadgeProps {
   icon: React.ReactElement
@@ -86,7 +87,7 @@ const styles = StyleSheet.create({
   content: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 12
+    paddingVertical: space.md
   },
   leftContent: {
     flex: 1
@@ -98,31 +99,31 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     flexWrap: "wrap",
-    gap: 8,
-    marginBottom: 4
+    gap: space.sm,
+    marginBottom: space.xs
   },
   label: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     letterSpacing: -0.2
   },
   badge: {
-    paddingHorizontal: 8,
+    paddingHorizontal: space.sm,
     paddingVertical: 3,
     borderRadius: 6
   },
   badgeContent: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4
+    gap: space.xs
   },
   badgeText: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.bold,
     letterSpacing: 0.3
   },
   description: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     lineHeight: 18
   }

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -9,8 +9,9 @@ import { useTracking } from "../../../contexts/TrackingProvider"
 import { useTheme } from "../../../hooks/useTheme"
 import { getQueueColor } from "../../../utils/queueStatus"
 import { formatCount } from "../../../utils/format"
-import { fonts } from "../../../styles/typography"
-import { HIGH_QUEUE_THRESHOLD, CRITICAL_QUEUE_THRESHOLD } from "../../../constants"
+import { fontSizes, fonts } from "../../../styles/typography"
+import { CRITICAL_QUEUE_THRESHOLD, HIGH_QUEUE_THRESHOLD, space } from "../../../constants"
+import { radius } from "@colota/shared"
 
 interface StatsCardProps {
   queueCount: number
@@ -173,9 +174,9 @@ export function StatsCard({ queueCount, sentCount, todayCount, interval, onManag
 
 const styles = StyleSheet.create({
   container: {
-    borderRadius: 16,
+    borderRadius: radius.lg,
     borderWidth: 2,
-    marginBottom: 24,
+    marginBottom: space.xl,
     overflow: "hidden"
   },
   gradientOverlay: {
@@ -194,42 +195,42 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   statLabel: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold,
     textTransform: "uppercase",
     letterSpacing: 0.8,
-    marginBottom: 8
+    marginBottom: space.sm
   },
   statValue: {
-    fontSize: 24,
+    fontSize: fontSizes.statValue,
     ...fonts.bold,
     letterSpacing: -0.5
   },
   unit: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.medium
   },
   disabledHint: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     marginTop: 2,
     fontStyle: "italic"
   },
   divider: {
     width: 1,
-    marginHorizontal: 12,
+    marginHorizontal: space.md,
     opacity: 0.3
   },
   warningWrapper: {
-    paddingHorizontal: 12,
-    paddingBottom: 12
+    paddingHorizontal: space.md,
+    paddingBottom: space.md
   },
   warningButton: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderRadius: 12,
+    paddingHorizontal: space.lg,
+    paddingVertical: space.md,
+    borderRadius: radius.md,
     borderWidth: 1.5
   },
   warningContent: {
@@ -239,15 +240,15 @@ const styles = StyleSheet.create({
   },
   warningText: {
     flex: 1,
-    marginLeft: 12
+    marginLeft: space.md
   },
   warningTitle: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold,
     marginBottom: 2
   },
   warningHint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -8,12 +8,13 @@ import { Text, StyleSheet, Switch, View, Pressable, TextInput, AppState } from "
 import { Lightbulb, ChevronDown, ChevronUp } from "lucide-react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
 import { fonts, fontSizes } from "../../../styles/typography"
-import { SYNC_INTERVAL_PRESETS, SYNC_INTERVAL_LABELS, OVERLAND_BATCH_MIN, OVERLAND_BATCH_MAX } from "../../../constants"
+import { OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, space } from "../../../constants"
 import { SectionTitle, Card, Divider, NumericInput, SettingRow } from "../../index"
 import { PresetOption } from "./PresetOption"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
 import { isOverlandFormat } from "../../../utils/apiPayload"
 import NativeLocationService from "../../../services/NativeLocationService"
+import { radius } from "@colota/shared"
 
 interface SyncStrategySettingsProps {
   settings: Settings
@@ -481,7 +482,7 @@ export function SyncStrategySettings({
 
 const styles = StyleSheet.create({
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   presetSpacer: {
     height: 8
@@ -490,14 +491,14 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 12
+    paddingVertical: space.md
   },
   advancedText: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold
   },
   advancedPanel: {
-    marginTop: 16
+    marginTop: space.lg
   },
   customBanner: {
     padding: 14,
@@ -507,21 +508,21 @@ const styles = StyleSheet.create({
   bannerRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8
+    gap: space.sm
   },
   customBannerText: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.medium
   },
   paramGroup: {
-    marginBottom: 4
+    marginBottom: space.xs
   },
   paramGroupTitle: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.bold,
     textTransform: "uppercase",
     letterSpacing: 1,
-    marginBottom: 16,
+    marginBottom: space.lg,
     opacity: 0.6
   },
   settingBlock: {
@@ -530,17 +531,17 @@ const styles = StyleSheet.create({
   blockLabel: {
     fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   blockHint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
-    marginBottom: 12,
+    marginBottom: space.md,
     lineHeight: 18
   },
   optionsGrid: {
     flexDirection: "row",
-    gap: 8,
+    gap: space.sm,
     flexWrap: "wrap"
   },
   gridOption: {
@@ -551,58 +552,58 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   gridLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   settingRowSpaced: {
-    marginTop: 16
+    marginTop: space.lg
   },
   nestedSetting: {
-    marginTop: 12,
-    paddingLeft: 16,
+    marginTop: space.md,
+    paddingLeft: space.lg,
     borderLeftWidth: 3
   },
   customSyncInput: {
-    marginTop: 12
+    marginTop: space.md
   },
   syncConditionChips: {
     flexDirection: "row",
     gap: 6
   },
   syncConditionChip: {
-    paddingHorizontal: 12,
+    paddingHorizontal: space.md,
     paddingVertical: 6,
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 1
   },
   syncConditionChipText: {
     ...fonts.medium,
-    fontSize: 12
+    fontSize: fontSizes.caption
   },
   ssidRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginTop: 8,
-    gap: 8
+    marginTop: space.sm,
+    gap: space.sm
   },
   ssidInput: {
     flex: 1,
     borderWidth: 1.5,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     paddingHorizontal: 10,
     paddingVertical: 6,
-    fontSize: 13,
+    fontSize: fontSizes.description,
     fontFamily: "monospace"
   },
   ssidFillButton: {
     alignSelf: "flex-start",
     paddingHorizontal: 10,
     paddingVertical: 6,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     borderWidth: 1
   },
   ssidFillText: {
     ...fonts.medium,
-    fontSize: 12
+    fontSize: fontSizes.caption
   }
 })

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -7,9 +7,10 @@ import React, { useState, useRef, useEffect, useCallback } from "react"
 import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-native"
 import { Info, AlertCircle, AlertTriangle, CheckCircle } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
-import { fontSizes } from "@colota/shared"
+import { fontSizes, fonts } from "../../styles/typography"
+import { radius } from "@colota/shared"
 import { type ModalRequest, type AlertVariant, registerModalHandler } from "../../services/modalService"
+import { space } from "../../constants"
 
 const VARIANT_ICONS = {
   info: Info,
@@ -137,11 +138,11 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    paddingHorizontal: 32
+    paddingHorizontal: space.xxl
   },
   card: {
     width: "100%",
-    padding: 24,
+    padding: space.xl,
     elevation: 8,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
@@ -155,13 +156,13 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     alignSelf: "center",
-    marginBottom: 16
+    marginBottom: space.lg
   },
   title: {
     fontSize: fontSizes.cardTitle,
     ...fonts.bold,
     textAlign: "center",
-    marginBottom: 12
+    marginBottom: space.md
   },
   body: {
     fontSize: fontSizes.body,
@@ -171,8 +172,8 @@ const styles = StyleSheet.create({
   },
   buttons: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 24
+    gap: space.md,
+    marginTop: space.xl
   },
   buttonsVertical: {
     flexDirection: "column"
@@ -183,7 +184,7 @@ const styles = StyleSheet.create({
   button: {
     flex: 1,
     paddingVertical: 14,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     alignItems: "center"
   },
   buttonText: {

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -7,7 +7,8 @@ import { View, Pressable, Text, StyleSheet } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Settings, LucideIcon, House, MapPinHouse, Waypoints } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
 
 interface Tab {
   name: string
@@ -70,7 +71,7 @@ export { TAB_ROUTES }
 const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
-    paddingTop: 8,
+    paddingTop: space.sm,
     paddingBottom: 6,
     elevation: 0,
     shadowOpacity: 0,
@@ -83,7 +84,7 @@ const styles = StyleSheet.create({
     gap: 3
   },
   label: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.medium
   }
 })

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -16,8 +16,9 @@ import {
   ViewStyle
 } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
 import { type LucideIcon } from "lucide-react-native"
+import { space } from "../../constants"
 
 type ButtonVariant = "primary" | "secondary" | "ghost" | "danger"
 
@@ -133,18 +134,18 @@ export function Button({
 
 const styles = StyleSheet.create({
   button: {
-    paddingVertical: 12,
-    paddingHorizontal: 24,
+    paddingVertical: space.md,
+    paddingHorizontal: space.xl,
     alignItems: "center",
-    marginVertical: 8
+    marginVertical: space.sm
   },
   content: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8
+    gap: space.sm
   },
   text: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold
   },
   icon: {

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -6,6 +6,8 @@
 import React from "react"
 import { View, Pressable, StyleSheet, ViewStyle, StyleProp, AccessibilityRole, AccessibilityState } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
+import { space } from "../../constants"
+import { radius } from "@colota/shared"
 
 type CardVariant = "default" | "elevated" | "outlined" | "interactive"
 
@@ -102,8 +104,8 @@ export function Card({
 const styles = StyleSheet.create({
   card: {
     flex: 1,
-    padding: 16,
-    borderRadius: 12,
+    padding: space.lg,
+    borderRadius: radius.md,
     borderWidth: 1,
     width: "100%"
   }

--- a/apps/mobile/src/components/ui/ChipGroup.tsx
+++ b/apps/mobile/src/components/ui/ChipGroup.tsx
@@ -6,7 +6,8 @@
 import React from "react"
 import { View, Pressable, Text, StyleSheet } from "react-native"
 import { ThemeColors } from "../../types/global"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
 
 interface ChipGroupProps<T extends string> {
   options: readonly { value: T; label: string }[]
@@ -47,7 +48,7 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 8
+    gap: space.sm
   },
   chip: {
     borderWidth: 2,
@@ -57,7 +58,7 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   label: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.bold
   }
 })

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -6,8 +6,9 @@
 import React, { useState, useRef, useEffect, useCallback } from "react"
 import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
-import { fontSizes } from "@colota/shared"
+import { fontSizes, fonts } from "../../styles/typography"
+import { radius } from "@colota/shared"
+import { space } from "../../constants"
 
 interface DisclosureModalProps {
   icon: React.ReactNode
@@ -111,11 +112,11 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    paddingHorizontal: 32
+    paddingHorizontal: space.xxl
   },
   card: {
     width: "100%",
-    padding: 24,
+    padding: space.xl,
     elevation: 8,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
@@ -129,13 +130,13 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     alignSelf: "center",
-    marginBottom: 16
+    marginBottom: space.lg
   },
   title: {
     fontSize: fontSizes.cardTitle,
     ...fonts.bold,
     textAlign: "center",
-    marginBottom: 16
+    marginBottom: space.lg
   },
   body: {
     fontSize: fontSizes.body,
@@ -143,17 +144,17 @@ const styles = StyleSheet.create({
     lineHeight: 20
   },
   bodySpaced: {
-    marginTop: 8
+    marginTop: space.sm
   },
   buttons: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 24
+    gap: space.md,
+    marginTop: space.xl
   },
   button: {
     flex: 1,
     paddingVertical: 14,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     alignItems: "center"
   },
   primaryButton: {},

--- a/apps/mobile/src/components/ui/Divider.tsx
+++ b/apps/mobile/src/components/ui/Divider.tsx
@@ -5,6 +5,7 @@
 
 import { View, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
+import { space } from "../../constants"
 
 export const Divider = () => {
   const { colors } = useTheme()
@@ -15,6 +16,6 @@ export const Divider = () => {
 const styles = StyleSheet.create({
   divider: {
     height: 1,
-    marginVertical: 16
+    marginVertical: space.lg
   }
 })

--- a/apps/mobile/src/components/ui/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ui/ErrorBoundary.tsx
@@ -8,6 +8,8 @@ import { ThemeColors } from "../../types/global"
 import { useTheme } from "../../hooks/useTheme"
 import { logger } from "../../utils/logger"
 import { fonts, fontSizes } from "../../styles/typography"
+import { space } from "../../constants"
+import { radius } from "@colota/shared"
 
 interface ErrorBoundaryInternalProps {
   children: React.ReactNode
@@ -93,9 +95,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20
   },
   errorButton: {
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8
+    paddingHorizontal: space.xl,
+    paddingVertical: space.md,
+    borderRadius: radius.sm
   },
   errorButtonText: {
     fontSize: fontSizes.label,

--- a/apps/mobile/src/components/ui/FieldMessage.tsx
+++ b/apps/mobile/src/components/ui/FieldMessage.tsx
@@ -6,7 +6,7 @@
 import React from "react"
 import { Text, StyleSheet, StyleProp, TextStyle } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
 
 type FieldMessageVariant = "info" | "warning" | "error"
 
@@ -25,7 +25,7 @@ export function FieldMessage({ children, variant = "info", style }: FieldMessage
 
 const styles = StyleSheet.create({
   message: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     marginTop: 6,
     ...fonts.medium
   }

--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -7,7 +7,8 @@ import React, { useEffect, useRef } from "react"
 import { View, Text, StyleSheet, Animated } from "react-native"
 import { Check } from "lucide-react-native"
 import { SpinningLoader } from "./SpinningLoader"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
 
 interface Props {
   saving: boolean
@@ -81,14 +82,14 @@ const styles = StyleSheet.create({
   badge: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: space.sm,
     paddingHorizontal: 20,
-    paddingVertical: 12,
+    paddingVertical: space.md,
     borderRadius: 24,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 8
   },
-  text: { fontSize: 14, ...fonts.semiBold }
+  text: { fontSize: fontSizes.body, ...fonts.semiBold }
 })

--- a/apps/mobile/src/components/ui/Footer.tsx
+++ b/apps/mobile/src/components/ui/Footer.tsx
@@ -6,7 +6,8 @@
 import React from "react"
 import { View, Text, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
 
 export function Footer() {
   const { colors } = useTheme()
@@ -20,12 +21,12 @@ export function Footer() {
 
 const styles = StyleSheet.create({
   footer: {
-    marginTop: 32,
-    marginBottom: 16,
+    marginTop: space.xxl,
+    marginBottom: space.lg,
     alignItems: "center"
   },
   copyright: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/components/ui/FormatOption.tsx
+++ b/apps/mobile/src/components/ui/FormatOption.tsx
@@ -6,9 +6,10 @@
 import React from "react"
 import { Text, StyleSheet, View, Pressable } from "react-native"
 import type { LucideIcon } from "lucide-react-native"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
 import { RadioDot } from "./RadioDot"
+import { space } from "../../constants"
 
 export const FormatOption = ({
   icon: Icon,
@@ -74,7 +75,7 @@ export const FormatOption = ({
 
 const styles = StyleSheet.create({
   formatOption: {
-    paddingVertical: 8
+    paddingVertical: space.sm
   },
   formatContent: {
     flexDirection: "row",
@@ -84,7 +85,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    gap: 16
+    gap: space.lg
   },
   textContent: {
     flex: 1
@@ -92,31 +93,31 @@ const styles = StyleSheet.create({
   titleRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: space.sm,
     marginBottom: 2
   },
   formatTitle: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     letterSpacing: -0.2
   },
   extensionBadge: {
-    paddingHorizontal: 8,
+    paddingHorizontal: space.sm,
     paddingVertical: 3,
     borderRadius: 6,
     borderWidth: 1
   },
   extensionText: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.bold,
     letterSpacing: 0.3
   },
   formatSubtitle: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     marginBottom: 2
   },
   formatDescription: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     lineHeight: 16
   }
 })

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -7,7 +7,8 @@ import React from "react"
 import { Text, StyleSheet, View, Pressable } from "react-native"
 import { ChevronRight } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
 
 type IconComponent = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
 
@@ -69,19 +70,19 @@ const styles = StyleSheet.create({
     paddingVertical: 10
   },
   icon: {
-    marginRight: 16
+    marginRight: space.lg
   },
   content: {
     flex: 1,
-    paddingRight: 8
+    paddingRight: space.sm
   },
   label: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     marginBottom: 2
   },
   sub: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/components/ui/LoadingOverlay.tsx
+++ b/apps/mobile/src/components/ui/LoadingOverlay.tsx
@@ -5,7 +5,9 @@
 
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
+import { radius } from "@colota/shared"
 
 type Props = {
   visible: boolean
@@ -39,8 +41,8 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   card: {
-    padding: 32,
-    borderRadius: 16,
+    padding: space.xxl,
+    borderRadius: radius.lg,
     alignItems: "center",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
@@ -49,13 +51,13 @@ const styles = StyleSheet.create({
     minWidth: 240
   },
   title: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginTop: 16,
-    marginBottom: 8
+    marginTop: space.lg,
+    marginBottom: space.sm
   },
   message: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     textAlign: "center"
   }
 })

--- a/apps/mobile/src/components/ui/NumericInput.tsx
+++ b/apps/mobile/src/components/ui/NumericInput.tsx
@@ -6,7 +6,9 @@
 import React from "react"
 import { View, Text, StyleSheet, TextInput } from "react-native"
 import { ThemeColors } from "../../types/global"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
+import { radius } from "@colota/shared"
 
 interface NumericInputProps {
   label: string
@@ -76,34 +78,34 @@ export function NumericInput({
 
 const styles = StyleSheet.create({
   container: {
-    marginBottom: 16
+    marginBottom: space.lg
   },
   label: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold,
-    marginBottom: 8
+    marginBottom: space.sm
   },
   hint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
-    marginBottom: 12,
+    marginBottom: space.md,
     lineHeight: 18
   },
   inputRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12
+    gap: space.md
   },
   input: {
     flex: 1,
     borderWidth: 1,
     padding: 14,
-    borderRadius: 12,
-    fontSize: 15,
+    borderRadius: radius.md,
+    fontSize: fontSizes.input,
     textAlign: "center"
   },
   unit: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.medium,
     minWidth: 64
   }

--- a/apps/mobile/src/components/ui/RadioDot.tsx
+++ b/apps/mobile/src/components/ui/RadioDot.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { View, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
+import { radius } from "@colota/shared"
 
 export function RadioDot({ selected }: { selected: boolean }) {
   const { colors } = useTheme()
@@ -24,7 +25,7 @@ const styles = StyleSheet.create({
   radio: {
     width: 24,
     height: 24,
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 2,
     justifyContent: "center",
     alignItems: "center"

--- a/apps/mobile/src/components/ui/SectionTitle.tsx
+++ b/apps/mobile/src/components/ui/SectionTitle.tsx
@@ -6,7 +6,8 @@
 import React from "react"
 import { View, StyleSheet, ViewStyle, StyleProp, Text } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
+import { space } from "../../constants"
 
 type SectionTitleProps = {
   children: React.ReactNode
@@ -26,11 +27,11 @@ export function SectionTitle({ children, style, color }: SectionTitleProps) {
 
 const styles = StyleSheet.create({
   sectionTitle: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     textTransform: "uppercase",
     ...fonts.bold,
     letterSpacing: 1.2,
-    marginBottom: 12,
-    paddingHorizontal: 4
+    marginBottom: space.md,
+    paddingHorizontal: space.xs
   }
 })

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -5,8 +5,9 @@
 
 import React from "react"
 import { View, Text, StyleSheet, type StyleProp, type ViewStyle } from "react-native"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
+import { space } from "../../constants"
 
 interface SettingRowProps {
   label: string
@@ -33,19 +34,19 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 4
+    paddingVertical: space.xs
   },
   settingContent: {
     flex: 1,
-    marginRight: 16
+    marginRight: space.lg
   },
   settingLabel: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     marginBottom: 2
   },
   settingHint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     lineHeight: 18
   }

--- a/apps/mobile/src/components/ui/Tab.tsx
+++ b/apps/mobile/src/components/ui/Tab.tsx
@@ -5,8 +5,9 @@
 
 import React from "react"
 import { Pressable, Text, StyleSheet } from "react-native"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
 import { ThemeColors } from "../../types/global"
+import { space } from "../../constants"
 
 interface TabProps {
   label: string
@@ -34,11 +35,11 @@ const styles = StyleSheet.create({
   tab: {
     flex: 1,
     alignItems: "center",
-    padding: 12,
+    padding: space.md,
     borderBottomWidth: 2
   },
   tabText: {
-    fontSize: 14
+    fontSize: fontSizes.body
   },
   tabTextActive: {
     ...fonts.bold

--- a/apps/mobile/src/components/ui/TimePicker.tsx
+++ b/apps/mobile/src/components/ui/TimePicker.tsx
@@ -6,8 +6,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { View, Text, TextInput, StyleSheet } from "react-native"
 import { ThemeColors } from "../../types/global"
-import { fonts } from "../../styles/typography"
+import { fontSizes, fonts } from "../../styles/typography"
 import { clamp, pad2 } from "../../utils/format"
+import { space } from "../../constants"
+import { radius } from "@colota/shared"
 
 interface TimePickerProps {
   value: string
@@ -99,21 +101,21 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
-    paddingVertical: 4
+    gap: space.sm,
+    paddingVertical: space.xs
   },
   input: {
     minWidth: 64,
     padding: 14,
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 1,
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.semiBold,
     fontVariant: ["tabular-nums"],
     textAlign: "center"
   },
   separator: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.semiBold,
     paddingHorizontal: 2
   }

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -19,6 +19,18 @@ export const SETTINGS_READ_ATTEMPTS = 3
 export const SETTINGS_READ_RETRY_DELAY_MS = 150
 
 // Touch targets
+// Spacing scale. Every padding, margin and gap that sits on the scale reads from here.
+export const space = { xs: 4, sm: 8, md: 12, lg: 16, xl: 24, xxl: 32 } as const
+
+// Sizes are not spacing: these are the painted or touchable extents of a control.
+export const size = {
+  touch: 48,
+  row: 56,
+  chip: 36,
+  iconColumn: 40,
+  icon: { sm: 16, md: 20, lg: 24 }
+} as const
+
 export const HIT_SLOP_SM = { top: 6, right: 6, bottom: 6, left: 6 } as const
 export const HIT_SLOP_MD = { top: 8, right: 8, bottom: 8, left: 8 } as const
 export const HIT_SLOP_LG = { top: 12, right: 12, bottom: 12, left: 12 } as const

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -8,13 +8,14 @@ import { Text, StyleSheet, View, ScrollView, Linking, Pressable, Image } from "r
 import { ScreenProps, ThemeColors } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
 import { ExternalLink, Bug, FileText, Code, ScrollText, MessageCircle, Copy, Check } from "lucide-react-native"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Card, Container, Divider, SectionTitle, Footer } from "../components"
 import { useTimeout } from "../hooks/useTimeout"
 import NativeLocationService from "../services/NativeLocationService"
 import icon from "../assets/icons/icon.png"
-import { REPO_URL, ISSUES_URL, PRIVACY_POLICY_URL, TILE_SERVER_DOCS_URL } from "../constants"
+import { ISSUES_URL, PRIVACY_POLICY_URL, REPO_URL, TILE_SERVER_DOCS_URL, space } from "../constants"
 import { logger } from "../utils/logger"
+import { radius } from "@colota/shared"
 
 // Helper function to map SDK to Android version
 function getAndroidVersion(sdkVersion: number): string {
@@ -390,13 +391,13 @@ export function AboutScreen({}: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingBottom: 40,
-    paddingTop: 8
+    paddingTop: space.sm
   },
   header: {
     marginTop: 20,
-    marginBottom: 24,
+    marginBottom: space.xl,
     alignItems: "center"
   },
   appIconContainer: {
@@ -405,7 +406,7 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     alignItems: "center",
     justifyContent: "center",
-    marginBottom: 16,
+    marginBottom: space.lg,
     overflow: "hidden"
   },
   appIcon: {
@@ -413,85 +414,85 @@ const styles = StyleSheet.create({
     height: 80
   },
   title: {
-    fontSize: 28,
+    fontSize: fontSizes.screenTitle,
     ...fonts.bold,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   version: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   },
   linkRow: {
     flexDirection: "row",
     alignItems: "center",
     paddingVertical: 14,
-    gap: 12
+    gap: space.md
   },
   linkTextContainer: {
     flex: 1
   },
   linkTitle: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.semiBold
   },
   linkSubtitle: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     marginTop: 1
   },
   techRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 8
+    paddingVertical: space.sm
   },
   techLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.medium
   },
   techValue: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   section: {
-    marginTop: 24
+    marginTop: space.xl
   },
   debugHint: {
-    fontSize: 11,
-    marginTop: 8,
+    fontSize: fontSizes.small,
+    marginTop: space.sm,
     fontStyle: "italic"
   },
   debugBadge: {
-    marginTop: 12,
-    paddingHorizontal: 12,
+    marginTop: space.md,
+    paddingHorizontal: space.md,
     paddingVertical: 6,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     flexDirection: "row",
     alignItems: "center",
     gap: 6
   },
   debugText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold
   },
   debugActions: {
     gap: 10,
-    marginTop: 16
+    marginTop: space.lg
   },
   copyButton: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 8,
-    paddingVertical: 12,
-    borderRadius: 12,
+    gap: space.sm,
+    paddingVertical: space.md,
+    borderRadius: radius.md,
     borderWidth: 1
   },
   copyButtonText: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   logHint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     textAlign: "center",
     fontStyle: "italic",
     lineHeight: 16

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -17,7 +17,7 @@ import {
 import { useFocusEffect } from "@react-navigation/native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Share2, Search, X, ArrowDown } from "lucide-react-native"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Container, SectionTitle } from "../components"
 import { Tab } from "../components/ui/Tab"
 import { FileLoggingPanel } from "../components/features/log/FileLoggingPanel"
@@ -26,6 +26,8 @@ import { logger, LOG_LEVELS, type LogLevel } from "../utils/logger"
 import { getMergedLogs, exportLogs, MergedLogEntry } from "../utils/logExport"
 import NativeLocationService from "../services/NativeLocationService"
 import { ScreenProps } from "../types/global"
+import { space } from "../constants"
+import { radius } from "@colota/shared"
 
 type FilterLevel = LogLevel
 
@@ -310,38 +312,38 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
 const styles = StyleSheet.create({
   tabBar: {
     flexDirection: "row",
-    marginBottom: 12
+    marginBottom: space.md
   },
   list: {
-    padding: 16,
+    padding: space.lg,
     paddingBottom: 40
   },
   headerButtons: {
     flexDirection: "row",
-    gap: 8
+    gap: space.sm
   },
   headerButton: {
-    padding: 8
+    padding: space.sm
   },
   filterBar: {
-    paddingHorizontal: 16,
-    paddingTop: 8,
-    paddingBottom: 8,
-    gap: 8
+    paddingHorizontal: space.lg,
+    paddingTop: space.sm,
+    paddingBottom: space.sm,
+    gap: space.sm
   },
   searchContainer: {
     flexDirection: "row",
     alignItems: "center",
     borderWidth: 1,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     paddingHorizontal: 10,
     height: 40,
-    gap: 8
+    gap: space.sm
   },
   searchInput: {
     flex: 1,
     ...fonts.regular,
-    fontSize: 14,
+    fontSize: fontSizes.body,
     padding: 0
   },
   levelChips: {
@@ -349,22 +351,22 @@ const styles = StyleSheet.create({
     gap: 6
   },
   chip: {
-    paddingHorizontal: 12,
+    paddingHorizontal: space.md,
     paddingVertical: 5,
-    borderRadius: 12
+    borderRadius: radius.md
   },
   separator: {
     height: 1,
-    marginHorizontal: 16,
-    marginTop: 4
+    marginHorizontal: space.lg,
+    marginTop: space.xs
   },
   chipText: {
     ...fonts.semiBold,
-    fontSize: 11
+    fontSize: fontSizes.small
   },
   logText: {
     ...fonts.regular,
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     fontFamily: "monospace",
     lineHeight: 18
   },
@@ -378,12 +380,12 @@ const styles = StyleSheet.create({
     paddingTop: 40
   },
   emptyText: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.medium,
     marginBottom: 6
   },
   emptyHint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     textAlign: "center",
     lineHeight: 18
@@ -407,12 +409,12 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 24,
     right: 24,
-    paddingHorizontal: 12,
+    paddingHorizontal: space.md,
     paddingVertical: 6,
-    borderRadius: 16
+    borderRadius: radius.lg
   },
   followingText: {
     ...fonts.medium,
-    fontSize: 11
+    fontSize: fontSizes.small
   }
 })

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -20,7 +20,7 @@ import { useAutoSave } from "../hooks/useAutoSave"
 import { useTimeout } from "../hooks/useTimeout"
 import { useTracking } from "../contexts/TrackingProvider"
 import NativeLocationService from "../services/NativeLocationService"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { SectionTitle, FloatingSaveIndicator, Container, Divider, ChipGroup } from "../components"
 import { findDuplicates } from "../utils/settingsValidation"
 import {
@@ -29,6 +29,8 @@ import {
   isTraccarJsonFormat,
   isOverlandFormat
 } from "../utils/apiPayload"
+import { space } from "../constants"
+import { radius } from "@colota/shared"
 
 type LocalCustomField = CustomField & { id: number }
 
@@ -748,7 +750,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingBottom: 40
   },
   header: {
@@ -756,21 +758,21 @@ const styles = StyleSheet.create({
     marginBottom: 20
   },
   title: {
-    fontSize: 28,
+    fontSize: fontSizes.screenTitle,
     ...fonts.bold,
     letterSpacing: -0.5,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   subtitle: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     lineHeight: 20
   },
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   templateHint: {
-    fontSize: 12,
-    marginTop: 8
+    fontSize: fontSizes.caption,
+    marginTop: space.sm
   },
   fieldsSection: {
     marginBottom: 20
@@ -781,23 +783,23 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   resetAllButton: {
-    paddingVertical: 4,
-    paddingHorizontal: 8
+    paddingVertical: space.xs,
+    paddingHorizontal: space.sm
   },
   resetAllText: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.bold,
     letterSpacing: 0.5
   },
   fieldsCard: {
-    padding: 12,
+    padding: space.md,
     borderRadius: 10,
     borderWidth: 1
   },
   fieldRow: {
     flexDirection: "row",
     paddingVertical: 10,
-    gap: 12
+    gap: space.md
   },
   keyColumn: {
     flex: 1,
@@ -810,14 +812,14 @@ const styles = StyleSheet.create({
     marginBottom: 2
   },
   fieldLabel: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.bold,
     letterSpacing: 0.5
   },
   modifiedBadge: {
     paddingHorizontal: 6,
     paddingVertical: 2,
-    borderRadius: 4
+    borderRadius: radius.xs
   },
   modifiedText: {
     fontSize: 9,
@@ -825,7 +827,7 @@ const styles = StyleSheet.create({
     letterSpacing: 0.3
   },
   fieldDescription: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     lineHeight: 15
   },
   valueColumn: {
@@ -841,73 +843,73 @@ const styles = StyleSheet.create({
     flex: 1,
     borderWidth: 1.5,
     paddingHorizontal: 10,
-    paddingVertical: 8,
-    borderRadius: 8,
-    fontSize: 14,
+    paddingVertical: space.sm,
+    borderRadius: radius.sm,
+    fontSize: fontSizes.body,
     fontFamily: "monospace"
   },
   resetButton: {
     width: 32,
     height: 32,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     justifyContent: "center",
     alignItems: "center"
   },
   resetIcon: {
-    fontSize: 18,
+    fontSize: fontSizes.heading,
     ...fonts.semiBold
   },
   customFieldRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
-    paddingVertical: 8
+    gap: space.sm,
+    paddingVertical: space.sm
   },
   customFieldInput: {
     flex: 1,
     borderWidth: 1.5,
     paddingHorizontal: 10,
-    paddingVertical: 8,
-    borderRadius: 8,
-    fontSize: 14,
+    paddingVertical: space.sm,
+    borderRadius: radius.sm,
+    fontSize: fontSizes.body,
     fontFamily: "monospace"
   },
   removeButton: {
     width: 32,
     height: 32,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     justifyContent: "center",
     alignItems: "center"
   },
   removeButtonText: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.bold
   },
   addButton: {
-    paddingVertical: 12,
+    paddingVertical: space.md,
     alignItems: "center",
     borderRadius: 10,
     borderWidth: 1.5,
     borderStyle: "dashed",
-    marginTop: 8
+    marginTop: space.sm
   },
   addButtonText: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   emptyHint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     textAlign: "center",
-    paddingVertical: 8
+    paddingVertical: space.sm
   },
   warningBanner: {
-    padding: 12,
-    borderRadius: 8,
+    padding: space.md,
+    borderRadius: radius.sm,
     borderWidth: 1,
     marginBottom: 20
   },
   warningText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     lineHeight: 18
   },
   exampleSection: {
@@ -915,31 +917,31 @@ const styles = StyleSheet.create({
   },
   copyButton: {
     alignSelf: "flex-end",
-    paddingVertical: 4,
+    paddingVertical: space.xs,
     paddingHorizontal: 2,
-    marginTop: 8
+    marginTop: space.sm
   },
   copyButtonText: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.bold,
     letterSpacing: 0.5
   },
   exampleCard: {
     padding: 14,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     borderWidth: 1
   },
   exampleCode: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     fontFamily: "monospace",
     lineHeight: 18
   },
   footer: {
-    paddingVertical: 16,
+    paddingVertical: space.lg,
     alignItems: "center"
   },
   footerText: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     textAlign: "center"
   }
 })

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -9,12 +9,14 @@ import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
 import { useTranslation } from "../i18n/useTranslation"
 import NativeLocationService from "../services/NativeLocationService"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Card, Container, Divider, SettingRow } from "../components"
 import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
 import type { UnitSystem, TimeFormat } from "../utils/geo"
+import { space } from "../constants"
+import { radius } from "@colota/shared"
 
 export function AppearanceScreen({}: ScreenProps) {
   const { mode, toggleTheme, colors } = useTheme()
@@ -240,68 +242,68 @@ export function AppearanceScreen({}: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
-    paddingTop: 16,
-    paddingBottom: 16
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.lg
   },
   linkRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 12
+    paddingVertical: space.md
   },
   linkContent: {
     flex: 1
   },
   linkLabel: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     marginBottom: 2
   },
   linkSub: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   },
   chipGroup: {
     flexDirection: "row",
-    gap: 8
+    gap: space.sm
   },
   chip: {
     paddingHorizontal: 14,
-    paddingVertical: 8,
+    paddingVertical: space.sm,
     borderRadius: 10,
     borderWidth: 1.5
   },
   chipLabel: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold
   },
   mapTilePanel: {
-    marginTop: 4,
-    paddingBottom: 4
+    marginTop: space.xs,
+    paddingBottom: space.xs
   },
   mapStyleSub: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.medium,
     marginBottom: 6
   },
-  mapStyleSubFirst: { marginTop: 12 },
+  mapStyleSubFirst: { marginTop: space.md },
   mapStyleSubSecond: { marginTop: 10 },
   mapStyleInput: {
     borderWidth: 1.5,
-    padding: 12,
-    borderRadius: 12,
-    fontSize: 13,
+    padding: space.md,
+    borderRadius: radius.md,
+    fontSize: fontSizes.description,
     ...fonts.regular
   },
   mapStyleFooter: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginTop: 8
+    marginTop: space.sm
   },
   mapStyleHint: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -15,6 +15,8 @@ import { SectionTitle, FloatingSaveIndicator, Container, Card, Divider, ChipGrou
 import NativeLocationService from "../services/NativeLocationService"
 import { logger } from "../utils/logger"
 import { findDuplicates } from "../utils/settingsValidation"
+import { space } from "../constants"
+import { radius } from "@colota/shared"
 
 const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
   { value: "none", label: "None" },
@@ -371,8 +373,8 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
-    paddingTop: 16,
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
     paddingBottom: 40
   },
   loadingContainer: {
@@ -381,33 +383,33 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   loadingText: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.regular
   },
   header: {
     marginBottom: 20
   },
   title: {
-    fontSize: 28,
+    fontSize: fontSizes.screenTitle,
     ...fonts.bold,
     letterSpacing: -0.5,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   subtitle: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.regular,
     lineHeight: 20
   },
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   fieldGroup: {
-    marginTop: 4
+    marginTop: space.xs
   },
   fieldLabel: {
     fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginBottom: 8
+    marginBottom: space.sm
   },
   fieldLabelSpaced: {
     marginTop: 14
@@ -415,34 +417,34 @@ const styles = StyleSheet.create({
   input: {
     borderWidth: 1.5,
     padding: 14,
-    borderRadius: 12,
-    fontSize: 15
+    borderRadius: radius.md,
+    fontSize: fontSizes.input
   },
   tokenInput: {
     minHeight: 80,
     fontFamily: "monospace",
-    fontSize: 13
+    fontSize: fontSizes.description
   },
   emptyHint: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     textAlign: "center",
-    paddingVertical: 8
+    paddingVertical: space.sm
   },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
-    paddingVertical: 8
+    gap: space.sm,
+    paddingVertical: space.sm
   },
   headerInputs: {
     flex: 1,
-    gap: 8
+    gap: space.sm
   },
   headerInput: {
     borderWidth: 1.5,
-    padding: 12,
+    padding: space.md,
     borderRadius: 10,
-    fontSize: 14
+    fontSize: fontSizes.body
   },
   removeButton: {
     width: 36,
@@ -452,60 +454,60 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   removeButtonText: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.bold
   },
   addButton: {
     paddingVertical: 14,
     alignItems: "center",
-    borderRadius: 12,
+    borderRadius: radius.md,
     borderWidth: 1.5,
     borderStyle: "dashed",
-    marginTop: 4
+    marginTop: space.xs
   },
   addButtonText: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.semiBold
   },
   hint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     marginTop: 10,
     textAlign: "center"
   },
   warningBanner: {
-    padding: 12,
-    borderRadius: 8,
+    padding: space.md,
+    borderRadius: radius.sm,
     borderWidth: 1,
     marginBottom: 20
   },
   warningText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     lineHeight: 18
   },
   footer: {
-    paddingVertical: 16,
+    paddingVertical: space.lg,
     alignItems: "center"
   },
   footerText: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     textAlign: "center"
   },
   linkRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 12
+    paddingVertical: space.md
   },
   linkContent: {
     flex: 1
   },
   linkLabel: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     marginBottom: 2
   },
   linkSub: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   }
 })

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -34,11 +34,12 @@ import {
   isValidFilenameTemplate,
   renderFilenamePreview
 } from "../utils/exportConverters"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { formatExportDateTime, formatBytes } from "../utils/format"
 import { showAlert } from "../services/modalService"
-import { SAVE_SUCCESS_DISPLAY_MS } from "../constants"
+import { SAVE_SUCCESS_DISPLAY_MS, space } from "../constants"
+import { radius } from "@colota/shared"
 
 type ExportInterval = "daily" | "weekly" | "monthly"
 type ExportMode = "all" | "incremental"
@@ -665,7 +666,7 @@ export function AutoExportScreen(_props: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingBottom: 40
   },
   header: {
@@ -673,26 +674,26 @@ const styles = StyleSheet.create({
     marginBottom: 20
   },
   subtitle: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     lineHeight: 20
   },
   section: {
-    marginTop: 24
+    marginTop: space.xl
   },
   settingLabel: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold,
     marginBottom: 2
   },
   settingDescription: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular
   },
   directoryRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
-    paddingVertical: 4
+    gap: space.md,
+    paddingVertical: space.xs
   },
   directoryContent: {
     flex: 1
@@ -701,27 +702,27 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 4
+    paddingVertical: space.xs
   },
   statusLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.regular
   },
   statusValue: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold,
     flexShrink: 1,
     textAlign: "right",
-    marginLeft: 12
+    marginLeft: space.md
   },
   errorRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: space.sm,
     paddingVertical: 6
   },
   errorText: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     flex: 1
   },
@@ -733,64 +734,64 @@ const styles = StyleSheet.create({
   },
   modeContent: {
     flex: 1,
-    marginRight: 16
+    marginRight: space.lg
   },
   fileRow: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 8
+    paddingVertical: space.sm
   },
   fileInfo: {
     flex: 1,
-    marginRight: 12
+    marginRight: space.md
   },
   fileName: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold,
     marginBottom: 2
   },
   fileMeta: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular
   },
   shareButton: {
-    padding: 8
+    padding: space.sm
   },
   fieldLabel: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold,
     textTransform: "uppercase",
     letterSpacing: 0.5,
-    marginTop: 12,
-    marginBottom: 8
+    marginTop: space.md,
+    marginBottom: space.sm
   },
   templateInput: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.regular,
     borderWidth: 1,
-    borderRadius: 8,
-    paddingHorizontal: 12,
+    borderRadius: radius.sm,
+    paddingHorizontal: space.md,
     paddingVertical: 10
   },
   templateHint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
-    marginTop: 8
+    marginTop: space.sm
   },
   templateTokenRow: {
     flexDirection: "row",
     alignItems: "baseline",
-    gap: 8
+    gap: space.sm
   },
   templateToken: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold,
-    marginTop: 8,
+    marginTop: space.sm,
     minWidth: 72
   },
   templatePreview: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold,
-    marginTop: 8
+    marginTop: space.sm
   }
 })

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -16,9 +16,10 @@ import BackupService, {
 } from "../services/BackupService"
 import { showAlert, showConfirm, showChoice } from "../services/modalService"
 import { logger } from "../utils/logger"
-import { fonts } from "../styles/typography"
-import { fontSizes } from "@colota/shared"
+import { fontSizes, fonts } from "../styles/typography"
+import { radius } from "@colota/shared"
 import type { ThemeColors } from "../types/global"
+import { space } from "../constants"
 
 type Props = RootScreenProps<"Backup & Restore">
 
@@ -360,49 +361,49 @@ export function BackupRestoreScreen({}: Props) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingBottom: 40
   },
   section: {
-    marginTop: 24
+    marginTop: space.xl
   },
   intro: {
-    marginBottom: 12,
-    fontSize: 14,
+    marginBottom: space.md,
+    fontSize: fontSizes.body,
     lineHeight: 20
   },
   fieldLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     fontWeight: "500",
-    marginBottom: 8
+    marginBottom: space.sm
   },
   inputRow: {
     flexDirection: "row",
     alignItems: "center",
     borderWidth: 1,
-    borderRadius: 8,
-    marginBottom: 8
+    borderRadius: radius.sm,
+    marginBottom: space.sm
   },
   inputField: {
     flex: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    fontSize: 16
+    paddingHorizontal: space.md,
+    paddingVertical: space.md,
+    fontSize: fontSizes.label
   },
   eyeButton: {
-    paddingHorizontal: 12,
-    paddingVertical: 12
+    paddingHorizontal: space.md,
+    paddingVertical: space.md
   },
   strengthRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 12,
-    gap: 8
+    marginBottom: space.md,
+    gap: space.sm
   },
   strengthBar: {
     flex: 1,
     flexDirection: "row",
-    gap: 4
+    gap: space.xs
   },
   strengthSegment: {
     flex: 1,
@@ -410,46 +411,46 @@ const styles = StyleSheet.create({
     borderRadius: 2
   },
   strengthLabel: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     fontWeight: "600",
     minWidth: 60,
     textAlign: "right"
   },
   errorText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     marginTop: -4,
-    marginBottom: 8
+    marginBottom: space.sm
   },
   hint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     lineHeight: 18,
-    marginTop: 8,
-    marginBottom: 16
+    marginTop: space.sm,
+    marginBottom: space.lg
   },
   modalOverlay: {
     flex: 1,
     justifyContent: "center",
-    paddingHorizontal: 16
+    paddingHorizontal: space.lg
   },
   modalCard: {
-    padding: 16,
-    borderRadius: 12,
+    padding: space.lg,
+    borderRadius: radius.md,
     borderWidth: 1
   },
   modalTitle: {
     fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   modalSubtitle: {
     fontSize: fontSizes.description,
     ...fonts.regular,
-    marginBottom: 16
+    marginBottom: space.lg
   },
   modalButtonsRow: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 4
+    gap: space.md,
+    marginTop: space.xs
   },
   modalButton: {
     flex: 1

--- a/apps/mobile/src/screens/ConnectionScreen.tsx
+++ b/apps/mobile/src/screens/ConnectionScreen.tsx
@@ -12,6 +12,7 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { FloatingSaveIndicator } from "../components/ui/FloatingSaveIndicator"
 import { Container } from "../components"
 import { ConnectionSettings } from "../components/features/settings/ConnectionSettings"
+import { space } from "../constants"
 
 export function ConnectionScreen({ navigation }: ScreenProps) {
   const { settings, setSettings, restartTracking } = useTracking()
@@ -58,8 +59,8 @@ export function ConnectionScreen({ navigation }: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
-    paddingTop: 16,
-    paddingBottom: 16
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.lg
   }
 })

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -20,7 +20,7 @@ import {
   DatabaseStatistics,
   WelcomeCard
 } from "../components"
-import { STATS_REFRESH_IDLE, MIN_STATS_INTERVAL_MS } from "../constants"
+import { MIN_STATS_INTERVAL_MS, STATS_REFRESH_IDLE, space } from "../constants"
 import { Square, Play } from "lucide-react-native"
 import { logger } from "../utils/logger"
 
@@ -308,8 +308,8 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     paddingTop: 20,
-    paddingHorizontal: 16,
-    paddingBottom: 8
+    paddingHorizontal: space.lg,
+    paddingBottom: space.sm
   },
   metricsSection: {
     marginBottom: 20

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -24,10 +24,11 @@ import { fonts, fontSizes } from "../styles/typography"
 import NativeLocationService from "../services/NativeLocationService"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Button, SectionTitle, Card, Container, Divider, FloatingSaveIndicator } from "../components"
-import { STATS_REFRESH_FAST, SAVE_SUCCESS_DISPLAY_MS } from "../constants"
+import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, space } from "../constants"
 import { useTimeout } from "../hooks/useTimeout"
 import { showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
+import { radius } from "@colota/shared"
 
 const BACKUP_TIP = "Tip: back up your data first (Settings -> Backup & Restore)."
 
@@ -479,51 +480,51 @@ const styles = StyleSheet.create({
     flex: 1
   },
   scrollContent: {
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingBottom: 40
   },
   header: {
     marginTop: 20,
-    marginBottom: 24
+    marginBottom: space.xl
   },
   title: {
-    fontSize: 28,
+    fontSize: fontSizes.screenTitle,
     ...fonts.bold,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   statRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 8
+    paddingVertical: space.sm
   },
   statLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.medium
   },
   statValue: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.bold
   },
   hint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     textAlign: "center",
     fontStyle: "italic",
     lineHeight: 16,
-    marginTop: 8
+    marginTop: space.sm
   },
   actionRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 12
+    paddingVertical: space.md
   },
   actionColumn: {
-    paddingVertical: 12
+    paddingVertical: space.md
   },
   actionInfo: {
     flex: 1
@@ -531,36 +532,36 @@ const styles = StyleSheet.create({
   actionLabel: {
     fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   actionHint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     lineHeight: 16,
     marginTop: 2
   },
   actionBadge: {
-    paddingHorizontal: 12,
+    paddingHorizontal: space.md,
     paddingVertical: 6,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     borderWidth: 1
   },
   actionBadgeText: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.bold
   },
   daysInputRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginTop: 12,
-    gap: 8
+    marginTop: space.md,
+    gap: space.sm
   },
   daysInput: {
     flex: 1,
     borderWidth: 1,
     padding: 10,
-    borderRadius: 8,
-    fontSize: 15,
+    borderRadius: radius.sm,
+    fontSize: fontSizes.input,
     textAlign: "center"
   },
   hintRow: {
@@ -570,7 +571,7 @@ const styles = StyleSheet.create({
     marginTop: 2
   },
   daysLabel: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.medium
   },
   buttonDisabled: {

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { Text, StyleSheet, View, ScrollView } from "react-native"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { MapPinOff, Upload } from "lucide-react-native"
 import { Container, Card, SectionTitle, Button, FormatSelector, LoadingOverlay } from "../components"
 import { useTheme } from "../hooks/useTheme"
@@ -14,6 +14,8 @@ import { EXPORT_FORMATS, ExportFormat } from "../utils/exportConverters"
 import { logger } from "../utils/logger"
 import { showAlert } from "../services/modalService"
 import { ScreenProps } from "../types/global"
+import { space } from "../constants"
+import { radius } from "@colota/shared"
 
 export function ExportLocationsScreen({}: ScreenProps) {
   const { colors } = useTheme()
@@ -133,32 +135,32 @@ export function ExportLocationsScreen({}: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingTop: 20,
     paddingBottom: 40
   },
   emptyCard: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   emptyState: {
     alignItems: "center",
-    paddingVertical: 32
+    paddingVertical: space.xxl
   },
   emptyTitle: {
-    fontSize: 18,
+    fontSize: fontSizes.heading,
     ...fonts.semiBold,
-    marginTop: 12,
-    marginBottom: 4
+    marginTop: space.md,
+    marginBottom: space.xs
   },
   emptySubtitle: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     textAlign: "center",
     lineHeight: 18
   },
   statsContainer: {
-    borderRadius: 16,
+    borderRadius: radius.lg,
     borderWidth: 2,
-    marginBottom: 24,
+    marginBottom: space.xl,
     overflow: "hidden"
   },
   statsGrid: {
@@ -170,22 +172,22 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   statLabel: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold,
     textTransform: "uppercase",
     letterSpacing: 0.8,
-    marginBottom: 8
+    marginBottom: space.sm
   },
   statValue: {
-    fontSize: 20,
+    fontSize: fontSizes.cardTitle,
     ...fonts.bold,
     letterSpacing: -0.5,
     textAlign: "center"
   },
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   exportButtonWrapper: {
-    marginBottom: 16
+    marginBottom: space.lg
   }
 })

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -8,13 +8,15 @@ import { View, Text, StyleSheet, ScrollView, Switch, TextInput, DeviceEventEmitt
 import { useTheme } from "../hooks/useTheme"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert, showConfirm } from "../services/modalService"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Container, SectionTitle, Card, SettingRow, Button, FieldMessage } from "../components"
 import { Check, Trash2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
 import { parsePositiveInt, isPositiveInt } from "../utils/settingsValidation"
 import type { RootScreenProps } from "../types/navigation"
+import { space } from "../constants"
+import { radius } from "@colota/shared"
 
 declare function requestIdleCallback(callback: () => void): number
 declare function cancelIdleCallback(handle: number): void
@@ -363,25 +365,25 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
 
 const styles = StyleSheet.create({
   content: { padding: 20, paddingBottom: 40 },
-  card: { marginBottom: 16 },
+  card: { marginBottom: space.lg },
   input: {
     padding: 10,
     borderWidth: 1.5,
-    borderRadius: 8,
-    fontSize: 15
+    borderRadius: radius.sm,
+    fontSize: fontSizes.input
   },
   nameInput: { flex: 1 },
   numInput: { width: 80, textAlign: "center" },
   toggleRow: { paddingVertical: 10 },
   disabledRow: { opacity: 0.45 },
-  nestedSetting: { marginLeft: 16, paddingLeft: 12, borderLeftWidth: 3, marginTop: 4, marginBottom: 4 },
+  nestedSetting: { marginLeft: space.lg, paddingLeft: space.md, borderLeftWidth: 3, marginTop: space.xs, marginBottom: space.xs },
   combinedNote: {
-    marginTop: 8,
-    paddingTop: 12,
+    marginTop: space.sm,
+    paddingTop: space.md,
     borderTopWidth: StyleSheet.hairlineWidth
   },
   combinedNoteText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     lineHeight: 17,
     fontStyle: "italic"

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -10,17 +10,10 @@ import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { Geofence, ScreenProps } from "../types/global"
 import { useTracking, useCoords } from "../contexts/TrackingProvider"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { ChevronRight, Wifi, PersonStanding, MapPinHouse, Share2 } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
-import {
-  DEFAULT_MAP_ZOOM,
-  WORLD_MAP_ZOOM,
-  GEOFENCE_ZOOM_PADDING,
-  MAP_ANIMATION_DURATION_MS,
-  MAX_MAP_ZOOM,
-  HIT_SLOP_MD
-} from "../constants"
+import { DEFAULT_MAP_ZOOM, GEOFENCE_ZOOM_PADDING, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM, WORLD_MAP_ZOOM, space } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { buildGeofencesGeoJSON } from "../components/features/map/mapUtils"
@@ -29,6 +22,7 @@ import { UserLocationOverlay } from "../components/features/map/UserLocationOver
 import { logger } from "../utils/logger"
 import { formatShortDistance, shortDistanceUnit, inputToMeters } from "../utils/geo"
 import { buildGeofencesLink } from "../utils/setupLink"
+import { radius } from "@colota/shared"
 
 const GeofenceMap = React.memo(function GeofenceMap({
   tracking,
@@ -393,9 +387,9 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
 const styles = StyleSheet.create({
   map: { height: 450, overflow: "hidden" },
   list: { padding: 20, paddingBottom: 40 },
-  section: { marginBottom: 16 },
-  hint: { fontSize: 13, ...fonts.regular, lineHeight: 18, marginBottom: 16 },
-  inputRow: { flexDirection: "row", gap: 12, marginBottom: 16 },
+  section: { marginBottom: space.lg },
+  hint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18, marginBottom: space.lg },
+  inputRow: { flexDirection: "row", gap: space.md, marginBottom: space.lg },
   inputGroup: { flex: 1 },
   inputGroupName: {
     flex: 2
@@ -405,36 +399,36 @@ const styles = StyleSheet.create({
     minWidth: 90
   },
   label: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold,
     marginBottom: 6,
     textTransform: "uppercase",
     letterSpacing: 0.5
   },
-  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: 15 },
+  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input },
   inputCentered: {
     textAlign: "center"
   },
-  placeBtn: { padding: 16, borderRadius: 12, alignItems: "center" },
-  placeBtnText: { fontSize: 15, ...fonts.semiBold },
-  card: { marginBottom: 12 },
+  placeBtn: { padding: space.lg, borderRadius: radius.md, alignItems: "center" },
+  placeBtnText: { fontSize: fontSizes.input, ...fonts.semiBold },
+  card: { marginBottom: space.md },
   row: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between"
   },
-  zoomBtn: { padding: 4, marginRight: 16 },
+  zoomBtn: { padding: space.xs, marginRight: space.lg },
   activeHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  shareBtn: { padding: 4, marginBottom: 12 },
+  shareBtn: { padding: space.xs, marginBottom: space.md },
   editBtn: { flex: 1, flexDirection: "row", alignItems: "center" },
-  info: { flex: 1, marginRight: 12 },
-  name: { fontSize: 15, ...fonts.semiBold, marginBottom: 2 },
-  radiusRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-  radius: { fontSize: 12 },
+  info: { flex: 1, marginRight: space.md },
+  name: { fontSize: fontSizes.input, ...fonts.semiBold, marginBottom: 2 },
+  radiusRow: { flexDirection: "row", alignItems: "center", gap: space.xs },
+  radius: { fontSize: fontSizes.caption },
   empty: { alignItems: "center", paddingVertical: 20 },
-  emptyText: { fontSize: 15, ...fonts.semiBold, marginBottom: 6 },
+  emptyText: { fontSize: fontSizes.input, ...fonts.semiBold, marginBottom: 6 },
   emptyHint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     textAlign: "center",
     maxWidth: 260,
     lineHeight: 18

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useEffect, useState } from "react"
 import { ScrollView, StyleSheet, Text, View } from "react-native"
 import { Download } from "lucide-react-native"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Button, Card, Container, Divider, LoadingOverlay, SectionTitle } from "../components"
 import { useTheme } from "../hooks/useTheme"
 import NativeLocationService from "../services/NativeLocationService"
@@ -16,6 +16,8 @@ import { logger } from "../utils/logger"
 import { FILE_FORMATS, IMPORT_FORMAT_ORDER, importDescription } from "../utils/fileFormats"
 import { ScreenProps } from "../types/global"
 import type { ThemeColors } from "../types/global"
+import { space } from "../constants"
+import { radius } from "@colota/shared"
 
 const IMPORT_FORMAT_LABELS = Object.fromEntries(
   (Object.keys(FILE_FORMATS) as ImportFormat[]).map((k) => [k, FILE_FORMATS[k].label])
@@ -257,14 +259,14 @@ export function ImportLocationsScreen({}: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
+    paddingHorizontal: space.lg,
     paddingTop: 20,
     paddingBottom: 40
   },
   statsContainer: {
-    borderRadius: 16,
+    borderRadius: radius.lg,
     borderWidth: 2,
-    marginBottom: 24,
+    marginBottom: space.xl,
     overflow: "hidden"
   },
   statsGrid: {
@@ -276,31 +278,31 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   statLabel: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold,
     textTransform: "uppercase",
     letterSpacing: 0.8,
-    marginBottom: 8
+    marginBottom: space.sm
   },
   statValue: {
-    fontSize: 20,
+    fontSize: fontSizes.cardTitle,
     ...fonts.bold,
     letterSpacing: -0.5,
     textAlign: "center"
   },
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   },
   intro: {
-    marginBottom: 12,
-    fontSize: 14,
+    marginBottom: space.md,
+    fontSize: fontSizes.body,
     lineHeight: 20
   },
   formatRow: {
     flexDirection: "row",
     alignItems: "center",
     paddingVertical: 10,
-    gap: 16
+    gap: space.lg
   },
   formatTextContent: {
     flex: 1
@@ -308,28 +310,28 @@ const styles = StyleSheet.create({
   formatTitleRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
-    marginBottom: 4,
+    gap: space.sm,
+    marginBottom: space.xs,
     flexWrap: "wrap"
   },
   formatTitle: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.semiBold,
     letterSpacing: -0.2
   },
   extensionBadge: {
-    paddingHorizontal: 8,
+    paddingHorizontal: space.sm,
     paddingVertical: 3,
     borderRadius: 6,
     borderWidth: 1
   },
   extensionText: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.bold,
     letterSpacing: 0.3
   },
   formatDescription: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     lineHeight: 16
   }
 })

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react"
 import { View, Text, StyleSheet, Pressable } from "react-native"
 import { useFocusEffect } from "@react-navigation/native"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { BarChart2 } from "lucide-react-native"
 import { Container } from "../components"
 import { Tab } from "../components/ui/Tab"
@@ -31,6 +31,7 @@ import {
 import { EXPORT_FORMATS, type ExportFormat } from "../utils/exportConverters"
 import { showAlert, showConfirm } from "../services/modalService"
 import type { RootScreenProps } from "../types/navigation"
+import { space } from "../constants"
 
 type TabType = "map" | "trips" | "data"
 
@@ -491,7 +492,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
 
 const styles = StyleSheet.create({
   headerBtn: {
-    padding: 8
+    padding: space.sm
   },
   mapContainer: {
     flex: 1
@@ -500,8 +501,8 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 16,
     alignSelf: "center",
-    paddingHorizontal: 24,
-    paddingVertical: 12,
+    paddingHorizontal: space.xl,
+    paddingVertical: space.md,
     elevation: 4,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
@@ -509,11 +510,11 @@ const styles = StyleSheet.create({
     shadowRadius: 4
   },
   floatingPillText: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.semiBold
   },
   tabBar: {
     flexDirection: "row",
-    marginBottom: 12
+    marginBottom: space.md
   }
 })

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -23,8 +23,9 @@ import { useTheme } from "../hooks/useTheme"
 import { DailyStat } from "../types/global"
 import NativeLocationService from "../services/NativeLocationService"
 import { formatDistance, formatDuration, startOfDaySec } from "../utils/geo"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { logger } from "../utils/logger"
+import { space } from "../constants"
 
 type Period = "week" | "month" | "30days"
 
@@ -262,10 +263,10 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
 
 const styles = StyleSheet.create({
   header: {
-    paddingHorizontal: 16,
-    paddingTop: 12,
-    paddingBottom: 8,
-    marginBottom: 8
+    paddingHorizontal: space.lg,
+    paddingTop: space.md,
+    paddingBottom: space.sm,
+    marginBottom: space.sm
   },
   loadingContainer: {
     flex: 1,
@@ -273,63 +274,63 @@ const styles = StyleSheet.create({
     justifyContent: "center"
   },
   listContent: {
-    paddingHorizontal: 12,
+    paddingHorizontal: space.md,
     paddingBottom: 20
   },
   summaryGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 10,
-    marginBottom: 16
+    marginBottom: space.lg
   },
   summaryCard: {
     flexBasis: "45%",
     flexGrow: 1,
     flexShrink: 0,
     alignItems: "center",
-    padding: 12,
+    padding: space.md,
     gap: 2
   },
   summaryValue: {
-    fontSize: 18,
+    fontSize: fontSizes.heading,
     ...fonts.bold
   },
   summaryLabel: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.semiBold,
     textTransform: "uppercase"
   },
   dayCard: {
-    marginBottom: 8,
-    padding: 12
+    marginBottom: space.sm,
+    padding: space.md
   },
   dayHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 4
+    marginBottom: space.xs
   },
   dayHeaderRight: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4
+    gap: space.xs
   },
   dayLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.bold
   },
   dayDistance: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.bold
   },
   dayStats: {
     flexDirection: "row",
-    gap: 16
+    gap: space.lg
   },
   dayStat: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular
   },
   empty: { alignItems: "center", paddingVertical: 40 },
-  emptyText: { fontSize: 15, ...fonts.semiBold }
+  emptyText: { fontSize: fontSizes.input, ...fonts.semiBold }
 })

--- a/apps/mobile/src/screens/MtlsSettingsScreen.tsx
+++ b/apps/mobile/src/screens/MtlsSettingsScreen.tsx
@@ -7,9 +7,10 @@ import React from "react"
 import { Text, StyleSheet, View, ScrollView } from "react-native"
 import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Container } from "../components"
 import { MtlsSection } from "../components/features/settings/MtlsSection"
+import { space } from "../constants"
 
 export function MtlsSettingsScreen({}: ScreenProps) {
   const { colors } = useTheme()
@@ -36,21 +37,21 @@ export function MtlsSettingsScreen({}: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
-    paddingTop: 16,
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
     paddingBottom: 40
   },
   header: {
     marginBottom: 20
   },
   title: {
-    fontSize: 28,
+    fontSize: fontSizes.screenTitle,
     ...fonts.bold,
     letterSpacing: -0.5,
-    marginBottom: 4
+    marginBottom: space.xs
   },
   subtitle: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.regular,
     lineHeight: 20
   }

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -11,11 +11,11 @@ import { useTheme } from "../hooks/useTheme"
 import { showAlert, showConfirm } from "../services/modalService"
 import { ScreenProps } from "../types/global"
 import { useCoords } from "../contexts/TrackingProvider"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { X, CheckCircle, RefreshCw, AlertTriangle } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
-import { DEFAULT_MAP_ZOOM, WORLD_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT } from "../constants"
+import { DEFAULT_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT, WORLD_MAP_ZOOM, space } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { logger } from "../utils/logger"
@@ -37,6 +37,7 @@ import {
   saveOfflineAreaBounds,
   removeOfflineAreaBounds
 } from "../components/features/map/OfflinePackManager"
+import { radius } from "@colota/shared"
 
 type ItemAction = { area: string; action: "deleting" | "canceling" | "refreshing" }
 type ThemeColors = ReturnType<typeof useTheme>["colors"]
@@ -885,72 +886,72 @@ export function OfflineMapsScreen({}: ScreenProps) {
 const styles = StyleSheet.create({
   map: { height: 450, overflow: "hidden" },
   list: { padding: 20, paddingBottom: 40 },
-  section: { marginBottom: 16 },
-  hint: { fontSize: 13, ...fonts.regular, lineHeight: 18, marginBottom: 16 },
-  inputGroup: { marginBottom: 16 },
+  section: { marginBottom: space.lg },
+  hint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18, marginBottom: space.lg },
+  inputGroup: { marginBottom: space.lg },
   label: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold,
     marginBottom: 6,
     textTransform: "uppercase",
     letterSpacing: 0.5
   },
-  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: 15 },
-  sizeEstimate: { fontSize: 12, ...fonts.regular, marginBottom: 12 },
-  downloadBtn: { padding: 16, borderRadius: 12, alignItems: "center" },
-  downloadBtnText: { fontSize: 16, ...fonts.semiBold },
+  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input },
+  sizeEstimate: { fontSize: fontSizes.caption, ...fonts.regular, marginBottom: space.md },
+  downloadBtn: { padding: space.lg, borderRadius: radius.md, alignItems: "center" },
+  downloadBtnText: { fontSize: fontSizes.label, ...fonts.semiBold },
   progressContainer: { gap: 10 },
   progressHeader: { flexDirection: "row", alignItems: "center", gap: 10 },
-  progressLabel: { fontSize: 14, ...fonts.semiBold },
+  progressLabel: { fontSize: fontSizes.body, ...fonts.semiBold },
   progressTrack: { height: 6, borderRadius: 3, overflow: "hidden" },
   progressFill: { height: "100%", borderRadius: 3 },
-  progressSub: { fontSize: 12, ...fonts.regular },
+  progressSub: { fontSize: fontSizes.caption, ...fonts.regular },
   cancelBtn: {
-    padding: 12,
+    padding: space.md,
     borderRadius: 10,
     borderWidth: 1.5,
     alignItems: "center",
-    marginTop: 4
+    marginTop: space.xs
   },
-  cancelBtnText: { fontSize: 14, ...fonts.semiBold },
-  errorText: { fontSize: 13, ...fonts.regular, marginTop: 10 },
-  card: { marginBottom: 12 },
+  cancelBtnText: { fontSize: fontSizes.body, ...fonts.semiBold },
+  errorText: { fontSize: fontSizes.description, ...fonts.regular, marginTop: 10 },
+  card: { marginBottom: space.md },
   row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  info: { flex: 1, marginRight: 12 },
+  info: { flex: 1, marginRight: space.md },
   nameRow: { flexDirection: "row", alignItems: "center", gap: 6, marginBottom: 2 },
-  areaName: { fontSize: 15, ...fonts.semiBold },
-  areaSub: { fontSize: 12 },
-  areaSubDate: { fontSize: 11, ...fonts.regular, marginTop: 2, opacity: 0.7 },
-  savedAreasMeta: { fontSize: 12, ...fonts.regular, marginTop: 2, marginBottom: 12, paddingHorizontal: 4 },
+  areaName: { fontSize: fontSizes.input, ...fonts.semiBold },
+  areaSub: { fontSize: fontSizes.caption },
+  areaSubDate: { fontSize: fontSizes.small, ...fonts.regular, marginTop: 2, opacity: 0.7 },
+  savedAreasMeta: { fontSize: fontSizes.caption, ...fonts.regular, marginTop: 2, marginBottom: space.md, paddingHorizontal: space.xs },
   actionBtns: { flexDirection: "row", gap: 6, alignItems: "center" },
   actionBtn: {
     width: 32,
     height: 32,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     alignItems: "center",
     justifyContent: "center"
   },
   cancelAreaBtn: {
-    paddingHorizontal: 12,
+    paddingHorizontal: space.md,
     paddingVertical: 6,
-    borderRadius: 8,
+    borderRadius: radius.sm,
     borderWidth: 1
   },
-  cancelAreaLabel: { fontSize: 13, ...fonts.semiBold },
+  cancelAreaLabel: { fontSize: fontSizes.description, ...fonts.semiBold },
   empty: { alignItems: "center", paddingVertical: 40 },
-  emptyText: { fontSize: 15, ...fonts.semiBold, marginBottom: 6 },
-  emptyHint: { fontSize: 13, textAlign: "center", maxWidth: 260, lineHeight: 18 },
+  emptyText: { fontSize: fontSizes.input, ...fonts.semiBold, marginBottom: 6 },
+  emptyHint: { fontSize: fontSizes.description, textAlign: "center", maxWidth: 260, lineHeight: 18 },
   mapHint: {
     position: "absolute",
     top: 14,
     left: 14,
     right: 14,
-    padding: 12,
-    borderRadius: 12,
+    padding: space.md,
+    borderRadius: radius.md,
     elevation: 8,
     shadowOpacity: 0.2,
     zIndex: 5,
     alignItems: "center"
   },
-  mapHintText: { fontSize: 13, ...fonts.semiBold }
+  mapHintText: { fontSize: fontSizes.description, ...fonts.semiBold }
 })

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -10,20 +10,14 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { ProfileService } from "../services/ProfileService"
 import { showAlert } from "../services/modalService"
 import { TrackingProfile, ProfileConditionType } from "../types/global"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Container, SectionTitle, Card, Divider, SettingRow, NumericInput, FieldMessage } from "../components"
 import { Check } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
-import {
-  MS_TO_KMH,
-  PROFILE_CONDITIONS,
-  SYNC_INTERVAL_PRESETS,
-  SYNC_INTERVAL_LABELS,
-  STATIONARY_MAX_INTERVAL_SECONDS,
-  defaultProfileDelays
-} from "../constants"
+import { MS_TO_KMH, PROFILE_CONDITIONS, STATIONARY_MAX_INTERVAL_SECONDS, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, defaultProfileDelays, space } from "../constants"
 import type { RootScreenProps } from "../types/navigation"
+import { radius } from "@colota/shared"
 
 function formatSyncDefault(seconds: number): string {
   if (SYNC_INTERVAL_LABELS[seconds]) return SYNC_INTERVAL_LABELS[seconds]
@@ -493,29 +487,29 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 }
 
 const styles = StyleSheet.create({
-  scrollContent: { paddingHorizontal: 16, paddingTop: 16, paddingBottom: 40 },
+  scrollContent: { paddingHorizontal: space.lg, paddingTop: space.lg, paddingBottom: 40 },
   header: { marginBottom: 20 },
-  title: { fontSize: 28, ...fonts.bold, letterSpacing: -0.5 },
-  inputGroup: { marginBottom: 4 },
+  title: { fontSize: fontSizes.screenTitle, ...fonts.bold, letterSpacing: -0.5 },
+  inputGroup: { marginBottom: space.xs },
   label: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.semiBold,
     marginBottom: 6,
     textTransform: "uppercase",
     letterSpacing: 0.5
   },
-  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: 15, ...fonts.regular },
+  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input, ...fonts.regular },
   numInput: {
     borderWidth: 1,
     padding: 10,
     borderRadius: 10,
-    fontSize: 15,
+    fontSize: fontSizes.input,
     textAlign: "center",
     width: 64,
     ...fonts.regular
   },
   inputWithUnit: { flexDirection: "row", alignItems: "center", gap: 6 },
-  unit: { fontSize: 14, ...fonts.medium, minWidth: 28 },
+  unit: { fontSize: fontSizes.body, ...fonts.medium, minWidth: 28 },
   conditionGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
@@ -523,31 +517,31 @@ const styles = StyleSheet.create({
   },
   conditionOption: {
     width: "47%",
-    padding: 12,
+    padding: space.md,
     borderRadius: 10,
     borderWidth: 1.5,
     alignItems: "center",
-    gap: 4
+    gap: space.xs
   },
-  conditionLabel: { fontSize: 13, ...fonts.semiBold },
-  conditionDesc: { fontSize: 11, ...fonts.regular, textAlign: "center" },
-  syncLabelRow: { marginBottom: 8 },
-  settingLabel: { fontSize: 16, ...fonts.semiBold, marginBottom: 2 },
-  settingHint: { fontSize: 13, ...fonts.regular, lineHeight: 18 },
-  syncGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
-  syncOption: { width: "31%", padding: 12, borderRadius: 10, borderWidth: 1.5, alignItems: "center" }, // ~3 per row with gap
-  syncOptionLabel: { fontSize: 13, ...fonts.semiBold },
-  customSyncInput: { marginTop: 12 },
+  conditionLabel: { fontSize: fontSizes.description, ...fonts.semiBold },
+  conditionDesc: { fontSize: fontSizes.small, ...fonts.regular, textAlign: "center" },
+  syncLabelRow: { marginBottom: space.sm },
+  settingLabel: { fontSize: fontSizes.label, ...fonts.semiBold, marginBottom: 2 },
+  settingHint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18 },
+  syncGrid: { flexDirection: "row", flexWrap: "wrap", gap: space.sm },
+  syncOption: { width: "31%", padding: space.md, borderRadius: 10, borderWidth: 1.5, alignItems: "center" }, // ~3 per row with gap
+  syncOptionLabel: { fontSize: fontSizes.description, ...fonts.semiBold },
+  customSyncInput: { marginTop: space.md },
   saveBtn: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 8,
-    padding: 16,
-    borderRadius: 12,
-    marginTop: 16
+    gap: space.sm,
+    padding: space.lg,
+    borderRadius: radius.md,
+    marginTop: space.lg
   },
-  saveBtnText: { fontSize: 16, ...fonts.semiBold },
+  saveBtnText: { fontSize: fontSizes.label, ...fonts.semiBold },
   saveBtnDisabled: { opacity: 0.6 },
-  sectionGap: { marginTop: 24 }
+  sectionGap: { marginTop: space.xl }
 })

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -30,6 +30,7 @@ import {
   Share2
 } from "lucide-react-native"
 import { logger } from "../utils/logger"
+import { space } from "../constants"
 
 type Props = RootScreenProps<"Settings">
 
@@ -264,11 +265,11 @@ export function SettingsScreen({ navigation }: Props) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
-    paddingTop: 16,
-    paddingBottom: 16
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.lg
   },
   section: {
-    marginBottom: 24
+    marginBottom: space.xl
   }
 })

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -8,7 +8,7 @@ import { View, Text, ScrollView, StyleSheet, Switch } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Container, Card, Button, SectionTitle } from "../components"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { CircleAlert, CircleCheck, Import } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
@@ -16,6 +16,7 @@ import { logger } from "../utils/logger"
 import { type Settings } from "../types/global"
 import { validateConfig, detectPreset, type ConfigEntry, type ValidationResult } from "../utils/setupConfig"
 import { decodeConfig } from "../utils/setupLink"
+import { space } from "../constants"
 
 export function SetupImportScreen({ route, navigation }: any) {
   const { colors } = useTheme()
@@ -239,31 +240,31 @@ export function SetupImportScreen({ route, navigation }: any) {
 
 const styles = StyleSheet.create({
   content: {
-    padding: 16,
+    padding: space.lg,
     paddingBottom: 40
   },
   headerCard: {
-    marginBottom: 16
+    marginBottom: space.lg
   },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12
+    gap: space.md
   },
   headerText: {
     flex: 1
   },
   title: {
-    fontSize: 18,
+    fontSize: fontSizes.heading,
     ...fonts.bold
   },
   subtitle: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     marginTop: 2
   },
   section: {
-    marginTop: 8
+    marginTop: space.sm
   },
   settingRow: {
     flexDirection: "row",
@@ -275,34 +276,34 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth
   },
   settingLabel: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold
   },
   toggleRow: {
     flexDirection: "row",
     alignItems: "center",
     paddingVertical: 6,
-    gap: 12
+    gap: space.md
   },
   toggleText: {
     flex: 1
   },
   toggleLabel: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.semiBold
   },
   toggleHint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     marginTop: 2
   },
   settingValue: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     maxWidth: "60%",
     textAlign: "right"
   },
   actions: {
-    marginTop: 24
+    marginTop: space.xl
   }
 })

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -8,13 +8,14 @@ import { View, Text, ScrollView, StyleSheet, Switch, Share } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Container, Card, Button, SectionTitle } from "../components"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Share2, TriangleAlert } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
 import { buildSetupConfig, buildSetupLink, type SetupShareParts, type SetupShareSelection } from "../utils/setupLink"
 import { DEFAULT_AUTH_CONFIG, type AuthConfig, type Geofence, type TrackingProfile } from "../types/global"
+import { space } from "../constants"
 
 type ShareCategory = keyof SetupShareSelection
 
@@ -193,38 +194,38 @@ export function ShareSetupScreen() {
 
 const styles = StyleSheet.create({
   content: {
-    padding: 16,
+    padding: space.lg,
     paddingBottom: 40
   },
   headerCard: {
-    marginBottom: 16
+    marginBottom: space.lg
   },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12
+    gap: space.md
   },
   headerText: {
     flex: 1
   },
   title: {
-    fontSize: 18,
+    fontSize: fontSizes.heading,
     ...fonts.bold
   },
   subtitle: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     marginTop: 2
   },
   section: {
-    marginTop: 8
+    marginTop: space.sm
   },
   row: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: 12,
-    gap: 12
+    paddingVertical: space.md,
+    gap: space.md
   },
   rowBorder: {
     borderBottomWidth: StyleSheet.hairlineWidth
@@ -233,11 +234,11 @@ const styles = StyleSheet.create({
     flex: 1
   },
   rowLabel: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   rowSub: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     marginTop: 2
   },
@@ -246,17 +247,17 @@ const styles = StyleSheet.create({
   },
   warningText: {
     flex: 1,
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     lineHeight: 17
   },
   actions: {
-    marginTop: 24
+    marginTop: space.xl
   },
   emptyHint: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.regular,
     textAlign: "center",
-    marginTop: 8
+    marginTop: space.sm
   }
 })

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -10,12 +10,13 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { ProfileService } from "../services/ProfileService"
 import { showAlert, showConfirm } from "../services/modalService"
 import { SavedTrackingProfile, ScreenProps } from "../types/global"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Container, SectionTitle, Card } from "../components"
 import { Plus, X, Zap, Share2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { buildProfilesLink } from "../utils/setupLink"
-import { PROFILE_CONDITIONS, MS_TO_KMH, HIT_SLOP_MD } from "../constants"
+import { HIT_SLOP_MD, MS_TO_KMH, PROFILE_CONDITIONS, space } from "../constants"
+import { radius } from "@colota/shared"
 
 function formatCondition(profile: SavedTrackingProfile): string {
   const condition = PROFILE_CONDITIONS.find((c) => c.type === profile.condition.type)
@@ -226,21 +227,21 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
 }
 
 const styles = StyleSheet.create({
-  list: { padding: 16, paddingBottom: 40 },
+  list: { padding: space.lg, paddingBottom: 40 },
   header: { marginBottom: 20 },
-  title: { fontSize: 28, ...fonts.bold, letterSpacing: -0.5, marginBottom: 6 },
-  subtitle: { fontSize: 14, ...fonts.regular, lineHeight: 20 },
+  title: { fontSize: fontSizes.screenTitle, ...fonts.bold, letterSpacing: -0.5, marginBottom: 6 },
+  subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: 20 },
   createBtn: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 8,
-    padding: 16,
-    borderRadius: 12,
-    marginBottom: 24
+    gap: space.sm,
+    padding: space.lg,
+    borderRadius: radius.md,
+    marginBottom: space.xl
   },
-  createBtnText: { fontSize: 15, ...fonts.semiBold },
-  card: { marginBottom: 12 },
+  createBtnText: { fontSize: fontSizes.input, ...fonts.semiBold },
+  card: { marginBottom: space.md },
   activeCard: { borderWidth: 2 },
   row: { flexDirection: "row", alignItems: "center" },
   iconWrap: {
@@ -249,31 +250,31 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     alignItems: "center",
     justifyContent: "center",
-    marginRight: 12
+    marginRight: space.md
   },
-  info: { flex: 1, marginRight: 12 },
-  nameRow: { flexDirection: "row", alignItems: "center", gap: 8, marginBottom: 2 },
-  name: { fontSize: 15, ...fonts.semiBold },
-  activeBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
-  activeBadgeText: { fontSize: 10, ...fonts.semiBold, textTransform: "uppercase" },
-  priorityBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
-  priorityText: { fontSize: 10, ...fonts.semiBold },
-  condition: { fontSize: 13, ...fonts.medium, marginBottom: 2 },
-  settings: { fontSize: 11, ...fonts.regular },
-  actions: { alignItems: "center", gap: 8 },
+  info: { flex: 1, marginRight: space.md },
+  nameRow: { flexDirection: "row", alignItems: "center", gap: space.sm, marginBottom: 2 },
+  name: { fontSize: fontSizes.input, ...fonts.semiBold },
+  activeBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },
+  activeBadgeText: { fontSize: fontSizes.micro, ...fonts.semiBold, textTransform: "uppercase" },
+  priorityBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },
+  priorityText: { fontSize: fontSizes.micro, ...fonts.semiBold },
+  condition: { fontSize: fontSizes.description, ...fonts.medium, marginBottom: 2 },
+  settings: { fontSize: fontSizes.small, ...fonts.regular },
+  actions: { alignItems: "center", gap: space.sm },
   deleteBtn: {
     width: 32,
     height: 32,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     alignItems: "center",
     justifyContent: "center"
   },
   activeHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  shareBtn: { padding: 4, marginBottom: 12 },
+  shareBtn: { padding: space.xs, marginBottom: space.md },
   empty: { alignItems: "center", paddingVertical: 40 },
-  emptyText: { fontSize: 15, ...fonts.semiBold, marginBottom: 6 },
+  emptyText: { fontSize: fontSizes.input, ...fonts.semiBold, marginBottom: 6 },
   emptyHint: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     textAlign: "center",
     maxWidth: 280,
     lineHeight: 18

--- a/apps/mobile/src/screens/TrackingSyncScreen.tsx
+++ b/apps/mobile/src/screens/TrackingSyncScreen.tsx
@@ -12,6 +12,7 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { FloatingSaveIndicator } from "../components/ui/FloatingSaveIndicator"
 import { Container } from "../components"
 import { SyncStrategySettings } from "../components/features/settings/SyncStrategySettings"
+import { space } from "../constants"
 
 export function TrackingSyncScreen({}: ScreenProps) {
   const { settings, setSettings, updateSettingsLocal, restartTracking } = useTracking()
@@ -61,8 +62,8 @@ export function TrackingSyncScreen({}: ScreenProps) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingHorizontal: 16,
-    paddingTop: 16,
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
     paddingBottom: 40
   }
 })

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -19,7 +19,7 @@ import {
   type LucideIcon
 } from "lucide-react-native"
 import { useTheme } from "../hooks/useTheme"
-import { fonts } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { Card } from "../components/ui/Card"
 import { Container } from "../components/ui/Container"
 import { TrackMap } from "../components/features/inspector/TrackMap"
@@ -27,13 +27,14 @@ import { InteractiveLineChart } from "../components/features/inspector/Interacti
 import { getTripColor, computeTripStats, buildBoundaryOverrideMap, splitBlockedReason } from "../utils/trips"
 import { formatDate, formatDistance, formatDuration, formatSpeed, formatTime } from "../utils/geo"
 import { EXPORT_FORMATS, EXPORT_FORMAT_KEYS, type ExportFormat } from "../utils/exportConverters"
-import { HIT_SLOP_LG } from "../constants"
+import { HIT_SLOP_LG, space } from "../constants"
 import { showAlert, showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
 import NativeLocationService from "../services/NativeLocationService"
 import { BOUNDARY_ACTION_SPLIT } from "../types/global"
 import type { Trip, ThemeColors, BoundaryAction } from "../types/global"
 import type { RootScreenProps } from "../types/navigation"
+import { radius } from "@colota/shared"
 
 const MAX_BARS = 120
 
@@ -434,11 +435,11 @@ function StatCard({
 
 const styles = StyleSheet.create({
   content: {
-    paddingBottom: 32
+    paddingBottom: space.xxl
   },
   section: {
-    paddingHorizontal: 16,
-    marginTop: 12
+    paddingHorizontal: space.lg,
+    marginTop: space.md
   },
   mapContainer: {
     height: 480
@@ -451,7 +452,7 @@ const styles = StyleSheet.create({
   headerTitleCenter: {
     flex: 1,
     alignItems: "center",
-    gap: 4
+    gap: space.xs
   },
   headerTitleLine: {
     flexDirection: "row",
@@ -459,7 +460,7 @@ const styles = StyleSheet.create({
     gap: 10
   },
   navBtn: {
-    padding: 4
+    padding: space.xs
   },
   dot: {
     width: 12,
@@ -467,91 +468,91 @@ const styles = StyleSheet.create({
     borderRadius: 6
   },
   title: {
-    fontSize: 20,
+    fontSize: fontSizes.cardTitle,
     ...fonts.bold
   },
   subtitle: {
-    fontSize: 13,
+    fontSize: fontSizes.description,
     ...fonts.regular,
     textAlign: "center"
   },
   statsGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 8
+    gap: space.sm
   },
   statCard: {
     alignItems: "center",
-    gap: 4,
-    paddingVertical: 12,
-    paddingHorizontal: 8,
+    gap: space.xs,
+    paddingVertical: space.md,
+    paddingHorizontal: space.sm,
     minWidth: "30%",
     flex: 1
   },
   statValue: {
-    fontSize: 16,
+    fontSize: fontSizes.label,
     ...fonts.bold
   },
   statLabel: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.regular,
     textTransform: "uppercase"
   },
   chartCard: {
-    padding: 12
+    padding: space.md
   },
   chartTitleRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 8
+    marginBottom: space.sm
   },
   chartTitle: {
-    fontSize: 14,
+    fontSize: fontSizes.body,
     ...fonts.semiBold
   },
   chartRange: {
-    fontSize: 11,
+    fontSize: fontSizes.small,
     ...fonts.regular
   },
   chartLabels: {
     flexDirection: "row",
     justifyContent: "space-between",
-    marginTop: 4,
+    marginTop: space.xs,
     paddingLeft: 40
   },
   chartLabel: {
-    fontSize: 10,
+    fontSize: fontSizes.micro,
     ...fonts.regular
   },
   exportBtn: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 8,
+    gap: space.sm,
     paddingVertical: 14
   },
   exportBtnText: {
-    fontSize: 15,
+    fontSize: fontSizes.input,
     ...fonts.semiBold
   },
   exportRow: {
     flexDirection: "row",
     justifyContent: "center",
-    gap: 8,
-    marginTop: 12
+    gap: space.sm,
+    marginTop: space.md
   },
   exportChip: {
     paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 8,
+    paddingVertical: space.sm,
+    borderRadius: radius.sm,
     borderWidth: 1
   },
   exportChipText: {
-    fontSize: 12,
+    fontSize: fontSizes.caption,
     ...fonts.bold
   },
   headerBtn: {
-    padding: 8
+    padding: space.sm
   }
 })

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -174,7 +174,10 @@ jest.mock("../../components/features/inspector/LocationTable", () => {
 })
 
 jest.mock("../../styles/typography", () => ({
-  fonts: { regular: {}, bold: {}, semiBold: {} }
+  fonts: { regular: {}, bold: {}, semiBold: {} },
+  // The real scale, not stubs: these tests render styles that read a named size, and a
+  // stubbed object would let a renamed key through.
+  fontSizes: jest.requireActual("@colota/shared").fontSizes
 }))
 
 jest.mock("../../utils/logger", () => ({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,5 @@
 export { lightColors, darkColors } from "./colors"
 export type { ThemeColors, ThemeMode } from "./colors"
 export { fontFamily, fontSizes } from "./typography"
+export { radius } from "./radius"
+export type { RadiusName } from "./radius"

--- a/packages/shared/src/radius.ts
+++ b/packages/shared/src/radius.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ *
+ * Single source of truth for Colota corner radii.
+ * Used by: apps/mobile, apps/docs
+ */
+
+export const radius = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  pill: 999
+} as const
+
+export type RadiusName = keyof typeof radius


### PR DESCRIPTION
Adds the space and size scales beside the existing constants, and a radius scale in the shared package, then points every literal that already sits on a scale at its token: 412 spacing values, 62 radii and 265 font sizes across 63 files.

Nothing moves on screen. Each token resolves to exactly the number it replaced, verified by diffing every removed literal against every added token. The 213 spacing values and 40 radii that are off-scale stay literal rather than being rounded onto it, because rounding is a design change.

The radius scale carries md at 12 because that is the app's most common corner by some margin; a scale without it would have covered thirty sites instead of sixty-two.

Four tests mocked styles/typography with fonts alone, so a style reading a named size resolved to undefined the moment the sweep touched their component. Their mocks now take the real scale from the shared package, so a renamed key fails the test rather than silently rendering nothing.
