### PR TITLE
chore(icons): lucide provider, size ladder, alias normalisation

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -4,6 +4,7 @@
  */
 import React, { useMemo, useState, useCallback } from "react"
 import { NavigationContainer, NavigationContainerRef } from "@react-navigation/native"
+import { LucideProvider } from "lucide-react-native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { View, StatusBar, Platform, StyleSheet } from "react-native"
@@ -246,25 +247,28 @@ function AppNavigator() {
 
   return (
     <SafeAreaProvider>
-      <StatusBar {...statusBarConfig} />
-      <NavigationContainer linking={linking} ref={navigationRef} onStateChange={handleStateChange}>
-        <View style={styles.flex}>
-          <Stack.Navigator initialRouteName="Dashboard" screenOptions={screenOptions}>
-            {SCREEN_CONFIG.map((screen) => (
-              <Stack.Screen
-                key={screen.name}
-                name={screen.name}
-                component={screen.component}
-                options={{
-                  headerTitle: screen.title,
-                  ...(TAB_SCREEN_NAMES.has(screen.name) && { headerBackVisible: false })
-                }}
-              />
-            ))}
-          </Stack.Navigator>
-          <BottomTabBar currentRoute={currentRoute} onNavigate={handleTabNavigate} />
-        </View>
-      </NavigationContainer>
+      {/* One provider so a 16 badge and a 24 tab glyph carry the same painted weight. */}
+      <LucideProvider strokeWidth={1.5} absoluteStrokeWidth>
+        <StatusBar {...statusBarConfig} />
+        <NavigationContainer linking={linking} ref={navigationRef} onStateChange={handleStateChange}>
+          <View style={styles.flex}>
+            <Stack.Navigator initialRouteName="Dashboard" screenOptions={screenOptions}>
+              {SCREEN_CONFIG.map((screen) => (
+                <Stack.Screen
+                  key={screen.name}
+                  name={screen.name}
+                  component={screen.component}
+                  options={{
+                    headerTitle: screen.title,
+                    ...(TAB_SCREEN_NAMES.has(screen.name) && { headerBackVisible: false })
+                  }}
+                />
+              ))}
+            </Stack.Navigator>
+            <BottomTabBar currentRoute={currentRoute} onNavigate={handleTabNavigate} />
+          </View>
+        </NavigationContainer>
+      </LucideProvider>
     </SafeAreaProvider>
   )
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,7 +25,7 @@
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "i18next": "^26.4.2",
-    "lucide-react-native": "^1.17.0",
+    "lucide-react-native": "^1.31.0",
     "react": "19.2.8",
     "react-native": "0.87.0",
     "react-native-safe-area-context": "^5.8.0",

--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -12,7 +12,7 @@ import { useTracking } from "../../../contexts/TrackingProvider"
 import { ServerStatus, ConnectionStatusProps } from "../../../types/global"
 import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
-import { space } from "../../../constants"
+import { size, space } from "../../../constants"
 import { radius } from "@colota/shared"
 
 export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps) {
@@ -98,7 +98,7 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
         {isOffline ? "Offline Mode" : displayUrl || "Server"}
       </Text>
       {!isOffline && <Text style={[styles.status, { color: config.color }]}>{config.label}</Text>}
-      <ChevronRight size={16} color={colors.textLight} />
+      <ChevronRight size={size.icon.sm} color={colors.textLight} />
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -5,7 +5,7 @@
 
 import React, { useRef, useEffect, useMemo, useCallback, useState } from "react"
 import { View, StyleSheet, Text, ActivityIndicator, DeviceEventEmitter, Image, Pressable } from "react-native"
-import { AlertTriangle } from "lucide-react-native"
+import { TriangleAlert } from "lucide-react-native"
 import { LocationCoords } from "../../../types/global"
 import { useTheme } from "../../../hooks/useTheme"
 import { useCoords } from "../../../contexts/TrackingProvider"
@@ -184,7 +184,7 @@ export function DashboardMap({
           ]}
         >
           <View style={[styles.iconCircle, { backgroundColor: colors.warning + "20" }]}>
-            <AlertTriangle size={32} color={colors.warning} />
+            <TriangleAlert size={32} color={colors.warning} />
           </View>
           <Text style={[styles.stateTitle, { color: colors.warning }]}>Location Services Off</Text>
           <Text style={[styles.stateSubtext, { color: colors.textSecondary }]}>

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -10,7 +10,7 @@ import { Settings, ThemeColors } from "../../../types/global"
 import { useTracking } from "../../../contexts/TrackingProvider"
 import { fontSizes, fonts } from "../../../styles/typography"
 import { Card } from "../../ui/Card"
-import { space } from "../../../constants"
+import { size, space } from "../../../constants"
 import { radius } from "@colota/shared"
 
 interface WelcomeCardProps {
@@ -44,7 +44,7 @@ function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps
           }
         ]}
       >
-        {completed && <Check size={13} color={colors.success} />}
+        {completed && <Check size={size.icon.sm} color={colors.success} />}
       </View>
       <Text
         style={[
@@ -55,7 +55,7 @@ function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps
       >
         {label}
       </Text>
-      {onPress && !completed && <ChevronRight size={18} color={colors.textLight} />}
+      {onPress && !completed && <ChevronRight size={size.icon.md} color={colors.textLight} />}
     </View>
   )
 

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -10,7 +10,7 @@ import { ThemeColors } from "../../../types/global"
 import { fontSizes, fonts } from "../../../styles/typography"
 import { formatDistance } from "../../../utils/geo"
 import { pad2 } from "../../../utils/format"
-import { HIT_SLOP_LG, space } from "../../../constants"
+import { HIT_SLOP_LG, size, space } from "../../../constants"
 import { radius } from "@colota/shared"
 
 interface CalendarPickerProps {
@@ -167,7 +167,7 @@ export function CalendarPicker({
           hitSlop={HIT_SLOP_LG}
           style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
         >
-          <ChevronLeft size={22} color={colors.primary} />
+          <ChevronLeft size={size.icon.md} color={colors.primary} />
         </Pressable>
 
         <Pressable
@@ -181,7 +181,7 @@ export function CalendarPicker({
                 <Text style={[styles.todayBadgeText, { color: colors.primary }]}>Today</Text>
               </View>
             )}
-            <Calendar size={14} color={colors.textSecondary} style={styles.calendarIcon} />
+            <Calendar size={size.icon.sm} color={colors.textSecondary} style={styles.calendarIcon} />
           </View>
           <Text style={[styles.countText, { color: colors.textSecondary }]}>
             {locationCount} {locationCount === 1 ? "location" : "locations"}
@@ -195,7 +195,7 @@ export function CalendarPicker({
           style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
           disabled={isToday}
         >
-          <ChevronRight size={22} color={isToday ? colors.textDisabled : colors.primary} />
+          <ChevronRight size={size.icon.md} color={isToday ? colors.textDisabled : colors.primary} />
         </Pressable>
       </View>
 
@@ -223,7 +223,7 @@ export function CalendarPicker({
               hitSlop={HIT_SLOP_LG}
               style={({ pressed }) => [styles.monthNav, pressed && { opacity: colors.pressedOpacity }]}
             >
-              <ChevronLeft size={18} color={colors.primary} />
+              <ChevronLeft size={size.icon.md} color={colors.primary} />
             </Pressable>
             <Text style={[styles.monthLabel, { color: colors.text }]}>{monthLabel}</Text>
             <Pressable
@@ -232,7 +232,7 @@ export function CalendarPicker({
               style={({ pressed }) => [styles.monthNav, pressed && { opacity: colors.pressedOpacity }]}
               disabled={isFutureMonth}
             >
-              <ChevronRight size={18} color={isFutureMonth ? colors.textDisabled : colors.primary} />
+              <ChevronRight size={size.icon.md} color={isFutureMonth ? colors.textDisabled : colors.primary} />
             </Pressable>
           </View>
 

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -21,7 +21,7 @@ import {
   type TrackLocation
 } from "../map/mapUtils"
 import { getSpeedUnit } from "../../../utils/geo"
-import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, space } from "../../../constants"
+import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, size, space } from "../../../constants"
 import { radius } from "@colota/shared"
 
 const HAS_NOTE = ["!=", ["get", "note"], ""]
@@ -321,7 +321,7 @@ export function TrackMap({
                   accessibilityRole="button"
                   accessibilityLabel="Start a new trip at this point"
                 >
-                  <Split size={16} color={colors.text} />
+                  <Split size={size.icon.sm} color={colors.text} />
                 </Pressable>
               )}
               {onPointDelete && popup.id >= 0 && (
@@ -333,7 +333,7 @@ export function TrackMap({
                   accessibilityRole="button"
                   accessibilityLabel="Delete this point"
                 >
-                  <Trash2 size={16} color={colors.error} />
+                  <Trash2 size={size.icon.sm} color={colors.error} />
                 </Pressable>
               )}
               <Pressable
@@ -344,7 +344,7 @@ export function TrackMap({
                 hitSlop={HIT_SLOP_MD}
                 style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
               >
-                <X size={16} color={colors.textSecondary} />
+                <X size={size.icon.sm} color={colors.textSecondary} />
               </Pressable>
             </View>
           </View>
@@ -386,7 +386,7 @@ export function TrackMap({
                       hitSlop={HIT_SLOP_MD}
                       style={({ pressed }) => [styles.noteSaveBtn, pressed && { opacity: colors.pressedOpacity }]}
                     >
-                      <Check size={18} color={colors.primary} />
+                      <Check size={size.icon.md} color={colors.primary} />
                     </Pressable>
                   )}
                 </View>

--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -12,7 +12,7 @@ import { formatDistance, formatDuration, formatSpeed, formatTime } from "../../.
 import type { Trip, ThemeColors } from "../../../types/global"
 import { getTripColor, computeTripStats, type TripStats } from "../../../utils/trips"
 import { EXPORT_FORMATS, EXPORT_FORMAT_KEYS, type ExportFormat } from "../../../utils/exportConverters"
-import { HIT_SLOP_SM, space } from "../../../constants"
+import { HIT_SLOP_SM, size, space } from "../../../constants"
 import { radius } from "@colota/shared"
 
 interface TripListProps {
@@ -84,28 +84,28 @@ const TripRow = React.memo(function TripRow({
 
       <View style={styles.tripStats}>
         <View style={styles.stat}>
-          <Route size={13} color={colors.textSecondary} />
+          <Route size={size.icon.sm} color={colors.textSecondary} />
           <Text style={[styles.statText, { color: colors.text }]}>{formatDistance(trip.distance)}</Text>
         </View>
         <View style={styles.stat}>
-          <Clock size={13} color={colors.textSecondary} />
+          <Clock size={size.icon.sm} color={colors.textSecondary} />
           <Text style={[styles.statText, { color: colors.text }]}>{formatDuration(duration)}</Text>
         </View>
         {stats && stats.avgSpeed > 0 && (
           <View style={styles.stat}>
-            <Gauge size={13} color={colors.textSecondary} />
+            <Gauge size={size.icon.sm} color={colors.textSecondary} />
             <Text style={[styles.statText, { color: colors.text }]}>{formatSpeed(stats.avgSpeed)}</Text>
           </View>
         )}
         {stats && stats.elevationGain > 0 && (
           <View style={styles.stat}>
-            <TrendingUp size={13} color={colors.textSecondary} />
+            <TrendingUp size={size.icon.sm} color={colors.textSecondary} />
             <Text style={[styles.statText, { color: colors.text }]}>{Math.round(stats.elevationGain)}m</Text>
           </View>
         )}
         {stats && stats.elevationLoss > 0 && (
           <View style={styles.stat}>
-            <TrendingDown size={13} color={colors.textSecondary} />
+            <TrendingDown size={size.icon.sm} color={colors.textSecondary} />
             <Text style={[styles.statText, { color: colors.text }]}>{Math.round(stats.elevationLoss)}m</Text>
           </View>
         )}
@@ -265,7 +265,7 @@ export function TripList({
               accessibilityRole="button"
               accessibilityLabel="Cancel selection"
             >
-              <X size={18} color={colors.text} />
+              <X size={size.icon.md} color={colors.text} />
             </Pressable>
             <Text style={[styles.cabSummary, { color: colors.text }]}>{selected.size} selected</Text>
           </View>
@@ -290,7 +290,7 @@ export function TripList({
                 accessibilityLabel="Export selected trips"
                 accessibilityState={{ expanded: showExport }}
               >
-                <Share size={18} color={showExport ? colors.primary : colors.text} />
+                <Share size={size.icon.md} color={showExport ? colors.primary : colors.text} />
               </Pressable>
             )}
             {onMerge && trips.length >= 2 && (
@@ -304,7 +304,7 @@ export function TripList({
                 accessibilityHint={isAdjacentSelection ? undefined : "Select two or more adjacent trips to merge them"}
                 accessibilityState={{ disabled: !isAdjacentSelection }}
               >
-                <Merge size={18} color={isAdjacentSelection ? colors.text : colors.textDisabled} />
+                <Merge size={size.icon.md} color={isAdjacentSelection ? colors.text : colors.textDisabled} />
               </Pressable>
             )}
             {onDelete && (
@@ -315,7 +315,7 @@ export function TripList({
                 accessibilityRole="button"
                 accessibilityLabel="Delete selected trips"
               >
-                <Trash2 size={18} color={colors.error} />
+                <Trash2 size={size.icon.md} color={colors.error} />
               </Pressable>
             )}
           </View>
@@ -333,7 +333,7 @@ export function TripList({
               accessibilityLabel="Export all trips"
               accessibilityState={{ expanded: showExport }}
             >
-              <Share size={14} color={showExport ? colors.primary : colors.textSecondary} />
+              <Share size={size.icon.sm} color={showExport ? colors.primary : colors.textSecondary} />
               <Text style={[styles.exportAllLabel, { color: showExport ? colors.primary : colors.textSecondary }]}>
                 Export All
               </Text>

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -11,7 +11,7 @@ import type { NativeSyntheticEvent } from "react-native"
 import { Compass, Info, X } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
-import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_DARK, MAP_STYLE_URL_LIGHT, space } from "../../../constants"
+import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_DARK, MAP_STYLE_URL_LIGHT, size, space } from "../../../constants"
 import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
@@ -196,7 +196,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
       {showCompass && (
         <MapActionButton onPress={handleCompassPress} style={[mapActionStyles.right, styles.compassPosition]}>
           <View style={{ transform: [{ rotate: `${-heading}deg` }] }}>
-            <Compass size={20} color={colors.textLight} />
+            <Compass size={size.icon.md} color={colors.textLight} />
           </View>
         </MapActionButton>
       )}
@@ -210,7 +210,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
             accessibilityRole="button"
             accessibilityLabel="Show map attribution"
           >
-            <Info size={20} color={colors.textLight} />
+            <Info size={size.icon.md} color={colors.textLight} />
           </MapActionButton>
 
           <Modal
@@ -232,7 +232,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
                   accessibilityLabel="Close"
                   style={({ pressed }) => [styles.attributionClose, pressed && { opacity: colors.pressedOpacity }]}
                 >
-                  <X size={20} color={colors.textLight} />
+                  <X size={size.icon.md} color={colors.textLight} />
                 </Pressable>
                 {attributionLinks.map((link) => (
                   <Pressable

--- a/apps/mobile/src/components/features/map/MapCenterButton.tsx
+++ b/apps/mobile/src/components/features/map/MapCenterButton.tsx
@@ -8,6 +8,7 @@ import { ViewStyle, StyleProp, StyleSheet } from "react-native"
 import { LocateFixed } from "lucide-react-native"
 import { useTheme } from "../../../hooks/useTheme"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
+import { size } from "../../../constants"
 
 interface Props {
   onPress: () => void
@@ -22,7 +23,7 @@ export const MapCenterButton: React.FC<Props> = ({ onPress, visible, style }) =>
 
   return (
     <MapActionButton onPress={onPress} style={[mapActionStyles.right, styles.position, style]}>
-      <LocateFixed size={20} color={colors.textLight} />
+      <LocateFixed size={size.icon.md} color={colors.textLight} />
     </MapActionButton>
   )
 }

--- a/apps/mobile/src/components/features/map/TrackToggleButton.tsx
+++ b/apps/mobile/src/components/features/map/TrackToggleButton.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { Route } from "lucide-react-native"
 import { useTheme } from "../../../hooks/useTheme"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
+import { size } from "../../../constants"
 
 interface Props {
   onPress: () => void
@@ -18,7 +19,7 @@ export function TrackToggleButton({ onPress, active }: Props) {
 
   return (
     <MapActionButton onPress={onPress} style={mapActionStyles.left}>
-      <Route size={20} color={active ? colors.primary : colors.textLight} />
+      <Route size={size.icon.md} color={active ? colors.primary : colors.textLight} />
     </MapActionButton>
   )
 }

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useCallback, useEffect, useRef } from "react"
 import { Text, StyleSheet, TextInput, Switch, View, Pressable } from "react-native"
-import { CheckCircle, ChevronRight } from "lucide-react-native"
+import { CircleCheckBig, ChevronRight } from "lucide-react-native"
 import { Settings, ThemeColors } from "../../../types/global"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { isEndpointAllowed } from "../../../utils/settingsValidation"
@@ -14,7 +14,7 @@ import { ensureLocalNetworkPermission } from "../../../services/LocationServiceP
 import { fontSizes, fonts } from "../../../styles/typography"
 import { SettingRow } from "../../ui/SettingRow"
 import { useTimeout } from "../../../hooks/useTimeout"
-import { TEST_RESULT_DISPLAY_MS, space } from "../../../constants"
+import { TEST_RESULT_DISPLAY_MS, size, space } from "../../../constants"
 import { logger } from "../../../utils/logger"
 import { Button, Card, SectionTitle, Divider, FieldMessage } from "../../index"
 import { showChoice } from "../../../services/modalService"
@@ -278,7 +278,7 @@ export function ConnectionSettings({
                   }
                 ]}
               >
-                {!testError && <CheckCircle size={16} color={colors.success} />}
+                {!testError && <CircleCheckBig size={size.icon.sm} color={colors.success} />}
                 <Text style={[styles.responseText, { color: testError ? colors.error : colors.success }]}>
                   {testResponse}
                 </Text>
@@ -297,7 +297,7 @@ export function ConnectionSettings({
                   Basic auth, bearer tokens, custom headers
                 </Text>
               </View>
-              <ChevronRight size={20} color={colors.textLight} />
+              <ChevronRight size={size.icon.md} color={colors.textLight} />
             </Pressable>
           </>
         )}

--- a/apps/mobile/src/components/features/settings/PresetOption.tsx
+++ b/apps/mobile/src/components/features/settings/PresetOption.tsx
@@ -9,7 +9,7 @@ import { SelectablePreset, TRACKING_PRESETS } from "../../../types/global"
 import { fontSizes, fonts } from "../../../styles/typography"
 import { useTheme } from "../../../hooks/useTheme"
 import { RadioDot } from "../../ui/RadioDot"
-import { space } from "../../../constants"
+import { size, space } from "../../../constants"
 
 interface BadgeProps {
   icon: React.ReactElement
@@ -61,11 +61,11 @@ export function PresetOption({ preset, isSelected, isOfflineMode, onSelect }: Pr
                 {config.label}
               </Text>
               {showRecommendedBadge && (
-                <Badge icon={<Check size={10} color={colors.success} />} label="Recommended" color={colors.success} />
+                <Badge icon={<Check size={size.icon.sm} color={colors.success} />} label="Recommended" color={colors.success} />
               )}
               {showWarningBadge && (
                 <Badge
-                  icon={<Zap size={10} color={colors.warning} />}
+                  icon={<Zap size={size.icon.sm} color={colors.warning} />}
                   label="High Battery Usage"
                   color={colors.warning}
                 />

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -4,13 +4,13 @@
  */
 import React from "react"
 import { View, Text, StyleSheet, Pressable } from "react-native"
-import { AlertTriangle, ChevronRight } from "lucide-react-native"
+import { TriangleAlert, ChevronRight } from "lucide-react-native"
 import { useTracking } from "../../../contexts/TrackingProvider"
 import { useTheme } from "../../../hooks/useTheme"
 import { getQueueColor } from "../../../utils/queueStatus"
 import { formatCount } from "../../../utils/format"
 import { fontSizes, fonts } from "../../../styles/typography"
-import { CRITICAL_QUEUE_THRESHOLD, HIGH_QUEUE_THRESHOLD, space } from "../../../constants"
+import { CRITICAL_QUEUE_THRESHOLD, HIGH_QUEUE_THRESHOLD, size, space } from "../../../constants"
 import { radius } from "@colota/shared"
 
 interface StatsCardProps {
@@ -149,7 +149,7 @@ export function StatsCard({ queueCount, sentCount, todayCount, interval, onManag
             onPress={onManageClick}
           >
             <View style={styles.warningContent}>
-              <AlertTriangle size={20} color={warningLevel === "critical" ? colors.error : colors.warning} />
+              <TriangleAlert size={size.icon.md} color={warningLevel === "critical" ? colors.error : colors.warning} />
               <View style={styles.warningText}>
                 <Text
                   style={[
@@ -164,7 +164,7 @@ export function StatsCard({ queueCount, sentCount, todayCount, interval, onManag
                 <Text style={[styles.warningHint, { color: colors.textSecondary }]}>Tap to manage data</Text>
               </View>
             </View>
-            <ChevronRight size={20} color={warningLevel === "critical" ? colors.error : colors.warning} />
+            <ChevronRight size={size.icon.md} color={warningLevel === "critical" ? colors.error : colors.warning} />
           </Pressable>
         </View>
       )}

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -8,7 +8,7 @@ import { Text, StyleSheet, Switch, View, Pressable, TextInput, AppState } from "
 import { Lightbulb, ChevronDown, ChevronUp } from "lucide-react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
 import { fonts, fontSizes } from "../../../styles/typography"
-import { OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, space } from "../../../constants"
+import { OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, size, space } from "../../../constants"
 import { SectionTitle, Card, Divider, NumericInput, SettingRow } from "../../index"
 import { PresetOption } from "./PresetOption"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
@@ -167,9 +167,9 @@ export function SyncStrategySettings({
         >
           <Text style={[styles.advancedText, { color: colors.text }]}>Advanced Settings</Text>
           {showAdvanced ? (
-            <ChevronUp size={20} color={colors.textLight} />
+            <ChevronUp size={size.icon.md} color={colors.textLight} />
           ) : (
-            <ChevronDown size={20} color={colors.textLight} />
+            <ChevronDown size={size.icon.md} color={colors.textLight} />
           )}
         </Pressable>
 
@@ -178,7 +178,7 @@ export function SyncStrategySettings({
             {settings.syncPreset === "custom" && (
               <View style={[styles.customBanner, { backgroundColor: colors.info + "15" }]}>
                 <View style={styles.bannerRow}>
-                  <Lightbulb size={14} color={colors.info} />
+                  <Lightbulb size={size.icon.sm} color={colors.info} />
                   <Text style={[styles.customBannerText, { color: colors.info }]}>Using custom configuration</Text>
                 </View>
               </View>

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -42,7 +42,7 @@ jest.mock("lucide-react-native", () => {
   const R = require("react")
   const { View } = require("react-native")
   return {
-    CheckCircle: () => R.createElement(View, null),
+    CircleCheckBig: () => R.createElement(View, null),
     ChevronRight: () => R.createElement(View, null)
   }
 })

--- a/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
@@ -33,7 +33,7 @@ jest.mock("lucide-react-native", () => {
   const R = require("react")
   const { View } = require("react-native")
   return {
-    AlertTriangle: () => R.createElement(View, null),
+    TriangleAlert: () => R.createElement(View, null),
     ChevronRight: () => R.createElement(View, null)
   }
 })

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useRef, useEffect, useCallback } from "react"
 import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-native"
-import { Info, AlertCircle, AlertTriangle, CheckCircle } from "lucide-react-native"
+import { Info, CircleAlert, TriangleAlert, CircleCheckBig } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { radius } from "@colota/shared"
@@ -14,9 +14,9 @@ import { space } from "../../constants"
 
 const VARIANT_ICONS = {
   info: Info,
-  error: AlertCircle,
-  warning: AlertTriangle,
-  success: CheckCircle
+  error: CircleAlert,
+  warning: TriangleAlert,
+  success: CircleCheckBig
 } as const
 
 export function AppModal() {

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -8,7 +8,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Settings, LucideIcon, House, MapPinHouse, Waypoints } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { space } from "../../constants"
+import { size, space } from "../../constants"
 
 interface Tab {
   name: string
@@ -57,7 +57,7 @@ export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
             style={({ pressed }) => [styles.tab, pressed && { opacity: 0.6 }]}
             onPress={() => onNavigate(tab.route)}
           >
-            <tab.icon size={22} color={color} />
+            <tab.icon size={size.icon.md} color={color} />
             <Text style={[styles.label, { color }]}>{tab.label}</Text>
           </Pressable>
         )

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -18,7 +18,7 @@ import {
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { type LucideIcon } from "lucide-react-native"
-import { space } from "../../constants"
+import { size, space } from "../../constants"
 
 type ButtonVariant = "primary" | "secondary" | "ghost" | "danger"
 
@@ -123,7 +123,7 @@ export function Button({
           {loading ? (
             <ActivityIndicator size="small" color={v.text} style={styles.icon} />
           ) : Icon ? (
-            <Icon size={18} color={v.text} style={styles.icon} />
+            <Icon size={size.icon.md} color={v.text} style={styles.icon} />
           ) : null}
           <Text style={[styles.text, { color: v.text }]}>{title}</Text>
         </View>

--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -8,7 +8,7 @@ import { View, Text, StyleSheet, Animated } from "react-native"
 import { Check } from "lucide-react-native"
 import { SpinningLoader } from "./SpinningLoader"
 import { fontSizes, fonts } from "../../styles/typography"
-import { space } from "../../constants"
+import { size, space } from "../../constants"
 
 interface Props {
   saving: boolean
@@ -59,9 +59,9 @@ export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, messag
         ]}
       >
         {saving ? (
-          <SpinningLoader size={16} color={colors.text} />
+          <SpinningLoader size={size.icon.sm} color={colors.text} />
         ) : !hasMessage ? (
-          <Check size={16} color={colors.text} />
+          <Check size={size.icon.sm} color={colors.text} />
         ) : null}
         <Text style={[styles.text, { color: colors.text }]}>{displayText}</Text>
       </View>

--- a/apps/mobile/src/components/ui/FormatOption.tsx
+++ b/apps/mobile/src/components/ui/FormatOption.tsx
@@ -9,7 +9,7 @@ import type { LucideIcon } from "lucide-react-native"
 import { fontSizes, fonts } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
 import { RadioDot } from "./RadioDot"
-import { space } from "../../constants"
+import { size, space } from "../../constants"
 
 export const FormatOption = ({
   icon: Icon,
@@ -39,7 +39,7 @@ export const FormatOption = ({
     >
       <View style={styles.formatContent}>
         <View style={styles.leftContent}>
-          <Icon size={22} color={colors.textLight} />
+          <Icon size={size.icon.md} color={colors.textLight} />
           <View style={styles.textContent}>
             <View style={styles.titleRow}>
               <Text

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -8,7 +8,7 @@ import { Text, StyleSheet, View, Pressable } from "react-native"
 import { ChevronRight } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { space } from "../../constants"
+import { size, space } from "../../constants"
 
 type IconComponent = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
 
@@ -46,7 +46,7 @@ export function ListItem({
     >
       {Icon && (
         <View style={styles.icon}>
-          <Icon size={22} color={colors.textLight} />
+          <Icon size={size.icon.md} color={colors.textLight} />
         </View>
       )}
       <View style={styles.content}>
@@ -57,7 +57,7 @@ export function ListItem({
           </Text>
         ) : null}
       </View>
-      <TrailingIcon size={20} color={colors.textLight} />
+      <TrailingIcon size={size.icon.md} color={colors.textLight} />
     </Pressable>
   )
 }

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -13,7 +13,7 @@ import { Card, Container, Divider, SectionTitle, Footer } from "../components"
 import { useTimeout } from "../hooks/useTimeout"
 import NativeLocationService from "../services/NativeLocationService"
 import icon from "../assets/icons/icon.png"
-import { ISSUES_URL, PRIVACY_POLICY_URL, REPO_URL, TILE_SERVER_DOCS_URL, space } from "../constants"
+import { ISSUES_URL, PRIVACY_POLICY_URL, REPO_URL, TILE_SERVER_DOCS_URL, size, space } from "../constants"
 import { logger } from "../utils/logger"
 import { radius } from "@colota/shared"
 
@@ -68,12 +68,12 @@ const LinkRow = ({
     style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
     onPress={() => onOpenURL(url)}
   >
-    <Icon size={20} color={colors.textLight} />
+    <Icon size={size.icon.md} color={colors.textLight} />
     <View style={styles.linkTextContainer}>
       <Text style={[styles.linkTitle, { color: colors.text }]}>{title}</Text>
       <Text style={[styles.linkSubtitle, { color: colors.textLight }]}>{subtitle}</Text>
     </View>
-    <ExternalLink size={18} color={colors.textLight} />
+    <ExternalLink size={size.icon.md} color={colors.textLight} />
   </Pressable>
 )
 
@@ -269,7 +269,7 @@ export function AboutScreen({}: ScreenProps) {
                 pressed && { opacity: colors.pressedOpacity }
               ]}
             >
-              <Bug size={14} color={colors.warning} />
+              <Bug size={size.icon.sm} color={colors.warning} />
               <Text style={[styles.debugText, { color: colors.warning }]}>Debug Mode (tap to hide)</Text>
             </Pressable>
           )}
@@ -328,7 +328,7 @@ export function AboutScreen({}: ScreenProps) {
                   Self-hosted map tile server - configure your own
                 </Text>
               </View>
-              <ExternalLink size={18} color={colors.textLight} />
+              <ExternalLink size={size.icon.md} color={colors.textLight} />
             </Pressable>
             <Divider />
             <Pressable
@@ -341,7 +341,7 @@ export function AboutScreen({}: ScreenProps) {
                   Map data by OpenStreetMap contributors
                 </Text>
               </View>
-              <ExternalLink size={18} color={colors.textLight} />
+              <ExternalLink size={size.icon.md} color={colors.textLight} />
             </Pressable>
           </Card>
         </View>
@@ -370,7 +370,7 @@ export function AboutScreen({}: ScreenProps) {
                 ]}
                 onPress={handleCopyDebugInfo}
               >
-                {copied ? <Check size={16} color={colors.success} /> : <Copy size={16} color={colors.primaryDark} />}
+                {copied ? <Check size={size.icon.sm} color={colors.success} /> : <Copy size={size.icon.sm} color={colors.primaryDark} />}
                 <Text style={[styles.copyButtonText, { color: copied ? colors.success : colors.primaryDark }]}>
                   {copied ? "Copied!" : "Copy Debug Info"}
                 </Text>

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -26,7 +26,7 @@ import { logger, LOG_LEVELS, type LogLevel } from "../utils/logger"
 import { getMergedLogs, exportLogs, MergedLogEntry } from "../utils/logExport"
 import NativeLocationService from "../services/NativeLocationService"
 import { ScreenProps } from "../types/global"
-import { space } from "../constants"
+import { size, space } from "../constants"
 import { radius } from "@colota/shared"
 
 type FilterLevel = LogLevel
@@ -111,9 +111,9 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
           style={({ pressed }) => [styles.headerButton, pressed && { opacity: colors.pressedOpacity }]}
         >
           {exporting ? (
-            <ActivityIndicator size={18} color={colors.primary} />
+            <ActivityIndicator size={size.icon.md} color={colors.primary} />
           ) : (
-            <Share2 size={20} color={colors.primary} />
+            <Share2 size={size.icon.md} color={colors.primary} />
           )}
         </Pressable>
       </View>
@@ -206,7 +206,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
       {tabBar}
       <View style={styles.filterBar}>
         <View style={[styles.searchContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
-          <Search size={16} color={colors.textLight} />
+          <Search size={size.icon.sm} color={colors.textLight} />
           <TextInput
             style={[styles.searchInput, { color: colors.text }]}
             placeholder="Filter logs..."
@@ -218,7 +218,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
           />
           {searchQuery.length > 0 && (
             <Pressable onPress={() => setSearchQuery("")}>
-              <X size={16} color={colors.textLight} />
+              <X size={size.icon.sm} color={colors.textLight} />
             </Pressable>
           )}
         </View>
@@ -298,7 +298,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
           onPress={scrollToEnd}
           style={[styles.scrollEndButton, { backgroundColor: colors.primary, bottom: insets.bottom + 24 }]}
         >
-          <ArrowDown size={20} color={colors.textOnPrimary} />
+          <ArrowDown size={size.icon.md} color={colors.textOnPrimary} />
         </Pressable>
       ) : filteredLogs.length > 0 ? (
         <View style={[styles.followingBadge, { backgroundColor: colors.primary + "20", bottom: insets.bottom + 24 }]}>

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -15,7 +15,7 @@ import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
 import type { UnitSystem, TimeFormat } from "../utils/geo"
-import { space } from "../constants"
+import { size, space } from "../constants"
 import { radius } from "@colota/shared"
 
 export function AppearanceScreen({}: ScreenProps) {
@@ -173,9 +173,9 @@ export function AppearanceScreen({}: ScreenProps) {
               <Text style={[styles.linkSub, { color: colors.textSecondary }]}>{t("appearance.mapStyle.subtitle")}</Text>
             </View>
             {showMapTileServer ? (
-              <ChevronUp size={20} color={colors.textLight} />
+              <ChevronUp size={size.icon.md} color={colors.textLight} />
             ) : (
-              <ChevronDown size={20} color={colors.textLight} />
+              <ChevronDown size={size.icon.md} color={colors.textLight} />
             )}
           </Pressable>
 

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -15,7 +15,7 @@ import { SectionTitle, FloatingSaveIndicator, Container, Card, Divider, ChipGrou
 import NativeLocationService from "../services/NativeLocationService"
 import { logger } from "../utils/logger"
 import { findDuplicates } from "../utils/settingsValidation"
-import { space } from "../constants"
+import { size, space } from "../constants"
 import { radius } from "@colota/shared"
 
 const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
@@ -353,7 +353,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
                   Authenticate to servers that require a client certificate
                 </Text>
               </View>
-              <ChevronRight size={20} color={colors.textLight} />
+              <ChevronRight size={size.icon.md} color={colors.textLight} />
             </Pressable>
           </Card>
         </View>

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -6,7 +6,7 @@
 import { useState, useCallback, useEffect } from "react"
 import { useFocusEffect } from "@react-navigation/native"
 import { Text, StyleSheet, Switch, View, ScrollView, Pressable, DeviceEventEmitter, TextInput } from "react-native"
-import { FolderOpen, CheckCircle, Share2, AlertTriangle } from "lucide-react-native"
+import { FolderOpen, CircleCheckBig, Share2, TriangleAlert } from "lucide-react-native"
 import {
   Container,
   Card,
@@ -38,7 +38,7 @@ import { fontSizes, fonts } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { formatExportDateTime, formatBytes } from "../utils/format"
 import { showAlert } from "../services/modalService"
-import { SAVE_SUCCESS_DISPLAY_MS, space } from "../constants"
+import { SAVE_SUCCESS_DISPLAY_MS, size, space } from "../constants"
 import { radius } from "@colota/shared"
 
 type ExportInterval = "daily" | "weekly" | "monthly"
@@ -416,7 +416,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               style={({ pressed }) => [styles.directoryRow, pressed && { opacity: colors.pressedOpacity }]}
               onPress={handlePickDirectory}
             >
-              <FolderOpen size={22} color={colors.primary} />
+              <FolderOpen size={size.icon.md} color={colors.primary} />
               <View style={styles.directoryContent}>
                 <Text style={[styles.settingLabel, { color: colors.text }]}>
                   {directoryUri ? "Directory Selected" : "Select Directory"}
@@ -427,7 +427,7 @@ export function AutoExportScreen(_props: ScreenProps) {
                     : "Tap to choose where files are saved"}
                 </Text>
               </View>
-              {directoryUri && <CheckCircle size={18} color={colors.success} />}
+              {directoryUri && <CircleCheckBig size={size.icon.md} color={colors.success} />}
             </Pressable>
           </Card>
         </View>
@@ -589,7 +589,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               <>
                 <Divider />
                 <View style={styles.errorRow}>
-                  <AlertTriangle size={14} color={colors.error} />
+                  <TriangleAlert size={size.icon.sm} color={colors.error} />
                   <Text style={[styles.errorText, { color: colors.error }]} numberOfLines={2}>
                     {lastError}
                   </Text>
@@ -650,7 +650,7 @@ export function AutoExportScreen(_props: ScreenProps) {
                       style={({ pressed }) => [styles.shareButton, pressed && { opacity: 0.5 }]}
                       onPress={() => handleShareFile(file)}
                     >
-                      <Share2 size={18} color={colors.primary} />
+                      <Share2 size={size.icon.md} color={colors.primary} />
                     </Pressable>
                   </View>
                 </View>

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -19,7 +19,7 @@ import { logger } from "../utils/logger"
 import { fontSizes, fonts } from "../styles/typography"
 import { radius } from "@colota/shared"
 import type { ThemeColors } from "../types/global"
-import { space } from "../constants"
+import { size, space } from "../constants"
 
 type Props = RootScreenProps<"Backup & Restore">
 
@@ -93,7 +93,7 @@ function PasswordField({ value, onChangeText, placeholder, editable, autoComplet
         style={styles.eyeButton}
         accessibilityLabel="Hold to show password"
       >
-        <Icon size={20} color={colors.textSecondary} />
+        <Icon size={size.icon.md} color={colors.textSecondary} />
       </Pressable>
     </View>
   )

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -24,7 +24,7 @@ import { fonts, fontSizes } from "../styles/typography"
 import NativeLocationService from "../services/NativeLocationService"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Button, SectionTitle, Card, Container, Divider, FloatingSaveIndicator } from "../components"
-import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, space } from "../constants"
+import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, size, space } from "../constants"
 import { useTimeout } from "../hooks/useTimeout"
 import { showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -403,7 +403,7 @@ export function DataManagementScreen({}: ScreenProps) {
                   Reclaim unused space and improve performance
                 </Text>
                 <View style={styles.hintRow}>
-                  <Lightbulb size={12} color={colors.textLight} />
+                  <Lightbulb size={size.icon.sm} color={colors.textLight} />
                   <Text style={[styles.actionHint, { color: colors.textLight }]}>
                     Run after large deletions to reclaim space
                   </Text>

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -13,7 +13,7 @@ import { useTracking, useCoords } from "../contexts/TrackingProvider"
 import { fontSizes, fonts } from "../styles/typography"
 import { ChevronRight, Wifi, PersonStanding, MapPinHouse, Share2 } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
-import { DEFAULT_MAP_ZOOM, GEOFENCE_ZOOM_PADDING, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM, WORLD_MAP_ZOOM, space } from "../constants"
+import { DEFAULT_MAP_ZOOM, GEOFENCE_ZOOM_PADDING, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM, WORLD_MAP_ZOOM, size, space } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { buildGeofencesGeoJSON } from "../components/features/map/mapUtils"
@@ -245,7 +245,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
             hitSlop={HIT_SLOP_MD}
             style={({ pressed }) => [styles.zoomBtn, pressed && { opacity: colors.pressedOpacity }]}
           >
-            <MapPinHouse size={20} color={colors.textSecondary} />
+            <MapPinHouse size={size.icon.md} color={colors.textSecondary} />
           </Pressable>
           <Pressable
             testID={`edit-geofence-${item.id}`}
@@ -258,11 +258,11 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
                 <Text style={[styles.radius, { color: colors.textSecondary }]}>
                   {formatShortDistance(item.radius)} radius
                 </Text>
-                {item.pauseOnWifi && <Wifi size={12} color={colors.textSecondary} />}
-                {item.pauseOnMotionless && <PersonStanding size={12} color={colors.textSecondary} />}
+                {item.pauseOnWifi && <Wifi size={size.icon.sm} color={colors.textSecondary} />}
+                {item.pauseOnMotionless && <PersonStanding size={size.icon.sm} color={colors.textSecondary} />}
               </View>
             </View>
-            <ChevronRight size={20} color={colors.textSecondary} />
+            <ChevronRight size={size.icon.md} color={colors.textSecondary} />
           </Pressable>
         </View>
       </Card>
@@ -362,7 +362,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [styles.shareBtn, pressed && { opacity: colors.pressedOpacity }]}
                 >
-                  <Share2 size={20} color={colors.textSecondary} />
+                  <Share2 size={size.icon.md} color={colors.textSecondary} />
                 </Pressable>
               </View>
             )}

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -16,7 +16,7 @@ import { logger } from "../utils/logger"
 import { FILE_FORMATS, IMPORT_FORMAT_ORDER, importDescription } from "../utils/fileFormats"
 import { ScreenProps } from "../types/global"
 import type { ThemeColors } from "../types/global"
-import { space } from "../constants"
+import { size, space } from "../constants"
 import { radius } from "@colota/shared"
 
 const IMPORT_FORMAT_LABELS = Object.fromEntries(
@@ -85,7 +85,7 @@ const FormatRow = ({ entry, colors }: { entry: (typeof SUPPORTED_FORMATS)[number
   const Icon = entry.icon
   return (
     <View style={styles.formatRow}>
-      <Icon size={22} color={colors.textLight} />
+      <Icon size={size.icon.md} color={colors.textLight} />
       <View style={styles.formatTextContent}>
         <View style={styles.formatTitleRow}>
           <Text style={[styles.formatTitle, { color: colors.text }]}>{entry.title}</Text>

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffe
 import { View, Text, StyleSheet, Pressable } from "react-native"
 import { useFocusEffect } from "@react-navigation/native"
 import { fontSizes, fonts } from "../styles/typography"
-import { BarChart2 } from "lucide-react-native"
+import { ChartNoAxesColumn } from "lucide-react-native"
 import { Container } from "../components"
 import { Tab } from "../components/ui/Tab"
 import { useTheme } from "../hooks/useTheme"
@@ -31,7 +31,7 @@ import {
 import { EXPORT_FORMATS, type ExportFormat } from "../utils/exportConverters"
 import { showAlert, showConfirm } from "../services/modalService"
 import type { RootScreenProps } from "../types/navigation"
-import { space } from "../constants"
+import { size, space } from "../constants"
 
 type TabType = "map" | "trips" | "data"
 
@@ -91,7 +91,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         onPress={() => navigation.navigate("Location Summary")}
         style={({ pressed }) => [styles.headerBtn, pressed && { opacity: colors.pressedOpacity }]}
       >
-        <BarChart2 size={20} color={colors.text} />
+        <ChartNoAxesColumn size={size.icon.md} color={colors.text} />
       </Pressable>
     ),
     [navigation, colors]

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -25,7 +25,7 @@ import NativeLocationService from "../services/NativeLocationService"
 import { formatDistance, formatDuration, startOfDaySec } from "../utils/geo"
 import { fontSizes, fonts } from "../styles/typography"
 import { logger } from "../utils/logger"
-import { space } from "../constants"
+import { size, space } from "../constants"
 
 type Period = "week" | "month" | "30days"
 
@@ -160,7 +160,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
             <Text style={[styles.dayLabel, { color: colors.text }]}>{formatDayLabel(item.day)}</Text>
             <View style={styles.dayHeaderRight}>
               <Text style={[styles.dayDistance, { color: colors.primary }]}>{formatDistance(item.distanceMeters)}</Text>
-              <ChevronRight size={14} color={colors.textDisabled} />
+              <ChevronRight size={size.icon.sm} color={colors.textDisabled} />
             </View>
           </View>
           <View style={styles.dayStats}>
@@ -182,7 +182,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
     () => (
       <View style={styles.summaryGrid}>
         <Card style={styles.summaryCard}>
-          <Route size={16} color={colors.primary} />
+          <Route size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.totalDistance}
             format={(n) => formatDistance(n)}
@@ -192,7 +192,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
         </Card>
 
         <Card style={styles.summaryCard}>
-          <MapPin size={16} color={colors.primary} />
+          <MapPin size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.totalTrips}
             format={(n) => String(n)}
@@ -202,7 +202,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
         </Card>
 
         <Card style={styles.summaryCard}>
-          <Calendar size={16} color={colors.primary} />
+          <Calendar size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.activeDays}
             format={(n) => String(n)}
@@ -212,7 +212,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
         </Card>
 
         <Card style={styles.summaryCard}>
-          <TrendingUp size={16} color={colors.primary} />
+          <TrendingUp size={size.icon.sm} color={colors.primary} />
           <AnimatedNumber
             value={summary.avgDistance}
             format={(n) => formatDistance(n)}

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -12,10 +12,10 @@ import { showAlert, showConfirm } from "../services/modalService"
 import { ScreenProps } from "../types/global"
 import { useCoords } from "../contexts/TrackingProvider"
 import { fontSizes, fonts } from "../styles/typography"
-import { X, CheckCircle, RefreshCw, AlertTriangle } from "lucide-react-native"
+import { X, CircleCheckBig, RefreshCw, TriangleAlert } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
-import { DEFAULT_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT, WORLD_MAP_ZOOM, space } from "../constants"
+import { DEFAULT_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT, WORLD_MAP_ZOOM, size, space } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { logger } from "../utils/logger"
@@ -700,12 +700,12 @@ export function OfflineMapsScreen({}: ScreenProps) {
               disabled={item.isActive}
             >
               <View style={styles.nameRow}>
-                {item.isComplete && <CheckCircle size={14} color={colors.success} />}
+                {item.isComplete && <CircleCheckBig size={size.icon.sm} color={colors.success} />}
                 {item.isActive && <ActivityIndicator size="small" color={colors.primary} />}
                 <Text style={[styles.areaName, { color: colors.text }]}>{item.name}</Text>
                 {isStale && (
                   <View testID={`stale-indicator-${item.name}`}>
-                    <AlertTriangle size={13} color={colors.warning} />
+                    <TriangleAlert size={size.icon.sm} color={colors.warning} />
                   </View>
                 )}
               </View>
@@ -751,7 +751,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
                     {isRefreshing ? (
                       <ActivityIndicator size="small" color={colors.primary} />
                     ) : (
-                      <RefreshCw size={14} color={colors.primary} />
+                      <RefreshCw size={size.icon.sm} color={colors.primary} />
                     )}
                   </Pressable>
                 )}
@@ -768,7 +768,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
                   {isDeleting ? (
                     <ActivityIndicator size="small" color={colors.error} />
                   ) : (
-                    <X size={16} color={colors.error} />
+                    <X size={size.icon.sm} color={colors.error} />
                   )}
                 </Pressable>
               </View>

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -15,7 +15,7 @@ import { Container, SectionTitle, Card, Divider, SettingRow, NumericInput, Field
 import { Check } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
-import { MS_TO_KMH, PROFILE_CONDITIONS, STATIONARY_MAX_INTERVAL_SECONDS, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, defaultProfileDelays, space } from "../constants"
+import { MS_TO_KMH, PROFILE_CONDITIONS, STATIONARY_MAX_INTERVAL_SECONDS, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, defaultProfileDelays, size, space } from "../constants"
 import type { RootScreenProps } from "../types/navigation"
 import { radius } from "@colota/shared"
 
@@ -237,7 +237,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                   ]}
                   onPress={() => setConditionType(opt.type)}
                 >
-                  <Icon size={20} color={selected ? colors.primary : colors.textSecondary} />
+                  <Icon size={size.icon.md} color={selected ? colors.primary : colors.textSecondary} />
                   <Text style={[styles.conditionLabel, { color: selected ? colors.primary : colors.text }]}>
                     {opt.label}
                   </Text>
@@ -476,7 +476,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
           onPress={handleSave}
           disabled={saving}
         >
-          <Check size={20} color={colors.textOnPrimary} />
+          <Check size={size.icon.md} color={colors.textOnPrimary} />
           <Text style={[styles.saveBtnText, { color: colors.textOnPrimary }]}>
             {saving ? "Saving..." : isEditing ? "Save Changes" : "Create Profile"}
           </Text>

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -9,7 +9,7 @@ import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Container, Card, Button, SectionTitle } from "../components"
 import { fontSizes, fonts } from "../styles/typography"
-import { CircleAlert, CircleCheck, Import } from "lucide-react-native"
+import { CircleAlert, CircleCheckBig, Import } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -227,7 +227,7 @@ export function SetupImportScreen({ route, navigation }: any) {
             title="Apply Configuration"
             onPress={handleApply}
             variant="primary"
-            icon={CircleCheck}
+            icon={CircleCheckBig}
             loading={applying}
             disabled={applying}
           />

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -15,7 +15,7 @@ import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
 import { buildSetupConfig, buildSetupLink, type SetupShareParts, type SetupShareSelection } from "../utils/setupLink"
 import { DEFAULT_AUTH_CONFIG, type AuthConfig, type Geofence, type TrackingProfile } from "../types/global"
-import { space } from "../constants"
+import { size, space } from "../constants"
 
 type ShareCategory = keyof SetupShareSelection
 
@@ -169,7 +169,7 @@ export function ShareSetupScreen() {
           <View style={styles.section}>
             <Card style={[styles.warningCard, { borderColor: colors.error }]}>
               <View style={styles.headerRow}>
-                <TriangleAlert size={20} color={colors.error} />
+                <TriangleAlert size={size.icon.md} color={colors.error} />
                 <Text style={[styles.warningText, { color: colors.text }]}>
                   This link will contain your {credentialFields.join(", ")} in plain text. Anyone who sees the link can
                   read them - only share it over a trusted channel.

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -15,7 +15,7 @@ import { Container, SectionTitle, Card } from "../components"
 import { Plus, X, Zap, Share2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { buildProfilesLink } from "../utils/setupLink"
-import { HIT_SLOP_MD, MS_TO_KMH, PROFILE_CONDITIONS, space } from "../constants"
+import { HIT_SLOP_MD, MS_TO_KMH, PROFILE_CONDITIONS, size, space } from "../constants"
 import { radius } from "@colota/shared"
 
 function formatCondition(profile: SavedTrackingProfile): string {
@@ -119,7 +119,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
             onPress={() => navigation.navigate("Profile Editor", { profileId: item.id })}
           >
             <View style={[styles.iconWrap, { backgroundColor: colors.primary + "15" }]}>
-              <ConditionIcon size={18} color={colors.primary} />
+              <ConditionIcon size={size.icon.md} color={colors.primary} />
             </View>
 
             <View style={styles.info}>
@@ -158,7 +158,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
                   pressed && { opacity: colors.pressedOpacity }
                 ]}
               >
-                <X size={16} color={colors.error} />
+                <X size={size.icon.sm} color={colors.error} />
               </Pressable>
             </View>
           </Pressable>
@@ -192,7 +192,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
               ]}
               onPress={() => navigation.navigate("Profile Editor", {})}
             >
-              <Plus size={20} color={colors.textOnPrimary} />
+              <Plus size={size.icon.md} color={colors.textOnPrimary} />
               <Text style={[styles.createBtnText, { color: colors.textOnPrimary }]}>Create Profile</Text>
             </Pressable>
 
@@ -205,7 +205,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [styles.shareBtn, pressed && { opacity: colors.pressedOpacity }]}
                 >
-                  <Share2 size={20} color={colors.textSecondary} />
+                  <Share2 size={size.icon.md} color={colors.textSecondary} />
                 </Pressable>
               </View>
             )}

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -27,7 +27,7 @@ import { InteractiveLineChart } from "../components/features/inspector/Interacti
 import { getTripColor, computeTripStats, buildBoundaryOverrideMap, splitBlockedReason } from "../utils/trips"
 import { formatDate, formatDistance, formatDuration, formatSpeed, formatTime } from "../utils/geo"
 import { EXPORT_FORMATS, EXPORT_FORMAT_KEYS, type ExportFormat } from "../utils/exportConverters"
-import { HIT_SLOP_LG, space } from "../constants"
+import { HIT_SLOP_LG, size, space } from "../constants"
 import { showAlert, showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
 import NativeLocationService from "../services/NativeLocationService"
@@ -218,7 +218,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
         hitSlop={8}
         style={({ pressed }) => [styles.headerBtn, (pressed || deleting) && { opacity: colors.pressedOpacity }]}
       >
-        <Trash2 size={20} color={colors.error} />
+        <Trash2 size={size.icon.md} color={colors.error} />
       </Pressable>
     ),
     [handleDelete, deleting, colors.error, colors.pressedOpacity]
@@ -272,7 +272,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               hitSlop={HIT_SLOP_LG}
               style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
             >
-              <ChevronLeft size={24} color={prevTrip ? colors.primary : colors.textDisabled} />
+              <ChevronLeft size={size.icon.lg} color={prevTrip ? colors.primary : colors.textDisabled} />
             </Pressable>
             <View style={styles.headerTitleCenter}>
               <View style={styles.headerTitleLine}>
@@ -289,7 +289,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               hitSlop={HIT_SLOP_LG}
               style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
             >
-              <ChevronRight size={24} color={nextTrip ? colors.primary : colors.textDisabled} />
+              <ChevronRight size={size.icon.lg} color={nextTrip ? colors.primary : colors.textDisabled} />
             </Pressable>
           </View>
         </View>
@@ -386,7 +386,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               pressed && { opacity: 0.8 }
             ]}
           >
-            <Share size={16} color={colors.textOnPrimary} />
+            <Share size={size.icon.sm} color={colors.textOnPrimary} />
             <Text style={[styles.exportBtnText, { color: colors.textOnPrimary }]}>Export Trip</Text>
           </Pressable>
 
@@ -426,7 +426,7 @@ function StatCard({
 }) {
   return (
     <Card style={styles.statCard}>
-      <Icon size={16} color={colors.primary} />
+      <Icon size={size.icon.sm} color={colors.primary} />
       <Text style={[styles.statValue, { color: colors.text }]}>{value}</Text>
       <Text style={[styles.statLabel, { color: colors.textSecondary }]}>{label}</Text>
     </Card>

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -206,9 +206,9 @@ jest.mock("lucide-react-native", () => {
   const stub = (name: any) => () => R.createElement(RN.Text, null, name)
   return {
     FolderOpen: stub("FolderOpen"),
-    CheckCircle: stub("CheckCircle"),
+    CircleCheckBig: stub("CircleCheckBig"),
     Share2: stub("Share2"),
-    AlertTriangle: stub("AlertTriangle")
+    TriangleAlert: stub("TriangleAlert")
   }
 })
 

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -76,7 +76,7 @@ jest.mock("lucide-react-native", () => {
   const { Text } = require("react-native")
   const stub = (name: string) => (_props: any) => R.createElement(Text, null, name)
   return {
-    BarChart2: stub("BarChart2")
+    ChartNoAxesColumn: stub("ChartNoAxesColumn")
   }
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
         "i18next": "^26.4.2",
-        "lucide-react-native": "^1.17.0",
+        "lucide-react-native": "^1.31.0",
         "react": "19.2.8",
         "react-native": "0.87.0",
         "react-native-safe-area-context": "^5.8.0",


### PR DESCRIPTION
Raise lucide-react-native to ^1.31.0, the floor that carries LucideProvider, and mount one provider at strokeWidth 1.5 with absoluteStrokeWidth so a 16 badge and a 24 tab glyph hold the same painted weight instead of thinning as they grow.

Icon sizes read size.icon rather than a literal. Forty-three move onto the ladder: twenty grew off the sub-16 floor, where an absolute 1.5px stroke closes the counters of a 12px glyph, and the rest snap from 18 or 22 to 20. Forty-nine were already on it. The one 32 hero glyph keeps its size.

Normalise the retired lucide aliases to TriangleAlert, CircleAlert and ChartNoAxesColumn, and settle the three different check glyphs on CircleCheckBig.
