### PR TITLE
refactor(ui): sentence case for headings, labels and screen titles

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -69,17 +69,17 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   {
     name: "API Config",
     component: ApiSettingsScreen,
-    title: "API Config"
+    title: "API config"
   },
   {
     name: "Auth Settings",
     component: AuthSettingsScreen,
-    title: "Auth Settings"
+    title: "Auth settings"
   },
   {
     name: "mTLS Settings",
     component: MtlsSettingsScreen,
-    title: "mTLS Settings"
+    title: "mTLS settings"
   },
   {
     name: "Geofences",
@@ -89,12 +89,12 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   {
     name: "Geofence Editor",
     component: GeofenceEditorScreen,
-    title: "Geofence Editor"
+    title: "Geofence editor"
   },
   {
     name: "Location History",
     component: LocationHistoryScreen,
-    title: "Location History"
+    title: "Location history"
   },
   {
     name: "Location Summary",
@@ -104,32 +104,32 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   {
     name: "Export Locations",
     component: ExportLocationsScreen,
-    title: "Export Locations"
+    title: "Export locations"
   },
   {
     name: "Import Locations",
     component: ImportLocationsScreen,
-    title: "Import Locations"
+    title: "Import locations"
   },
   {
     name: "Auto-Export",
     component: AutoExportScreen,
-    title: "Auto-Export"
+    title: "Auto-export"
   },
   {
     name: "Data Management",
     component: DataManagementScreen,
-    title: "Data Management"
+    title: "Data management"
   },
   {
     name: "Tracking Profiles",
     component: TrackingProfilesScreen,
-    title: "Tracking Profiles"
+    title: "Tracking profiles"
   },
   {
     name: "Profile Editor",
     component: ProfileEditorScreen,
-    title: "Profile Editor"
+    title: "Profile editor"
   },
   {
     name: "About Colota",
@@ -139,22 +139,22 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   {
     name: "Setup Import",
     component: SetupImportScreen,
-    title: "Import Configuration"
+    title: "Import configuration"
   },
   {
     name: "Share Setup",
     component: ShareSetupScreen,
-    title: "Share Setup"
+    title: "Share setup"
   },
   {
     name: "Trip Detail",
     component: TripDetailScreen,
-    title: "Trip Detail"
+    title: "Trip detail"
   },
   {
     name: "Offline Maps",
     component: OfflineMapsScreen,
-    title: "Offline Maps"
+    title: "Offline maps"
   },
   {
     name: "Logging",
@@ -164,7 +164,7 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   {
     name: "Backup & Restore",
     component: BackupRestoreScreen,
-    title: "Backup & Restore"
+    title: "Backup & restore"
   },
   {
     name: "Appearance",
@@ -179,7 +179,7 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   {
     name: "Tracking & Sync",
     component: TrackingSyncScreen,
-    title: "Tracking & Sync"
+    title: "Tracking & sync"
   }
 ]
 

--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -74,7 +74,7 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
       error: { color: colors.error, label: "Unreachable" },
       notConfigured: { color: colors.warning, label: "No endpoint" },
       deviceOffline: { color: colors.textSecondary, label: "Device offline" },
-      offline: { color: colors.textSecondary, label: "Offline Mode" },
+      offline: { color: colors.textSecondary, label: "Offline mode" },
       loading: { color: colors.textLight, label: "Checking" }
     }
 
@@ -95,7 +95,7 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
     >
       <View style={[styles.dot, { backgroundColor: config.color }]} />
       <Text style={[styles.host, { color: colors.text }]} numberOfLines={1}>
-        {isOffline ? "Offline Mode" : displayUrl || "Server"}
+        {isOffline ? "Offline mode" : displayUrl || "Server"}
       </Text>
       {!isOffline && <Text style={[styles.status, { color: config.color }]}>{config.label}</Text>}
       <ChevronRight size={size.icon.sm} color={colors.textLight} />

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -164,7 +164,7 @@ export function DashboardMap({
             <Image source={icon} style={styles.icon} />
           </View>
           <Text style={[styles.stateTitle, { color: isBatteryCritical ? colors.error : colors.text }]}>
-            {isBatteryCritical ? "Tracking Stopped" : "Tracking Disabled"}
+            {isBatteryCritical ? "Tracking stopped" : "Tracking disabled"}
           </Text>
           <Text style={[styles.stateSubtext, { color: colors.textSecondary }]}>
             {isBatteryCritical
@@ -186,7 +186,7 @@ export function DashboardMap({
           <View style={[styles.iconCircle, { backgroundColor: colors.warning + "20" }]}>
             <TriangleAlert size={32} color={colors.warning} />
           </View>
-          <Text style={[styles.stateTitle, { color: colors.warning }]}>Location Services Off</Text>
+          <Text style={[styles.stateTitle, { color: colors.warning }]}>Location services off</Text>
           <Text style={[styles.stateSubtext, { color: colors.textSecondary }]}>
             Tracking can&apos;t get GPS fixes. Tap to open Settings.
           </Text>

--- a/apps/mobile/src/components/features/dashboard/__tests__/ConnectionStatus.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/ConnectionStatus.test.tsx
@@ -142,7 +142,7 @@ describe("ConnectionStatus", () => {
 
     const { getByText } = render(<ConnectionStatus endpoint={url} navigation={mockNavigation} />)
 
-    await waitFor(() => expect(getByText("Offline Mode")).toBeTruthy())
+    await waitFor(() => expect(getByText("Offline mode")).toBeTruthy())
   })
 
   it("shows 'Device offline' when the device has no network", async () => {

--- a/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
@@ -128,20 +128,20 @@ describe("DashboardMap info cards", () => {
   it("shows Tracking Disabled when not tracking", () => {
     const { getByText } = render(<DashboardMap {...baseProps} tracking={false} />)
 
-    expect(getByText("Tracking Disabled")).toBeTruthy()
+    expect(getByText("Tracking disabled")).toBeTruthy()
   })
 
   it("shows battery critical message when not tracking and battery is critical", () => {
     const { getByText } = render(<DashboardMap {...baseProps} tracking={false} isBatteryCritical={true} />)
 
-    expect(getByText("Tracking Stopped")).toBeTruthy()
+    expect(getByText("Tracking stopped")).toBeTruthy()
     expect(getByText("Battery critically low. Charge your device to resume.")).toBeTruthy()
   })
 
   it("shows normal disabled message when not tracking and battery is fine", () => {
     const { getByText } = render(<DashboardMap {...baseProps} tracking={false} isBatteryCritical={false} />)
 
-    expect(getByText("Tracking Disabled")).toBeTruthy()
+    expect(getByText("Tracking disabled")).toBeTruthy()
     expect(getByText("Start tracking to see the map.")).toBeTruthy()
   })
 
@@ -149,7 +149,7 @@ describe("DashboardMap info cards", () => {
     mockCoords = null
     const { getByText, queryByText } = render(<DashboardMap {...baseProps} locationEnabled={false} />)
 
-    expect(getByText("Location Services Off")).toBeTruthy()
+    expect(getByText("Location services off")).toBeTruthy()
     expect(getByText(/Tap to open Settings/)).toBeTruthy()
     // The Searching GPS spinner overlay should NOT show simultaneously
     expect(queryByText("Searching GPS...")).toBeNull()
@@ -160,7 +160,7 @@ describe("DashboardMap info cards", () => {
     const { getByText, queryByText } = render(<DashboardMap {...baseProps} locationEnabled={true} />)
 
     expect(getByText("Searching GPS...")).toBeTruthy()
-    expect(queryByText("Location Services Off")).toBeNull()
+    expect(queryByText("Location services off")).toBeNull()
   })
 
   it("shows location-off status bar when tracking with cached coords but location services off", () => {
@@ -174,7 +174,7 @@ describe("DashboardMap info cards", () => {
     // Profile chip is hidden while location is off (location-off takes priority)
     expect(queryByText("Charging")).toBeNull()
     // Full-screen overlay should NOT show because we have valid coords
-    expect(queryByText("Location Services Off")).toBeNull()
+    expect(queryByText("Location services off")).toBeNull()
   })
 
   it("hides profile and pause-zone chips when location services are off", () => {

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -300,7 +300,7 @@ export function TrackMap({
           <View style={[styles.iconCircle, { backgroundColor: colors.border }]}>
             <MapPinOff size={32} color={colors.textSecondary} />
           </View>
-          <Text style={[styles.emptyTitle, { color: colors.text }]}>No Locations</Text>
+          <Text style={[styles.emptyTitle, { color: colors.text }]}>No locations</Text>
           <Text style={[styles.emptySubtext, { color: colors.textSecondary }]}>No tracked locations for this day.</Text>
         </View>
       )}

--- a/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
+++ b/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
@@ -120,7 +120,7 @@ export function FileLoggingPanel() {
 
   return (
     <ScrollView contentContainerStyle={styles.scroll}>
-      <SectionTitle>File Logging</SectionTitle>
+      <SectionTitle>File logging</SectionTitle>
 
       <Card style={styles.card}>
         <Text style={[styles.intro, { color: colors.textSecondary }]}>

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -63,12 +63,12 @@ export function ConnectionSettings({
           if (stats.queued > 0) {
             const hasEndpoint = !!settings.endpoint
             const buttons = [
-              ...(hasEndpoint ? [{ text: "Sync First", style: "primary" as const }] : []),
+              ...(hasEndpoint ? [{ text: "Sync first", style: "primary" as const }] : []),
               { text: "Keep in Queue", style: "secondary" as const },
               { text: "Cancel", style: "secondary" as const }
             ]
             const choice = await showChoice({
-              title: "Unsent Locations",
+              title: "Unsent locations",
               message: `You have ${stats.queued} locations waiting to sync. What would you like to do?`,
               buttons
             })
@@ -181,7 +181,7 @@ export function ConnectionSettings({
     <View style={styles.section}>
       <SectionTitle>Connection</SectionTitle>
       <Card>
-        <SettingRow label="Offline Mode" hint="Save locally, no network sync">
+        <SettingRow label="Offline mode" hint="Save locally, no network sync">
           <Switch
             value={settings.isOfflineMode}
             onValueChange={handleOfflineModeChange}
@@ -199,7 +199,7 @@ export function ConnectionSettings({
 
             <View style={styles.inputGroup}>
               <View style={styles.inputHeader}>
-                <Text style={[styles.inputLabel, { color: colors.text }]}>Server Endpoint</Text>
+                <Text style={[styles.inputLabel, { color: colors.text }]}>Server endpoint</Text>
                 {endpointInput && (
                   <View
                     style={[
@@ -265,7 +265,7 @@ export function ConnectionSettings({
                 if (!endpointInput || !isEndpointAllowed(endpointInput)) return
                 handleTestEndpoint()
               }}
-              title={testing ? "Testing..." : "Test Connection"}
+              title={testing ? "Testing..." : "Test connection"}
             />
 
             {testResponse && (

--- a/apps/mobile/src/components/features/settings/PresetOption.tsx
+++ b/apps/mobile/src/components/features/settings/PresetOption.tsx
@@ -66,7 +66,7 @@ export function PresetOption({ preset, isSelected, isOfflineMode, onSelect }: Pr
               {showWarningBadge && (
                 <Badge
                   icon={<Zap size={size.icon.sm} color={colors.warning} />}
-                  label="High Battery Usage"
+                  label="High battery usage"
                   color={colors.warning}
                 />
               )}

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -159,7 +159,7 @@ export function StatsCard({ queueCount, sentCount, todayCount, interval, onManag
                     }
                   ]}
                 >
-                  {warningLevel === "critical" ? "Critical Queue Size" : "High Queue Size"}
+                  {warningLevel === "critical" ? "Critical queue size" : "High queue size"}
                 </Text>
                 <Text style={[styles.warningHint, { color: colors.textSecondary }]}>Tap to manage data</Text>
               </View>

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -143,7 +143,7 @@ export function SyncStrategySettings({
 
   return (
     <View style={styles.section}>
-      <SectionTitle>Tracking Configuration</SectionTitle>
+      <SectionTitle>Tracking configuration</SectionTitle>
       <Card>
         <View accessibilityRole="radiogroup">
           {(Object.keys(TRACKING_PRESETS) as SelectablePreset[]).map((preset, index) => (
@@ -165,7 +165,7 @@ export function SyncStrategySettings({
           style={({ pressed }) => [styles.advancedToggle, pressed && { opacity: colors.pressedOpacity }]}
           onPress={() => setShowAdvanced(!showAdvanced)}
         >
-          <Text style={[styles.advancedText, { color: colors.text }]}>Advanced Settings</Text>
+          <Text style={[styles.advancedText, { color: colors.text }]}>Advanced settings</Text>
           {showAdvanced ? (
             <ChevronUp size={size.icon.md} color={colors.textLight} />
           ) : (
@@ -186,10 +186,10 @@ export function SyncStrategySettings({
 
             {/* Tracking Parameters Group */}
             <View style={styles.paramGroup}>
-              <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Tracking Parameters</Text>
+              <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Tracking parameters</Text>
 
               <NumericInput
-                label="Tracking Interval"
+                label="Tracking interval"
                 value={intervalInput}
                 onChange={(val) => handleNumericChange("interval", val, 1)}
                 onBlur={() => handleNumericBlur("interval", 1)}
@@ -200,7 +200,7 @@ export function SyncStrategySettings({
               />
 
               <NumericInput
-                label="Movement Threshold"
+                label="Movement threshold"
                 value={distanceInput}
                 onChange={(val) => handleNumericChange("distance", val, 0)}
                 onBlur={() => handleNumericBlur("distance", 0)}
@@ -217,11 +217,11 @@ export function SyncStrategySettings({
 
                 {/* Network Parameters Group */}
                 <View style={styles.paramGroup}>
-                  <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Network Settings</Text>
+                  <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Network settings</Text>
 
                   {/* Sync Interval */}
                   <View style={styles.settingBlock}>
-                    <Text style={[styles.blockLabel, { color: colors.text }]}>Sync Interval</Text>
+                    <Text style={[styles.blockLabel, { color: colors.text }]}>Sync interval</Text>
                     <Text style={[styles.blockHint, { color: colors.textSecondary }]}>
                       How often to upload data to server
                     </Text>
@@ -285,7 +285,7 @@ export function SyncStrategySettings({
                   {isCustomSyncInterval && (
                     <View style={styles.customSyncInput}>
                       <NumericInput
-                        label="Custom Sync Interval"
+                        label="Custom sync interval"
                         value={syncIntervalInput}
                         onChange={(val) => {
                           setSyncIntervalInput(val)
@@ -316,7 +316,7 @@ export function SyncStrategySettings({
                   {showOverlandBatchSize && (
                     <View style={styles.customSyncInput}>
                       <NumericInput
-                        label="Batch Size"
+                        label="Batch size"
                         value={overlandBatchSizeInput}
                         onChange={(val) => {
                           setOverlandBatchSizeInput(val)
@@ -347,7 +347,7 @@ export function SyncStrategySettings({
 
                   {/* Sync Condition */}
                   <View style={styles.settingRowSpaced}>
-                    <Text style={[styles.blockLabel, { color: colors.text }]}>Sync Only On</Text>
+                    <Text style={[styles.blockLabel, { color: colors.text }]}>Sync only on</Text>
                     <Text style={[styles.blockHint, { color: colors.textSecondary }]}>
                       {settings.syncCondition === "any" && "Upload on any network connection"}
                       {settings.syncCondition === "wifi_any" && "Upload only when connected to Wi-Fi"}
@@ -439,9 +439,9 @@ export function SyncStrategySettings({
 
             {/* Quality Parameters Group */}
             <View style={styles.paramGroup}>
-              <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Quality Filters</Text>
+              <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Quality filters</Text>
 
-              <SettingRow label="Filter Inaccurate Locations" hint="Reject fixes the GPS chip reports as imprecise">
+              <SettingRow label="Filter inaccurate locations" hint="Reject fixes the GPS chip reports as imprecise">
                 <Switch
                   value={settings.filterInaccurateLocations}
                   onValueChange={(value) =>
@@ -461,7 +461,7 @@ export function SyncStrategySettings({
               {settings.filterInaccurateLocations && (
                 <View style={[styles.nestedSetting, { borderLeftColor: colors.border }]}>
                   <NumericInput
-                    label="Accuracy Threshold"
+                    label="Accuracy threshold"
                     value={accuracyThresholdInput}
                     onChange={(val) => handleNumericChange("accuracyThreshold", val, 1)}
                     onBlur={() => handleNumericBlur("accuracyThreshold", 1)}

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -137,7 +137,7 @@ describe("ConnectionSettings", () => {
   it("shows Offline Mode toggle", () => {
     const { getByText } = renderComponent()
 
-    expect(getByText("Offline Mode")).toBeTruthy()
+    expect(getByText("Offline mode")).toBeTruthy()
     expect(getByText("Save locally, no network sync")).toBeTruthy()
   })
 
@@ -145,13 +145,13 @@ describe("ConnectionSettings", () => {
     it("shows Server Endpoint input", () => {
       const { getByText } = renderComponent()
 
-      expect(getByText("Server Endpoint")).toBeTruthy()
+      expect(getByText("Server endpoint")).toBeTruthy()
     })
 
     it("shows Test Connection button", () => {
       const { getByText } = renderComponent()
 
-      expect(getByText("Test Connection")).toBeTruthy()
+      expect(getByText("Test connection")).toBeTruthy()
     })
 
     it("shows Authentication & Headers link", () => {
@@ -177,13 +177,13 @@ describe("ConnectionSettings", () => {
     it("hides Server Endpoint input", () => {
       const { queryByText } = renderComponent({ isOfflineMode: true })
 
-      expect(queryByText("Server Endpoint")).toBeNull()
+      expect(queryByText("Server endpoint")).toBeNull()
     })
 
     it("hides Test Connection button", () => {
       const { queryByText } = renderComponent({ isOfflineMode: true })
 
-      expect(queryByText("Test Connection")).toBeNull()
+      expect(queryByText("Test connection")).toBeNull()
     })
 
     it("hides Authentication & Headers link", () => {
@@ -217,7 +217,7 @@ describe("ConnectionSettings", () => {
       await waitFor(() => {
         expect(mockShowChoice).toHaveBeenCalledWith(
           expect.objectContaining({
-            title: "Unsent Locations",
+            title: "Unsent locations",
             message: expect.stringContaining("10 locations")
           })
         )
@@ -290,7 +290,7 @@ describe("ConnectionSettings", () => {
       await waitFor(() => {
         expect(mockShowChoice).toHaveBeenCalledWith(
           expect.objectContaining({
-            buttons: expect.not.arrayContaining([expect.objectContaining({ text: "Sync First" })])
+            buttons: expect.not.arrayContaining([expect.objectContaining({ text: "Sync first" })])
           })
         )
       })
@@ -318,7 +318,7 @@ describe("ConnectionSettings", () => {
       })
       const { getByText } = renderComponent({}, "http://example.com/api")
 
-      fireEvent.press(getByText("Test Connection"))
+      fireEvent.press(getByText("Test connection"))
 
       await waitFor(() => {
         expect(getByText(/HTTPS is required for public endpoints/)).toBeTruthy()
@@ -330,7 +330,7 @@ describe("ConnectionSettings", () => {
       mockTestEndpoint.mockResolvedValue({ ok: true, status: 200 })
       const { getByText } = renderComponent({}, "https://example.com/api")
 
-      fireEvent.press(getByText("Test Connection"))
+      fireEvent.press(getByText("Test connection"))
 
       await waitFor(() => {
         expect(getByText("Connection successful")).toBeTruthy()
@@ -346,7 +346,7 @@ describe("ConnectionSettings", () => {
       })
       const { getByText } = renderComponent({}, "https://example.com/api")
 
-      fireEvent.press(getByText("Test Connection"))
+      fireEvent.press(getByText("Test connection"))
 
       await waitFor(() => {
         expect(getByText(/TLS handshake failed/)).toBeTruthy()

--- a/apps/mobile/src/components/features/settings/__tests__/PresetOption.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/PresetOption.test.tsx
@@ -99,6 +99,6 @@ describe("PresetOption", () => {
       <PresetOption preset="instant" isSelected={false} isOfflineMode={false} onSelect={mockOnSelect} />
     )
 
-    expect(getByText("High Battery Usage")).toBeTruthy()
+    expect(getByText("High battery usage")).toBeTruthy()
   })
 })

--- a/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/StatsCard.test.tsx
@@ -80,7 +80,7 @@ describe("StatsCard", () => {
       const onManage = jest.fn()
       const { getByText } = render(<StatsCard {...baseProps} queueCount={75} onManageClick={onManage} />)
 
-      expect(getByText("High Queue Size")).toBeTruthy()
+      expect(getByText("High queue size")).toBeTruthy()
       expect(getByText("Tap to manage data")).toBeTruthy()
     })
 
@@ -88,7 +88,7 @@ describe("StatsCard", () => {
       const onManage = jest.fn()
       const { getByText } = render(<StatsCard {...baseProps} queueCount={200} onManageClick={onManage} />)
 
-      expect(getByText("Critical Queue Size")).toBeTruthy()
+      expect(getByText("Critical queue size")).toBeTruthy()
     })
 
     it("calls onManageClick when warning banner is pressed", () => {
@@ -125,8 +125,8 @@ describe("StatsCard", () => {
       const onManage = jest.fn()
       const { queryByText } = render(<StatsCard {...baseProps} queueCount={200} onManageClick={onManage} />)
 
-      expect(queryByText("High Queue Size")).toBeNull()
-      expect(queryByText("Critical Queue Size")).toBeNull()
+      expect(queryByText("High queue size")).toBeNull()
+      expect(queryByText("Critical queue size")).toBeNull()
     })
   })
 })

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -150,22 +150,22 @@ describe("SyncStrategySettings", () => {
     it("shows advanced settings when toggle is pressed", () => {
       const { getByText, queryByText } = renderComponent()
 
-      expect(queryByText("Tracking Parameters")).toBeNull()
+      expect(queryByText("Tracking parameters")).toBeNull()
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
-      expect(getByText("Tracking Parameters")).toBeTruthy()
-      expect(getByText("Network Settings")).toBeTruthy()
+      expect(getByText("Tracking parameters")).toBeTruthy()
+      expect(getByText("Network settings")).toBeTruthy()
     })
 
     it("hides advanced settings when toggle is pressed again", () => {
       const { getByText, queryByText } = renderComponent()
 
-      fireEvent.press(getByText("Advanced Settings"))
-      expect(getByText("Tracking Parameters")).toBeTruthy()
+      fireEvent.press(getByText("Advanced settings"))
+      expect(getByText("Tracking parameters")).toBeTruthy()
 
-      fireEvent.press(getByText("Advanced Settings"))
-      expect(queryByText("Tracking Parameters")).toBeNull()
+      fireEvent.press(getByText("Advanced settings"))
+      expect(queryByText("Tracking parameters")).toBeNull()
     })
   })
 
@@ -173,7 +173,7 @@ describe("SyncStrategySettings", () => {
     it("shows custom configuration banner when preset is custom", () => {
       const { getByText } = renderComponent({ syncPreset: "custom" })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       expect(getByText("Using custom configuration")).toBeTruthy()
     })
@@ -181,7 +181,7 @@ describe("SyncStrategySettings", () => {
     it("does not show custom banner when a named preset is selected", () => {
       const { getByText, queryByText } = renderComponent({ syncPreset: "instant" })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       expect(queryByText("Using custom configuration")).toBeNull()
     })
@@ -191,7 +191,7 @@ describe("SyncStrategySettings", () => {
     it("renders all sync interval options inline", () => {
       const { getByText, getAllByText } = renderComponent()
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       expect(getAllByText("Instant").length).toBeGreaterThan(0)
       expect(getByText("1 min")).toBeTruthy()
@@ -203,7 +203,7 @@ describe("SyncStrategySettings", () => {
     it("selecting a sync interval sets preset to custom", () => {
       const { getByText } = renderComponent()
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
       fireEvent.press(getByText("5 min"))
 
       expect(mockOnSettingsChange).toHaveBeenCalledWith(
@@ -225,17 +225,17 @@ describe("SyncStrategySettings", () => {
     it("shows accuracy threshold input when filter is enabled", () => {
       const { getByText } = renderComponent({ filterInaccurateLocations: true })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
-      expect(getByText("Accuracy Threshold")).toBeTruthy()
+      expect(getByText("Accuracy threshold")).toBeTruthy()
     })
 
     it("hides accuracy threshold input when filter is disabled", () => {
       const { getByText, queryByText } = renderComponent({ filterInaccurateLocations: false })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
-      expect(queryByText("Accuracy Threshold")).toBeNull()
+      expect(queryByText("Accuracy threshold")).toBeNull()
     })
   })
 
@@ -246,7 +246,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const intervalInput = getByDisplayValue("5")
       fireEvent.changeText(intervalInput, "0")
@@ -263,7 +263,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const intervalInput = getByDisplayValue("5")
       fireEvent.changeText(intervalInput, "-3")
@@ -279,7 +279,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const intervalInput = getByDisplayValue("5")
       fireEvent.changeText(intervalInput, "abc")
@@ -295,7 +295,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const intervalInput = getByDisplayValue("5")
       fireEvent.changeText(intervalInput, "10")
@@ -313,7 +313,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const distanceInput = getByDisplayValue("10")
       fireEvent.changeText(distanceInput, "-5")
@@ -330,7 +330,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const distanceInput = getByDisplayValue("10")
       fireEvent.changeText(distanceInput, "abc")
@@ -348,7 +348,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const thresholdInput = getByDisplayValue("100")
       fireEvent.changeText(thresholdInput, "0")
@@ -366,7 +366,7 @@ describe("SyncStrategySettings", () => {
         syncPreset: "custom"
       })
 
-      fireEvent.press(getByText("Advanced Settings"))
+      fireEvent.press(getByText("Advanced settings"))
 
       const thresholdInput = getByDisplayValue("100")
       fireEvent.changeText(thresholdInput, "200")

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -19,7 +19,7 @@ interface Tab {
 
 const TABS: Tab[] = [
   { name: "dashboard", label: "Dashboard", icon: House, route: "Dashboard" },
-  { name: "history", label: "History", icon: Waypoints, route: "Location History" },
+  { name: "history", label: "History", icon: Waypoints, route: "Location history" },
   { name: "geofences", label: "Geofences", icon: MapPinHouse, route: "Geofences" },
   { name: "settings", label: "Settings", icon: Settings, route: "Settings" }
 ]

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -86,7 +86,7 @@ export function DisclosureModal({ icon, title, paragraphs, confirmLabel, registe
               ]}
               onPress={handleNotNow}
             >
-              <Text style={[styles.buttonText, { color: colors.textSecondary }]}>Not Now</Text>
+              <Text style={[styles.buttonText, { color: colors.textSecondary }]}>Not now</Text>
             </Pressable>
 
             <Pressable

--- a/apps/mobile/src/components/ui/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ui/ErrorBoundary.tsx
@@ -57,7 +57,7 @@ class ErrorBoundaryInternal extends Component<ErrorBoundaryInternalProps, ErrorB
             ]}
             onPress={this.handleReset}
           >
-            <Text style={[styles.errorButtonText, { color: colors.textOnPrimary }]}>Try Again</Text>
+            <Text style={[styles.errorButtonText, { color: colors.textOnPrimary }]}>Try again</Text>
           </Pressable>
         </View>
       )

--- a/apps/mobile/src/components/ui/LocalNetworkDisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/LocalNetworkDisclosureModal.tsx
@@ -19,7 +19,7 @@ export function LocalNetworkDisclosureModal() {
   return (
     <DisclosureModal
       icon={<Wifi size={28} color={colors.primary} />}
-      title="Local Network Access"
+      title="Local network access"
       paragraphs={[
         "Your server is on the local network. Colota needs local network access permission to reach it.",
         "This permission is only used to connect to your self-hosted server. No device scanning or discovery is performed."

--- a/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
@@ -19,7 +19,7 @@ export function LocationDisclosureModal() {
   return (
     <DisclosureModal
       icon={<MapPin size={28} color={colors.primary} />}
-      title="Location Data Collection"
+      title="Location data collection"
       paragraphs={[
         "Colota collects location data to enable GPS tracking and sending your position to your configured server, even when the app is closed or not in use.",
         "This data is sent only to the server you set up. No data is shared with third parties.",

--- a/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
@@ -51,11 +51,11 @@ describe("DisclosureModal", () => {
     expect(getByText("First paragraph.")).toBeTruthy()
     expect(getByText("Second paragraph.")).toBeTruthy()
     expect(getByText("Confirm")).toBeTruthy()
-    expect(getByText("Not Now")).toBeTruthy()
+    expect(getByText("Not now")).toBeTruthy()
 
     // Clean up by dismissing
     await act(async () => {
-      fireEvent.press(getByText("Not Now"))
+      fireEvent.press(getByText("Not now"))
     })
     expect(await resultPromise!).toBe(false)
   })
@@ -84,7 +84,7 @@ describe("DisclosureModal", () => {
     })
 
     await act(async () => {
-      fireEvent.press(getByText("Not Now"))
+      fireEvent.press(getByText("Not now"))
     })
 
     expect(await resultPromise!).toBe(false)

--- a/apps/mobile/src/components/ui/__tests__/ErrorBoundary.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ErrorBoundary.test.tsx
@@ -64,7 +64,7 @@ describe("ErrorBoundary", () => {
 
     expect(getByText("Something went wrong")).toBeTruthy()
     expect(getByText("Test error message")).toBeTruthy()
-    expect(getByText("Try Again")).toBeTruthy()
+    expect(getByText("Try again")).toBeTruthy()
   })
 
   it("logs error via logger.error", () => {
@@ -101,7 +101,7 @@ describe("ErrorBoundary", () => {
 
     shouldThrow = false
 
-    fireEvent.press(getByText("Try Again"))
+    fireEvent.press(getByText("Try again"))
 
     expect(getByText("Recovered")).toBeTruthy()
   })

--- a/apps/mobile/src/components/ui/__tests__/NumericInput.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/NumericInput.test.tsx
@@ -22,7 +22,7 @@ describe("NumericInput", () => {
   function renderInput(overrides: Partial<React.ComponentProps<typeof NumericInput>> = {}) {
     return render(
       <NumericInput
-        label="Test Label"
+        label="Test label"
         value="10"
         onChange={mockOnChange}
         onBlur={mockOnBlur}
@@ -36,7 +36,7 @@ describe("NumericInput", () => {
   it("renders label, value, and unit", () => {
     const { getByText, getByDisplayValue } = renderInput()
 
-    expect(getByText("Test Label")).toBeTruthy()
+    expect(getByText("Test label")).toBeTruthy()
     expect(getByDisplayValue("10")).toBeTruthy()
     expect(getByText("seconds")).toBeTruthy()
   })

--- a/apps/mobile/src/hooks/useTheme.tsx
+++ b/apps/mobile/src/hooks/useTheme.tsx
@@ -108,7 +108,7 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
  * ```tsx
  * const { colors, mode, toggleTheme } = useTheme();
  * <View style={{ backgroundColor: colors.background }}>
- *   <Button onPress={toggleTheme} title="Toggle Theme" />
+ *   <Button onPress={toggleTheme} title="Toggle theme" />
  * </View>
  * ```
  */

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -222,7 +222,7 @@ export function AboutScreen({}: ScreenProps) {
       value: `${buildConfig.MIN_SDK_VERSION} (Android ${getAndroidVersion(buildConfig.MIN_SDK_VERSION)})`
     },
     { label: "Compile SDK", value: buildConfig.COMPILE_SDK_VERSION.toString() },
-    { label: "Build Tools", value: buildConfig.BUILD_TOOLS_VERSION },
+    { label: "Build tools", value: buildConfig.BUILD_TOOLS_VERSION },
     { label: "Kotlin", value: buildConfig.KOTLIN_VERSION },
     { label: "NDK", value: buildConfig.NDK_VERSION }
   ]
@@ -279,7 +279,7 @@ export function AboutScreen({}: ScreenProps) {
         <Card>
           <LinkRow
             icon={FileText}
-            title="Privacy Policy"
+            title="Privacy policy"
             subtitle={PRIVACY_POLICY_URL}
             url={PRIVACY_POLICY_URL}
             colors={colors}
@@ -288,7 +288,7 @@ export function AboutScreen({}: ScreenProps) {
           <Divider />
           <LinkRow
             icon={Code}
-            title="Source Code"
+            title="Source code"
             subtitle="github.com/dietrichmax/colota"
             url={REPO_URL}
             colors={colors}
@@ -316,14 +316,14 @@ export function AboutScreen({}: ScreenProps) {
 
         {/* Map Data Attribution */}
         <View style={styles.section}>
-          <SectionTitle>Map Data</SectionTitle>
+          <SectionTitle>Map data</SectionTitle>
           <Card>
             <Pressable
               style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
               onPress={() => handleOpenURL(TILE_SERVER_DOCS_URL)}
             >
               <View style={styles.linkTextContainer}>
-                <Text style={[styles.linkTitle, { color: colors.text }]}>Colota Tiles</Text>
+                <Text style={[styles.linkTitle, { color: colors.text }]}>Colota tiles</Text>
                 <Text style={[styles.linkSubtitle, { color: colors.textLight }]}>
                   Self-hosted map tile server - configure your own
                 </Text>
@@ -372,7 +372,7 @@ export function AboutScreen({}: ScreenProps) {
               >
                 {copied ? <Check size={size.icon.sm} color={colors.success} /> : <Copy size={size.icon.sm} color={colors.primaryDark} />}
                 <Text style={[styles.copyButtonText, { color: copied ? colors.success : colors.primaryDark }]}>
-                  {copied ? "Copied!" : "Copy Debug Info"}
+                  {copied ? "Copied!" : "Copy debug info"}
                 </Text>
               </Pressable>
 

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -20,8 +20,8 @@ import { radius } from "@colota/shared"
 
 const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
   { value: "none", label: "None" },
-  { value: "basic", label: "Basic Auth" },
-  { value: "bearer", label: "Bearer Token" }
+  { value: "basic", label: "Basic auth" },
+  { value: "bearer", label: "Bearer token" }
 ]
 
 type LocalHeader = { key: string; value: string; id: number }
@@ -249,7 +249,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
 
         {/* Custom Headers Section */}
         <View style={styles.section}>
-          <SectionTitle>Custom Headers</SectionTitle>
+          <SectionTitle>Custom headers</SectionTitle>
           <Card>
             {localHeaders.length === 0 ? (
               <Text style={[styles.emptyHint, { color: colors.textSecondary }]}>No custom headers configured</Text>
@@ -341,7 +341,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
         )}
 
         <View style={styles.section}>
-          <SectionTitle>Client Certificate</SectionTitle>
+          <SectionTitle>Client certificate</SectionTitle>
           <Card>
             <Pressable
               style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -410,7 +410,7 @@ export function AutoExportScreen(_props: ScreenProps) {
 
         {/* Export Directory */}
         <View style={styles.section}>
-          <SectionTitle>Export Directory</SectionTitle>
+          <SectionTitle>Export directory</SectionTitle>
           <Card>
             <Pressable
               style={({ pressed }) => [styles.directoryRow, pressed && { opacity: colors.pressedOpacity }]}
@@ -419,7 +419,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               <FolderOpen size={size.icon.md} color={colors.primary} />
               <View style={styles.directoryContent}>
                 <Text style={[styles.settingLabel, { color: colors.text }]}>
-                  {directoryUri ? "Directory Selected" : "Select Directory"}
+                  {directoryUri ? "Directory selected" : "Select directory"}
                 </Text>
                 <Text style={[styles.settingDescription, { color: colors.textSecondary }]} numberOfLines={1}>
                   {directoryUri
@@ -442,7 +442,7 @@ export function AutoExportScreen(_props: ScreenProps) {
 
         {/* File Name */}
         <View style={styles.section}>
-          <SectionTitle>File Name</SectionTitle>
+          <SectionTitle>File name</SectionTitle>
           <Card>
             <TextInput
               style={[styles.templateInput, { color: colors.text, borderColor: colors.border }]}
@@ -515,7 +515,7 @@ export function AutoExportScreen(_props: ScreenProps) {
 
         {/* Export Range */}
         <View style={styles.section}>
-          <SectionTitle>Export Range</SectionTitle>
+          <SectionTitle>Export range</SectionTitle>
           <Card>
             {MODE_OPTIONS.map((option, i) => (
               <View key={option.key}>
@@ -541,7 +541,7 @@ export function AutoExportScreen(_props: ScreenProps) {
 
         {/* File Retention */}
         <View style={styles.section}>
-          <SectionTitle>File Retention</SectionTitle>
+          <SectionTitle>File retention</SectionTitle>
           <Card>
             <NumericInput
               label="Files to keep"
@@ -566,21 +566,21 @@ export function AutoExportScreen(_props: ScreenProps) {
           <SectionTitle>Status</SectionTitle>
           <Card>
             <View style={styles.statusRow}>
-              <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Last Export</Text>
+              <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Last export</Text>
               <Text style={[styles.statusValue, { color: colors.text }]}>{formatExportDateTime(lastExport)}</Text>
             </View>
             {lastFileName && (
               <>
                 <Divider />
                 <View style={styles.statusRow}>
-                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Last File</Text>
+                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Last file</Text>
                   <Text style={[styles.statusValue, { color: colors.text }]} numberOfLines={1}>
                     {lastFileName}
                   </Text>
                 </View>
                 <Divider />
                 <View style={styles.statusRow}>
-                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Locations Exported</Text>
+                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Locations exported</Text>
                   <Text style={[styles.statusValue, { color: colors.text }]}>{lastRowCount}</Text>
                 </View>
               </>
@@ -600,7 +600,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               <>
                 <Divider />
                 <View style={styles.statusRow}>
-                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Next Export</Text>
+                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Next export</Text>
                   <Text style={[styles.statusValue, { color: colors.text }]}>{formatExportDateTime(nextExport)}</Text>
                 </View>
               </>
@@ -609,7 +609,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               <>
                 <Divider />
                 <View style={styles.statusRow}>
-                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Export Files</Text>
+                  <Text style={[styles.statusLabel, { color: colors.textSecondary }]}>Export files</Text>
                   <Text style={[styles.statusValue, { color: colors.text }]}>{fileCount}</Text>
                 </View>
               </>
@@ -621,7 +621,7 @@ export function AutoExportScreen(_props: ScreenProps) {
         {directoryUri && (
           <View style={styles.section}>
             <Button
-              title={exporting ? "Exporting..." : "Export Now"}
+              title={exporting ? "Exporting..." : "Export now"}
               onPress={handleExportNow}
               disabled={exporting}
               loading={exporting}
@@ -632,7 +632,7 @@ export function AutoExportScreen(_props: ScreenProps) {
         {/* Export History */}
         {exportFiles.length > 0 && (
           <View style={styles.section}>
-            <SectionTitle>Export History</SectionTitle>
+            <SectionTitle>Export history</SectionTitle>
             <Card>
               {exportFiles.map((file, i) => (
                 <View key={file.name}>

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -278,7 +278,7 @@ export function BackupRestoreScreen({}: Props) {
     <Container>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         <View style={styles.section}>
-          <SectionTitle>Encrypted Backup</SectionTitle>
+          <SectionTitle>Encrypted backup</SectionTitle>
           <Card>
             <Text style={[styles.intro, { color: colors.textSecondary }]}>
               Bundle your locations, settings and credentials into a single encrypted file you can store anywhere.

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -53,8 +53,8 @@ export function DashboardScreen({ navigation }: ScreenProps) {
       const openSettings = await showConfirm({
         title: "Please enable Location Services",
         message: "Location Services are disabled. Tracking will not work until they are enabled in Settings.",
-        confirmText: "Location Settings",
-        cancelText: "Start Anyway"
+        confirmText: "Location settings",
+        cancelText: "Start anyway"
       })
       if (openSettings) {
         await NativeLocationService.openLocationSettings()
@@ -234,7 +234,7 @@ export function DashboardScreen({ navigation }: ScreenProps) {
               onPress={tracking ? handleStop : handleStart}
               activeOpacity={0.9}
               disabled={!tracking && (isBatteryCritical || !settingsHydrated)}
-              title={tracking ? "Stop Tracking" : "Start Tracking"}
+              title={tracking ? "Stop tracking" : "Start tracking"}
             />
           </Animated.View>
         </View>

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -161,7 +161,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
   const handleClearSentHistory = useCallback(async () => {
     const confirmed = await showConfirm({
-      title: "Clear Sent History",
+      title: "Clear sent history",
       message: `Delete ${stats.sent} sent location${stats.sent !== 1 ? "s" : ""}? This cannot be undone.\n\n${BACKUP_TIP}`,
       confirmText: "Clear",
       destructive: true
@@ -176,7 +176,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
   const handleClearQueue = useCallback(async () => {
     const confirmed = await showConfirm({
-      title: "Clear Queue",
+      title: "Clear queue",
       message: `Delete ${stats.queued} pending location${stats.queued !== 1 ? "s" : ""}? These will not be synced.\n\n${BACKUP_TIP}`,
       confirmText: "Clear",
       destructive: true
@@ -191,9 +191,9 @@ export function DataManagementScreen({}: ScreenProps) {
 
   const handleDeleteAllLocations = useCallback(async () => {
     const confirmed = await showConfirm({
-      title: "Delete All Locations",
+      title: "Delete all locations",
       message: `Delete all ${stats.total} stored location${stats.total !== 1 ? "s" : ""}? This cannot be undone.\n\n${BACKUP_TIP}`,
-      confirmText: "Delete All",
+      confirmText: "Delete all",
       destructive: true
     })
     if (!confirmed) return
@@ -212,7 +212,7 @@ export function DataManagementScreen({}: ScreenProps) {
     }
 
     const confirmed = await showConfirm({
-      title: "Delete Old Locations",
+      title: "Delete old locations",
       message: `Delete all locations older than ${days} day${days !== 1 ? "s" : ""}? This cannot be undone.\n\n${BACKUP_TIP}`,
       confirmText: "Delete",
       destructive: true
@@ -227,7 +227,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
   const handleInsertDummyData = useCallback(async () => {
     const confirmed = await showConfirm({
-      title: "Insert Dummy Data",
+      title: "Insert dummy data",
       message: "Insert ~200 fake GPS locations across the past 7 days? This is for testing only.",
       confirmText: "Insert"
     })
@@ -273,7 +273,7 @@ export function DataManagementScreen({}: ScreenProps) {
         <ScrollView contentContainerStyle={styles.scrollContent}>
           {/* Header */}
           <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.text }]}>Data Management</Text>
+            <Text style={[styles.title, { color: colors.text }]}>Data management</Text>
           </View>
 
           {/* Stats */}
@@ -281,7 +281,7 @@ export function DataManagementScreen({}: ScreenProps) {
             <SectionTitle>DATABASE STATISTICS</SectionTitle>
             <Card>
               {[
-                ["Total Locations", stats.total.toLocaleString(), colors.text],
+                ["Total locations", stats.total.toLocaleString(), colors.text],
                 ...(!isOfflineMode
                   ? [
                       ["Sent", stats.sent.toLocaleString(), colors.success],
@@ -307,7 +307,7 @@ export function DataManagementScreen({}: ScreenProps) {
             <View style={styles.section}>
               <SectionTitle>QUEUE ACTIONS</SectionTitle>
               <Card>
-                <Button onPress={handleManualFlush} disabled={isProcessing || stats.queued === 0} title="Sync Now" />
+                <Button onPress={handleManualFlush} disabled={isProcessing || stats.queued === 0} title="Sync now" />
                 <Text style={[styles.hint, { color: colors.textLight }]}>
                   {stats.queued === 0
                     ? "Queue is empty"
@@ -325,7 +325,7 @@ export function DataManagementScreen({}: ScreenProps) {
                 <>
                   {/* Clear Sent History */}
                   <ActionRow
-                    label="Clear Sent History"
+                    label="Clear sent history"
                     hint="Delete all successfully sent locations"
                     color={colors.success}
                     textColor={colors.textLight}
@@ -337,7 +337,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
                   {/* Clear Queue */}
                   <ActionRow
-                    label="Clear Queue"
+                    label="Clear queue"
                     hint="Delete all pending locations"
                     color={colors.warning}
                     textColor={colors.textLight}
@@ -351,7 +351,7 @@ export function DataManagementScreen({}: ScreenProps) {
                 <>
                   {/* Delete All Locations (offline mode) */}
                   <ActionRow
-                    label="Delete All Locations"
+                    label="Delete all locations"
                     hint="Remove all stored locations from the database"
                     color={colors.error}
                     textColor={colors.textLight}
@@ -365,7 +365,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
               {/* Delete Older Than */}
               <View style={styles.actionColumn}>
-                <Text style={[styles.actionLabel, { color: colors.text }]}>Delete Old Locations</Text>
+                <Text style={[styles.actionLabel, { color: colors.text }]}>Delete old locations</Text>
                 <Text style={[styles.actionHint, { color: colors.textLight }]}>
                   Remove locations older than specified days
                 </Text>
@@ -398,7 +398,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
               {/* Vacuum */}
               <View style={styles.actionColumn}>
-                <Text style={[styles.actionLabel, { color: colors.text }]}>Optimize Database</Text>
+                <Text style={[styles.actionLabel, { color: colors.text }]}>Optimize database</Text>
                 <Text style={[styles.actionHint, { color: colors.textLight }]}>
                   Reclaim unused space and improve performance
                 </Text>
@@ -418,7 +418,7 @@ export function DataManagementScreen({}: ScreenProps) {
               <SectionTitle>DEV TOOLS</SectionTitle>
               <Card>
                 <View style={styles.actionColumn}>
-                  <Text style={[styles.actionLabel, { color: colors.text }]}>Insert Dummy Data</Text>
+                  <Text style={[styles.actionLabel, { color: colors.text }]}>Insert dummy data</Text>
                   <Text style={[styles.actionHint, { color: colors.textLight }]}>
                     Generate ~200 fake GPS locations across the past 7 days for testing trips and calendar
                   </Text>

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -85,7 +85,7 @@ export function ExportLocationsScreen({}: ScreenProps) {
           <Card style={styles.emptyCard}>
             <View style={styles.emptyState}>
               <MapPinOff size={40} color={colors.textLight} />
-              <Text style={[styles.emptyTitle, { color: colors.text }]}>No Locations</Text>
+              <Text style={[styles.emptyTitle, { color: colors.text }]}>No locations</Text>
               <Text style={[styles.emptySubtitle, { color: colors.textLight }]}>
                 Start tracking to record locations that can be exported.
               </Text>
@@ -97,7 +97,7 @@ export function ExportLocationsScreen({}: ScreenProps) {
             <View style={[styles.statsContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
               <View style={styles.statsGrid}>
                 <View style={styles.statItem}>
-                  <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Total Locations</Text>
+                  <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Total locations</Text>
                   <Text style={[styles.statValue, { color: colors.primaryDark }]}>
                     {totalLocations.toLocaleString()}
                   </Text>
@@ -107,7 +107,7 @@ export function ExportLocationsScreen({}: ScreenProps) {
 
             {/* Format Selection */}
             <View style={styles.section}>
-              <SectionTitle>Select Format</SectionTitle>
+              <SectionTitle>Select format</SectionTitle>
               <Card>
                 <FormatSelector selectedFormat={selectedFormat} onSelectFormat={setSelectedFormat} />
               </Card>
@@ -128,7 +128,7 @@ export function ExportLocationsScreen({}: ScreenProps) {
         )}
       </ScrollView>
 
-      <LoadingOverlay visible={exporting} title="Exporting Data" message={exportProgress} />
+      <LoadingOverlay visible={exporting} title="Exporting data" message={exportProgress} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -193,7 +193,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
   const handleDelete = useCallback(async () => {
     if (!geofenceId) return
     const confirmed = await showConfirm({
-      title: "Delete Geofence",
+      title: "Delete geofence",
       message: `Delete "${name}"?`,
       confirmText: "Delete",
       destructive: true
@@ -347,7 +347,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
         </Card>
 
         <Button
-          title={saving ? "Saving..." : "Save Geofence"}
+          title={saving ? "Saving..." : "Save geofence"}
           onPress={handleSave}
           disabled={
             saving ||
@@ -357,7 +357,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           }
           icon={Check}
         />
-        {isEditing && <Button title="Delete Geofence" onPress={handleDelete} variant="danger" icon={Trash2} />}
+        {isEditing && <Button title="Delete geofence" onPress={handleDelete} variant="danger" icon={Trash2} />}
       </ScrollView>
     </Container>
   )

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -288,7 +288,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
         ListHeaderComponent={
           <>
             <View style={styles.section}>
-              <SectionTitle>Create Geofence</SectionTitle>
+              <SectionTitle>Create geofence</SectionTitle>
               <Card>
                 <Text style={[styles.hint, { color: colors.textSecondary }]}>
                   Enter a name and radius, then tap the map to place
@@ -347,7 +347,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
                   disabled={placingGeofence}
                 >
                   <Text style={[styles.placeBtnText, { color: colors.textOnPrimary }]}>
-                    {placingGeofence ? "Tap Map to Place..." : "Place Geofence"}
+                    {placingGeofence ? "Tap Map to Place..." : "Place geofence"}
                   </Text>
                 </Pressable>
               </Card>

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -216,7 +216,7 @@ export function ImportLocationsScreen({}: ScreenProps) {
         <View style={[styles.statsContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
           <View style={styles.statsGrid}>
             <View style={styles.statItem}>
-              <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Total Locations</Text>
+              <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Total locations</Text>
               <Text style={[styles.statValue, { color: colors.primaryDark }]}>{totalLocations.toLocaleString()}</Text>
             </View>
           </View>
@@ -224,7 +224,7 @@ export function ImportLocationsScreen({}: ScreenProps) {
 
         {/* Supported formats */}
         <View style={styles.section}>
-          <SectionTitle>Supported Formats</SectionTitle>
+          <SectionTitle>Supported formats</SectionTitle>
           <Card>
             {SUPPORTED_FORMATS.map((entry, i) => (
               <React.Fragment key={entry.title}>
@@ -247,7 +247,7 @@ export function ImportLocationsScreen({}: ScreenProps) {
               Imported rows are flagged as already replicated by default, so they stay local. If you've configured an
               optional sync backend, the confirm dialog also offers to queue them for upload.
             </Text>
-            <Button onPress={handleChooseFile} disabled={busy} title="Choose File" icon={Download} />
+            <Button onPress={handleChooseFile} disabled={busy} title="Choose file" icon={Download} />
           </Card>
         </View>
       </ScrollView>

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -30,8 +30,8 @@ import { size, space } from "../constants"
 type Period = "week" | "month" | "30days"
 
 const PERIOD_OPTIONS = [
-  { value: "week" as const, label: "This Week" },
-  { value: "month" as const, label: "This Month" },
+  { value: "week" as const, label: "This week" },
+  { value: "month" as const, label: "This month" },
   { value: "30days" as const, label: "Last 30 Days" }
 ]
 const COUNT_UP_DURATION = 600 // ms
@@ -208,7 +208,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
             format={(n) => String(n)}
             style={[styles.summaryValue, { color: colors.text }]}
           />
-          <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Active Days</Text>
+          <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Active days</Text>
         </Card>
 
         <Card style={styles.summaryCard}>

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -106,7 +106,7 @@ const DownloadForm = memo(
     return (
       <>
         <View style={styles.section}>
-          <SectionTitle>Download Area</SectionTitle>
+          <SectionTitle>Download area</SectionTitle>
           <Card>
             <Text style={[styles.hint, { color: colors.textSecondary }]}>
               Pan and zoom the map to frame the area you want to download, then enter a name and tap Download. Size
@@ -156,7 +156,7 @@ const DownloadForm = memo(
                     pressed && { opacity: colors.pressedOpacity }
                   ]}
                 >
-                  <Text style={[styles.cancelBtnText, { color: colors.error }]}>Cancel Download</Text>
+                  <Text style={[styles.cancelBtnText, { color: colors.error }]}>Cancel download</Text>
                 </Pressable>
               </View>
             ) : (
@@ -170,7 +170,7 @@ const DownloadForm = memo(
                 onPress={onDownload}
                 disabled={!estimatedSizeLabel}
               >
-                <Text style={[styles.downloadBtnText, { color: colors.textOnPrimary }]}>Download Area</Text>
+                <Text style={[styles.downloadBtnText, { color: colors.textOnPrimary }]}>Download area</Text>
               </Pressable>
             )}
 
@@ -180,7 +180,7 @@ const DownloadForm = memo(
 
         {areasCount > 0 && (
           <>
-            <SectionTitle>Saved Areas</SectionTitle>
+            <SectionTitle>Saved areas</SectionTitle>
             {totalStorageBytes > 0 && (
               <Text style={[styles.savedAreasMeta, { color: colors.textSecondary }]}>
                 {areasCount} {areasCount === 1 ? "area" : "areas"} · {formatBytes(totalStorageBytes)}
@@ -438,9 +438,9 @@ export function OfflineMapsScreen({}: ScreenProps) {
     const isUnmetered = await NativeLocationService.isUnmeteredConnection()
     if (!isUnmetered) {
       const wifiConfirmed = await showConfirm({
-        title: "Mobile Data",
+        title: "Mobile data",
         message: "You're not on WiFi. Downloading map tiles may use significant mobile data. Continue?",
-        confirmText: "Download Anyway",
+        confirmText: "Download anyway",
         destructive: false
       })
       if (!wifiConfirmed) return
@@ -513,7 +513,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
       const isUnmetered = await NativeLocationService.isUnmeteredConnection()
       if (!isUnmetered) {
         const wifiConfirmed = await showConfirm({
-          title: "Mobile Data",
+          title: "Mobile data",
           message: "You're not on WiFi. Re-downloading may use significant mobile data. Continue?",
           confirmText: "Continue",
           destructive: false
@@ -557,7 +557,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
   const handleDelete = useCallback(
     async (area: OfflineAreaInfo) => {
       const confirmed = await showConfirm({
-        title: "Delete Area",
+        title: "Delete area",
         message: `Delete "${area.name}"? The downloaded tiles will be removed from your device.`,
         confirmText: "Delete",
         destructive: true

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -183,7 +183,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>{isEditing ? "Edit Profile" : "New Profile"}</Text>
+          <Text style={[styles.title, { color: colors.text }]}>{isEditing ? "Edit profile" : "New profile"}</Text>
         </View>
 
         {/* Name & Priority */}
@@ -218,7 +218,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         </Card>
 
         {/* Condition */}
-        <SectionTitle style={styles.sectionGap}>Activation Condition</SectionTitle>
+        <SectionTitle style={styles.sectionGap}>Activation condition</SectionTitle>
         <Card>
           <View style={styles.conditionGrid}>
             {PROFILE_CONDITIONS.map((opt) => {
@@ -269,9 +269,9 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         </Card>
 
         {/* Tracking Settings */}
-        <SectionTitle style={styles.sectionGap}>Tracking Settings</SectionTitle>
+        <SectionTitle style={styles.sectionGap}>Tracking settings</SectionTitle>
         <Card>
-          <SettingRow label="Tracking Interval" hint={`Default: ${settings.interval}s`}>
+          <SettingRow label="Tracking interval" hint={`Default: ${settings.interval}s`}>
             <View style={styles.inputWithUnit}>
               <TextInput
                 style={inputStyle}
@@ -300,7 +300,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
             </FieldMessage>
           ) : (
             <SettingRow
-              label="Movement Threshold"
+              label="Movement threshold"
               hint={`Default: ${metersToInput(settings.distance)} ${shortDistanceUnit()}`}
             >
               <View style={styles.inputWithUnit}>
@@ -322,7 +322,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
               <Divider />
 
               <View style={styles.syncLabelRow}>
-                <Text style={[styles.settingLabel, { color: colors.text }]}>Sync Interval</Text>
+                <Text style={[styles.settingLabel, { color: colors.text }]}>Sync interval</Text>
                 <Text style={[styles.settingHint, { color: colors.textSecondary }]}>
                   Default: {formatSyncDefault(settings.syncInterval)}
                 </Text>
@@ -378,7 +378,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
               {isCustomSyncInterval && (
                 <View style={styles.customSyncInput}>
                   <NumericInput
-                    label="Custom Sync Interval"
+                    label="Custom sync interval"
                     value={syncIntervalStr}
                     onChange={(val) => {
                       setSyncIntervalStr(val)
@@ -409,7 +409,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         <Card>
           {profile.condition.type === "stationary" ? (
             <SettingRow
-              label="Activation Delay"
+              label="Activation delay"
               hint="How long the device must be still before this profile activates. Resumes instantly via the hardware motion sensor when you move again."
             >
               <View style={styles.inputWithUnit}>
@@ -427,7 +427,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
           ) : (
             <>
               <SettingRow
-                label="Activation Delay"
+                label="Activation delay"
                 hint="How long the condition must hold before this profile takes over. Avoids switching on brief, temporary changes. 0 = instant."
               >
                 <View style={styles.inputWithUnit}>
@@ -446,7 +446,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
               <Divider />
 
               <SettingRow
-                label="Deactivation Delay"
+                label="Deactivation delay"
                 hint="How long after the condition stops before reverting to your defaults. Prevents rapid back-and-forth switching."
               >
                 <View style={styles.inputWithUnit}>
@@ -478,7 +478,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         >
           <Check size={size.icon.md} color={colors.textOnPrimary} />
           <Text style={[styles.saveBtnText, { color: colors.textOnPrimary }]}>
-            {saving ? "Saving..." : isEditing ? "Save Changes" : "Create Profile"}
+            {saving ? "Saving..." : isEditing ? "Save changes" : "Create profile"}
           </Text>
         </Pressable>
       </ScrollView>

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -147,7 +147,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-tracking-profiles"
               icon={UserRoundPen}
-              label="Tracking Profiles"
+              label="Tracking profiles"
               sub="Auto-switch GPS settings based on conditions"
               onPress={() => navigation.navigate("Tracking Profiles")}
             />
@@ -173,7 +173,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-data-management"
               icon={Database}
-              label="Data Management"
+              label="Data management"
               sub="View queue and clear data"
               onPress={() => navigation.navigate("Data Management")}
             />
@@ -181,7 +181,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-import-locations"
               icon={Download}
-              label="Import Locations"
+              label="Import locations"
               sub="Merge locations from a GeoJSON or Google Timeline file"
               onPress={() => navigation.navigate("Import Locations")}
             />
@@ -189,7 +189,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-export-locations"
               icon={Upload}
-              label="Export Locations"
+              label="Export locations"
               sub="Export locations as CSV, GeoJSON, GPX or KML"
               onPress={() => navigation.navigate("Export Locations")}
             />
@@ -213,7 +213,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-share-setup"
               icon={Share2}
-              label="Share Setup"
+              label="Share setup"
               sub="Share your settings, geofences and profiles as a link"
               onPress={() => navigation.navigate("Share Setup")}
             />
@@ -221,7 +221,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-offline-maps"
               icon={Map}
-              label="Offline Maps"
+              label="Offline maps"
               sub="Download map tiles for use without internet"
               onPress={() => navigation.navigate("Offline Maps")}
             />

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -167,12 +167,12 @@ export function SetupImportScreen({ route, navigation }: any) {
             <View style={styles.headerRow}>
               <CircleAlert size={28} color={colors.error} />
               <View style={styles.headerText}>
-                <Text style={[styles.title, { color: colors.text }]}>Invalid Configuration</Text>
+                <Text style={[styles.title, { color: colors.text }]}>Invalid configuration</Text>
                 <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{result.error}</Text>
               </View>
             </View>
           </Card>
-          <Button title="Go Back" onPress={handleCancel} variant="primary" />
+          <Button title="Go back" onPress={handleCancel} variant="primary" />
         </ScrollView>
       </Container>
     )
@@ -186,7 +186,7 @@ export function SetupImportScreen({ route, navigation }: any) {
           <View style={styles.headerRow}>
             <Import size={28} color={colors.primary} />
             <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.text }]}>Import Configuration</Text>
+              <Text style={[styles.title, { color: colors.text }]}>Import configuration</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 A setup link wants to apply {result.entries.length} setting{result.entries.length !== 1 ? "s" : ""}
               </Text>
@@ -224,7 +224,7 @@ export function SetupImportScreen({ route, navigation }: any) {
 
         <View style={styles.actions}>
           <Button
-            title="Apply Configuration"
+            title="Apply configuration"
             onPress={handleApply}
             variant="primary"
             icon={CircleCheckBig}

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -127,7 +127,7 @@ export function ShareSetupScreen() {
           <View style={styles.headerRow}>
             <Share2 size={28} color={colors.primary} />
             <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.text }]}>Share Setup</Text>
+              <Text style={[styles.title, { color: colors.text }]}>Share setup</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 Choose what to bundle into a setup link, then share it. The recipient opens it to apply the same
                 configuration.

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -88,7 +88,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
   const handleDelete = useCallback(
     async (item: SavedTrackingProfile) => {
       const confirmed = await showConfirm({
-        title: "Delete Profile",
+        title: "Delete profile",
         message: `Delete "${item.name}"?`,
         confirmText: "Delete",
         destructive: true
@@ -178,7 +178,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
         ListHeaderComponent={
           <>
             <View style={styles.header}>
-              <Text style={[styles.title, { color: colors.text }]}>Tracking Profiles</Text>
+              <Text style={[styles.title, { color: colors.text }]}>Tracking profiles</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 Auto-switch GPS settings based on charging, Android Auto, or speed
               </Text>
@@ -193,7 +193,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
               onPress={() => navigation.navigate("Profile Editor", {})}
             >
               <Plus size={size.icon.md} color={colors.textOnPrimary} />
-              <Text style={[styles.createBtnText, { color: colors.textOnPrimary }]}>Create Profile</Text>
+              <Text style={[styles.createBtnText, { color: colors.textOnPrimary }]}>Create profile</Text>
             </Pressable>
 
             {profiles.length > 0 && (

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -298,7 +298,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
         <View style={[styles.statsGrid, styles.section]}>
           <StatCard icon={Route} label="Distance" value={formatDistance(trip.distance)} colors={colors} />
           <StatCard icon={Clock} label="Duration" value={formatDuration(duration)} colors={colors} />
-          <StatCard icon={Gauge} label="Avg Speed" value={formatSpeed(stats.avgSpeed)} colors={colors} />
+          <StatCard icon={Gauge} label="Avg speed" value={formatSpeed(stats.avgSpeed)} colors={colors} />
           <StatCard icon={MapPin} label="Points" value={String(trip.locationCount)} colors={colors} />
           {stats.elevationGain > 0 && (
             <StatCard
@@ -387,7 +387,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
             ]}
           >
             <Share size={size.icon.sm} color={colors.textOnPrimary} />
-            <Text style={[styles.exportBtnText, { color: colors.textOnPrimary }]}>Export Trip</Text>
+            <Text style={[styles.exportBtnText, { color: colors.textOnPrimary }]}>Export trip</Text>
           </Pressable>
 
           {showExport && (

--- a/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
@@ -223,7 +223,7 @@ describe("AboutScreen", () => {
   it("opens Privacy Policy URL when link pressed", async () => {
     const { getByText } = renderScreen()
 
-    fireEvent.press(getByText("Privacy Policy"))
+    fireEvent.press(getByText("Privacy policy"))
 
     await waitFor(() => {
       expect(Linking.openURL).toHaveBeenCalledWith("https://colota.app/privacy-policy")

--- a/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
@@ -124,8 +124,8 @@ describe("AuthSettingsScreen", () => {
       await waitFor(() => {
         expect(getByText("None")).toBeTruthy()
       })
-      expect(getByText("Basic Auth")).toBeTruthy()
-      expect(getByText("Bearer Token")).toBeTruthy()
+      expect(getByText("Basic auth")).toBeTruthy()
+      expect(getByText("Bearer token")).toBeTruthy()
     })
 
     it("defaults to None with no credential fields visible", async () => {
@@ -147,7 +147,7 @@ describe("AuthSettingsScreen", () => {
         expect(getByText("None")).toBeTruthy()
       })
 
-      fireEvent.press(getByText("Basic Auth"))
+      fireEvent.press(getByText("Basic auth"))
 
       expect(getByText("Username")).toBeTruthy()
       expect(getByText("Password")).toBeTruthy()
@@ -160,7 +160,7 @@ describe("AuthSettingsScreen", () => {
         expect(getByText("None")).toBeTruthy()
       })
 
-      fireEvent.press(getByText("Bearer Token"))
+      fireEvent.press(getByText("Bearer token"))
 
       expect(getByText("Token")).toBeTruthy()
     })
@@ -172,10 +172,10 @@ describe("AuthSettingsScreen", () => {
         expect(getByText("None")).toBeTruthy()
       })
 
-      fireEvent.press(getByText("Basic Auth"))
+      fireEvent.press(getByText("Basic auth"))
       expect(getByText("Username")).toBeTruthy()
 
-      fireEvent.press(getByText("Bearer Token"))
+      fireEvent.press(getByText("Bearer token"))
       expect(queryByText("Username")).toBeNull()
       expect(queryByText("Password")).toBeNull()
       expect(getByText("Token")).toBeTruthy()
@@ -188,7 +188,7 @@ describe("AuthSettingsScreen", () => {
         expect(getByText("None")).toBeTruthy()
       })
 
-      fireEvent.press(getByText("Bearer Token"))
+      fireEvent.press(getByText("Bearer token"))
       expect(getByText("Token")).toBeTruthy()
 
       fireEvent.press(getByText("None"))
@@ -202,7 +202,7 @@ describe("AuthSettingsScreen", () => {
         expect(getByText("None")).toBeTruthy()
       })
 
-      fireEvent.press(getByText("Basic Auth"))
+      fireEvent.press(getByText("Basic auth"))
 
       expect(mockImmediateSaveAndRestart).toHaveBeenCalled()
     })
@@ -248,7 +248,7 @@ describe("AuthSettingsScreen", () => {
         expect(getByText("None")).toBeTruthy()
       })
 
-      fireEvent.press(getByText("Basic Auth"))
+      fireEvent.press(getByText("Basic auth"))
 
       const usernameInput = getByPlaceholderText("Username")
       fireEvent.changeText(usernameInput, "newuser")

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -378,10 +378,10 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Select Directory")).toBeTruthy()
+      expect(getByText("Select directory")).toBeTruthy()
     })
 
-    fireEvent.press(getByText("Select Directory"))
+    fireEvent.press(getByText("Select directory"))
 
     await waitFor(() => {
       expect(mockPickExportDirectory).toHaveBeenCalled()
@@ -442,8 +442,8 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Next Export")).toBeTruthy()
-      expect(getByText("Export Files")).toBeTruthy()
+      expect(getByText("Next export")).toBeTruthy()
+      expect(getByText("Export files")).toBeTruthy()
       expect(getByText("3")).toBeTruthy()
     })
   })
@@ -463,8 +463,8 @@ describe("AutoExportScreen", () => {
     const { queryByText, getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(queryByText("Next Export")).toBeNull()
-      expect(getByText("Export Files")).toBeTruthy()
+      expect(queryByText("Next export")).toBeNull()
+      expect(getByText("Export files")).toBeTruthy()
     })
   })
 
@@ -622,7 +622,7 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Export Now")).toBeTruthy()
+      expect(getByText("Export now")).toBeTruthy()
     })
   })
 
@@ -630,7 +630,7 @@ describe("AutoExportScreen", () => {
     const { queryByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(queryByText("Export Now")).toBeNull()
+      expect(queryByText("Export now")).toBeNull()
     })
   })
 
@@ -649,10 +649,10 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Export Now")).toBeTruthy()
+      expect(getByText("Export now")).toBeTruthy()
     })
 
-    fireEvent.press(getByText("Export Now"))
+    fireEvent.press(getByText("Export now"))
 
     await waitFor(() => {
       expect(mockRunAutoExportNow).toHaveBeenCalled()
@@ -702,9 +702,9 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Last File")).toBeTruthy()
+      expect(getByText("Last file")).toBeTruthy()
       expect(getByText("colota_export_2026-03-10_1200.geojson")).toBeTruthy()
-      expect(getByText("Locations Exported")).toBeTruthy()
+      expect(getByText("Locations exported")).toBeTruthy()
       expect(getByText("42")).toBeTruthy()
     })
   })
@@ -741,7 +741,7 @@ describe("AutoExportScreen", () => {
     const { getByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(getByText("Export History")).toBeTruthy()
+      expect(getByText("Export history")).toBeTruthy()
       expect(getByText("colota_export_2026-03-10.geojson")).toBeTruthy()
       expect(getByText("colota_export_2026-03-09.geojson")).toBeTruthy()
     })
@@ -753,7 +753,7 @@ describe("AutoExportScreen", () => {
     const { queryByText } = render(<AutoExportScreen {...mockProps} />)
 
     await waitFor(() => {
-      expect(queryByText("Export History")).toBeNull()
+      expect(queryByText("Export history")).toBeNull()
     })
   })
 

--- a/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
@@ -120,7 +120,7 @@ describe("DashboardScreen", () => {
 
     const { getByText } = render(<DashboardScreen navigation={mockNavigation} />)
 
-    expect(getByText("Start Tracking")).toBeTruthy()
+    expect(getByText("Start tracking")).toBeTruthy()
   })
 
   it("shows Stop Tracking button when tracking", () => {
@@ -128,7 +128,7 @@ describe("DashboardScreen", () => {
 
     const { getByText } = render(<DashboardScreen navigation={mockNavigation} />)
 
-    expect(getByText("Stop Tracking")).toBeTruthy()
+    expect(getByText("Stop tracking")).toBeTruthy()
   })
 
   it("shows CoordinateDisplay when tracking with valid coords", () => {
@@ -155,7 +155,7 @@ describe("DashboardScreen", () => {
 
     const { getByText } = render(<DashboardScreen navigation={mockNavigation} />)
 
-    expect(getByText("Start Tracking")).toBeDisabled()
+    expect(getByText("Start tracking")).toBeDisabled()
   })
 
   it("hides WelcomeCard while settings have not been read", () => {
@@ -219,7 +219,7 @@ describe("DashboardScreen", () => {
     mockIsLocationEnabled.mockResolvedValue(true)
 
     const { getByText } = render(<DashboardScreen navigation={mockNavigation} />)
-    fireEvent.press(getByText("Start Tracking"))
+    fireEvent.press(getByText("Start tracking"))
 
     await waitFor(() => expect(mockStartTracking).toHaveBeenCalled())
     expect(mockShowConfirm).not.toHaveBeenCalled()
@@ -232,7 +232,7 @@ describe("DashboardScreen", () => {
     mockShowConfirm.mockResolvedValue(true) // user taps "Location Settings"
 
     const { getByText } = render(<DashboardScreen navigation={mockNavigation} />)
-    fireEvent.press(getByText("Start Tracking"))
+    fireEvent.press(getByText("Start tracking"))
 
     await waitFor(() => expect(mockOpenLocationSettings).toHaveBeenCalled())
     expect(mockStartTracking).not.toHaveBeenCalled()
@@ -244,7 +244,7 @@ describe("DashboardScreen", () => {
     mockShowConfirm.mockResolvedValue(false) // user taps "Close"
 
     const { getByText } = render(<DashboardScreen navigation={mockNavigation} />)
-    fireEvent.press(getByText("Start Tracking"))
+    fireEvent.press(getByText("Start tracking"))
 
     await waitFor(() => expect(mockStartTracking).toHaveBeenCalled())
     expect(mockOpenLocationSettings).not.toHaveBeenCalled()

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -168,7 +168,7 @@ describe("DataManagementScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Data Management")).toBeTruthy()
+      expect(getByText("Data management")).toBeTruthy()
     })
   })
 
@@ -176,7 +176,7 @@ describe("DataManagementScreen", () => {
     const { getByText, getAllByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Total Locations")).toBeTruthy()
+      expect(getByText("Total locations")).toBeTruthy()
       expect(getByText("105")).toBeTruthy()
       expect(getByText("Sent")).toBeTruthy()
       // "100" appears as stat value and as badge count for Clear Sent History
@@ -194,7 +194,7 @@ describe("DataManagementScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Sync Now")).toBeTruthy()
+      expect(getByText("Sync now")).toBeTruthy()
     })
   })
 
@@ -212,7 +212,7 @@ describe("DataManagementScreen", () => {
     const { getByText, getAllByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Clear Sent History")).toBeTruthy()
+      expect(getByText("Clear sent history")).toBeTruthy()
       // "100" appears both as the Sent stat and as the Clear Sent History badge
       expect(getAllByText("100").length).toBeGreaterThanOrEqual(2)
     })
@@ -222,7 +222,7 @@ describe("DataManagementScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Clear Queue")).toBeTruthy()
+      expect(getByText("Clear queue")).toBeTruthy()
     })
   })
 
@@ -230,7 +230,7 @@ describe("DataManagementScreen", () => {
     const { getByText, getByDisplayValue } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Delete Old Locations")).toBeTruthy()
+      expect(getByText("Delete old locations")).toBeTruthy()
       expect(getByDisplayValue("90")).toBeTruthy()
       expect(getByText("days")).toBeTruthy()
       expect(getByText("Delete")).toBeTruthy()
@@ -241,7 +241,7 @@ describe("DataManagementScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Optimize Database")).toBeTruthy()
+      expect(getByText("Optimize database")).toBeTruthy()
       expect(getByText("Optimize")).toBeTruthy()
     })
   })
@@ -253,7 +253,7 @@ describe("DataManagementScreen", () => {
 
     await waitFor(() => {
       expect(getByText("DEV TOOLS")).toBeTruthy()
-      expect(getByText("Insert Dummy Data")).toBeTruthy()
+      expect(getByText("Insert dummy data")).toBeTruthy()
     })
   })
 
@@ -264,7 +264,7 @@ describe("DataManagementScreen", () => {
 
     await waitFor(() => {
       expect(queryByText("DEV TOOLS")).toBeNull()
-      expect(queryByText("Insert Dummy Data")).toBeNull()
+      expect(queryByText("Insert dummy data")).toBeNull()
     })
   })
 
@@ -276,12 +276,12 @@ describe("DataManagementScreen", () => {
       expect(getAllByText("100").length).toBeGreaterThanOrEqual(1)
     })
 
-    fireEvent.press(getByText("Clear Sent History"))
+    fireEvent.press(getByText("Clear sent history"))
 
     await waitFor(() => {
       expect(mockShowConfirm).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "Clear Sent History",
+          title: "Clear sent history",
           destructive: true
         })
       )
@@ -297,7 +297,7 @@ describe("DataManagementScreen", () => {
       const { queryByText, getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Total Locations")).toBeTruthy()
+        expect(getByText("Total locations")).toBeTruthy()
       })
 
       expect(queryByText("Sent")).toBeNull()
@@ -308,30 +308,30 @@ describe("DataManagementScreen", () => {
       const { queryByText, getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Data Management")).toBeTruthy()
+        expect(getByText("Data management")).toBeTruthy()
       })
 
       expect(queryByText("QUEUE ACTIONS")).toBeNull()
-      expect(queryByText("Sync Now")).toBeNull()
+      expect(queryByText("Sync now")).toBeNull()
     })
 
     it("hides Clear Sent History and Clear Queue actions", async () => {
       const { queryByText, getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Data Management")).toBeTruthy()
+        expect(getByText("Data management")).toBeTruthy()
       })
 
-      expect(queryByText("Clear Sent History")).toBeNull()
-      expect(queryByText("Clear Queue")).toBeNull()
+      expect(queryByText("Clear sent history")).toBeNull()
+      expect(queryByText("Clear queue")).toBeNull()
     })
 
     it("still shows Delete Old Locations and Optimize Database", async () => {
       const { getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Delete Old Locations")).toBeTruthy()
-        expect(getByText("Optimize Database")).toBeTruthy()
+        expect(getByText("Delete old locations")).toBeTruthy()
+        expect(getByText("Optimize database")).toBeTruthy()
       })
     })
 
@@ -348,7 +348,7 @@ describe("DataManagementScreen", () => {
       const { getByText, getAllByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Delete All Locations")).toBeTruthy()
+        expect(getByText("Delete all locations")).toBeTruthy()
         // "105" appears as Total Locations stat and as Delete All badge
         expect(getAllByText("105").length).toBeGreaterThanOrEqual(2)
       })
@@ -361,12 +361,12 @@ describe("DataManagementScreen", () => {
         expect(getAllByText("105").length).toBeGreaterThanOrEqual(1)
       })
 
-      fireEvent.press(getByText("Delete All Locations"))
+      fireEvent.press(getByText("Delete all locations"))
 
       await waitFor(() => {
         expect(mockShowConfirm).toHaveBeenCalledWith(
           expect.objectContaining({
-            title: "Delete All Locations",
+            title: "Delete all locations",
             destructive: true
           })
         )

--- a/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
@@ -220,7 +220,7 @@ describe("ExportLocationsScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Select Format")).toBeTruthy()
+      expect(getByText("Select format")).toBeTruthy()
     })
   })
 
@@ -230,7 +230,7 @@ describe("ExportLocationsScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("No Locations")).toBeTruthy()
+      expect(getByText("No locations")).toBeTruthy()
       expect(getByText("Start tracking to record locations that can be exported.")).toBeTruthy()
     })
   })
@@ -239,7 +239,7 @@ describe("ExportLocationsScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Total Locations")).toBeTruthy()
+      expect(getByText("Total locations")).toBeTruthy()
       expect(getByText("100")).toBeTruthy()
     })
   })
@@ -288,7 +288,7 @@ describe("ExportLocationsScreen", () => {
     fireEvent.press(getByText("Export CSV"))
 
     await waitFor(() => {
-      expect(getByText("Exporting Data")).toBeTruthy()
+      expect(getByText("Exporting data")).toBeTruthy()
     })
   })
 
@@ -298,7 +298,7 @@ describe("ExportLocationsScreen", () => {
     const { getByText, queryByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("No Locations")).toBeTruthy()
+      expect(getByText("No locations")).toBeTruthy()
     })
 
     // totalLocations is 0 so the format cards are not rendered and no export button exists

--- a/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
@@ -221,7 +221,7 @@ describe("GeofenceEditorScreen", () => {
     await waitFor(() => {
       expect(mockShowConfirm).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "Delete Geofence",
+          title: "Delete geofence",
           message: 'Delete "Home"?',
           confirmText: "Delete",
           destructive: true

--- a/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
@@ -229,10 +229,10 @@ describe("GeofenceScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Place Geofence")).toBeTruthy()
+      expect(getByText("Place geofence")).toBeTruthy()
     })
 
-    fireEvent.press(getByText("Place Geofence"))
+    fireEvent.press(getByText("Place geofence"))
 
     expect(mockShowAlert).toHaveBeenCalledWith("Missing Name", "Please enter a name.", "warning")
   })
@@ -241,12 +241,12 @@ describe("GeofenceScreen", () => {
     const { getByText, getByPlaceholderText, getByDisplayValue } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Place Geofence")).toBeTruthy()
+      expect(getByText("Place geofence")).toBeTruthy()
     })
 
     fireEvent.changeText(getByPlaceholderText("Home, Work..."), "Test Zone")
     fireEvent.changeText(getByDisplayValue("50"), "0")
-    fireEvent.press(getByText("Place Geofence"))
+    fireEvent.press(getByText("Place geofence"))
 
     expect(mockShowAlert).toHaveBeenCalledWith("Invalid Radius", "Please enter a valid radius.", "warning")
   })
@@ -255,12 +255,12 @@ describe("GeofenceScreen", () => {
     const { getByText, getByPlaceholderText, getByDisplayValue } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Place Geofence")).toBeTruthy()
+      expect(getByText("Place geofence")).toBeTruthy()
     })
 
     fireEvent.changeText(getByPlaceholderText("Home, Work..."), "Test Zone")
     fireEvent.changeText(getByDisplayValue("50"), "100")
-    fireEvent.press(getByText("Place Geofence"))
+    fireEvent.press(getByText("Place geofence"))
 
     expect(mockShowAlert).not.toHaveBeenCalled()
     expect(getByText("Tap Map to Place...")).toBeTruthy()

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -217,7 +217,7 @@ describe("OfflineMapsScreen", () => {
     fireEvent.changeText(getByPlaceholderText("Home area, Trail..."), "my area")
     fireEvent.press(getByTestId("download-btn"))
     await waitFor(() => {
-      expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Mobile Data" }))
+      expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Mobile data" }))
     })
   })
 
@@ -229,7 +229,7 @@ describe("OfflineMapsScreen", () => {
     fireEvent.changeText(getByPlaceholderText("Home area, Trail..."), "my area")
     fireEvent.press(getByTestId("download-btn"))
     await waitFor(() => {
-      expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Mobile Data" }))
+      expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Mobile data" }))
       expect(mockCreateOfflinePack).not.toHaveBeenCalled()
     })
   })
@@ -307,7 +307,7 @@ describe("OfflineMapsScreen", () => {
     await waitForMapReady(findByText)
     fireEvent.changeText(getByPlaceholderText("Home area, Trail..."), "my area")
     fireEvent.press(getByTestId("download-btn"))
-    fireEvent.press(await findByText("Cancel Download"))
+    fireEvent.press(await findByText("Cancel download"))
     await waitFor(() => {
       expect(mockDeleteOfflineArea).toHaveBeenCalledWith("my area")
       expect(mockRemoveOfflineAreaBounds).toHaveBeenCalledWith("my area")

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -121,12 +121,12 @@ describe("ProfileEditorScreen", () => {
 
   it("renders new profile title", () => {
     const { getByText } = renderNewProfile()
-    expect(getByText("New Profile")).toBeTruthy()
+    expect(getByText("New profile")).toBeTruthy()
   })
 
   it("shows Create Profile button for new profile", () => {
     const { getByText } = renderNewProfile()
-    expect(getByText("Create Profile")).toBeTruthy()
+    expect(getByText("Create profile")).toBeTruthy()
   })
 
   it("shows all condition options", () => {
@@ -168,7 +168,7 @@ describe("ProfileEditorScreen", () => {
   it("shows alert when saving with empty name", async () => {
     const { getByText } = renderNewProfile()
 
-    fireEvent.press(getByText("Create Profile"))
+    fireEvent.press(getByText("Create profile"))
 
     await waitFor(() => {
       expect(mockShowAlert).toHaveBeenCalledWith("Missing Name", "Please enter a profile name.", "warning")
@@ -184,7 +184,7 @@ describe("ProfileEditorScreen", () => {
     // Select speed_above condition - defaults to 30 km/h threshold
     fireEvent.press(getByText("Speed Above"))
 
-    fireEvent.press(getByText("Create Profile"))
+    fireEvent.press(getByText("Create profile"))
 
     await waitFor(() => {
       expect(mockCreateProfile).toHaveBeenCalled()
@@ -200,7 +200,7 @@ describe("ProfileEditorScreen", () => {
     const nameInput = getByDisplayValue("")
     fireEvent.changeText(nameInput, "My Profile")
 
-    fireEvent.press(getByText("Create Profile"))
+    fireEvent.press(getByText("Create profile"))
 
     await waitFor(() => {
       expect(mockCreateProfile).toHaveBeenCalled()
@@ -212,7 +212,7 @@ describe("ProfileEditorScreen", () => {
     const { getByText } = renderNewProfile()
 
     // Try to save with empty name
-    fireEvent.press(getByText("Create Profile"))
+    fireEvent.press(getByText("Create profile"))
 
     await waitFor(() => {
       expect(mockShowAlert).toHaveBeenCalled()
@@ -227,7 +227,7 @@ describe("ProfileEditorScreen", () => {
     const { getByText } = renderEditProfile()
 
     await waitFor(() => {
-      expect(getByText("Edit Profile")).toBeTruthy()
+      expect(getByText("Edit profile")).toBeTruthy()
     })
   })
 
@@ -235,7 +235,7 @@ describe("ProfileEditorScreen", () => {
     const { getByText } = renderEditProfile()
 
     await waitFor(() => {
-      expect(getByText("Save Changes")).toBeTruthy()
+      expect(getByText("Save changes")).toBeTruthy()
     })
   })
 
@@ -262,10 +262,10 @@ describe("ProfileEditorScreen", () => {
     const { getByText } = renderEditProfile()
 
     await waitFor(() => {
-      expect(getByText("Save Changes")).toBeTruthy()
+      expect(getByText("Save changes")).toBeTruthy()
     })
 
-    fireEvent.press(getByText("Save Changes"))
+    fireEvent.press(getByText("Save changes"))
 
     await waitFor(() => {
       expect(mockUpdateProfile).toHaveBeenCalled()
@@ -292,7 +292,7 @@ describe("ProfileEditorScreen", () => {
     const nameInput = getByDisplayValue("")
     fireEvent.changeText(nameInput, "Fail Profile")
 
-    fireEvent.press(getByText("Create Profile"))
+    fireEvent.press(getByText("Create profile"))
 
     await waitFor(() => {
       expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to save profile.", "error")
@@ -322,24 +322,24 @@ describe("ProfileEditorScreen", () => {
     const { getByText, queryByText } = renderNewProfile()
 
     // Charging: both delays
-    expect(getByText("Activation Delay")).toBeTruthy()
-    expect(getByText("Deactivation Delay")).toBeTruthy()
+    expect(getByText("Activation delay")).toBeTruthy()
+    expect(getByText("Deactivation delay")).toBeTruthy()
 
     // Stationary: activation delay only (deactivation is instant via the motion sensor)
     fireEvent.press(getByText("Stationary"))
-    expect(getByText("Activation Delay")).toBeTruthy()
-    expect(queryByText("Deactivation Delay")).toBeNull()
+    expect(getByText("Activation delay")).toBeTruthy()
+    expect(queryByText("Deactivation delay")).toBeNull()
   })
 
   it("hides the movement threshold for a stationary profile and shows a note instead", () => {
     const { getByText, queryByText } = renderNewProfile()
 
     // Default (charging): the field is shown
-    expect(getByText("Movement Threshold")).toBeTruthy()
+    expect(getByText("Movement threshold")).toBeTruthy()
 
     // Stationary: field hidden (the distance filter is forced to 0), note shown instead
     fireEvent.press(getByText("Stationary"))
-    expect(queryByText("Movement Threshold")).toBeNull()
+    expect(queryByText("Movement threshold")).toBeNull()
     expect(getByText(/Movement threshold does not apply/)).toBeTruthy()
   })
 

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -180,7 +180,7 @@ describe("SettingsScreen", () => {
   it("navigates to Tracking Profiles", () => {
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    fireEvent.press(getByText("Tracking Profiles"))
+    fireEvent.press(getByText("Tracking profiles"))
 
     expect(mockNavigate).toHaveBeenCalledWith("Tracking Profiles")
   })
@@ -188,7 +188,7 @@ describe("SettingsScreen", () => {
   it("navigates to Data Management", () => {
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    fireEvent.press(getByText("Data Management"))
+    fireEvent.press(getByText("Data management"))
 
     expect(mockNavigate).toHaveBeenCalledWith("Data Management")
   })
@@ -217,7 +217,7 @@ describe("SettingsScreen", () => {
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
     expect(getByText("Connection")).toBeTruthy()
-    expect(getByText("Tracking Profiles")).toBeTruthy()
-    expect(getByText("Data Management")).toBeTruthy()
+    expect(getByText("Tracking profiles")).toBeTruthy()
+    expect(getByText("Data management")).toBeTruthy()
   })
 })

--- a/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
@@ -107,29 +107,29 @@ describe("SetupImportScreen", () => {
   describe("parsing and validation", () => {
     it("shows error when no config param is provided", () => {
       const { getByText } = renderScreen()
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
       expect(getByText("No configuration data in URL")).toBeTruthy()
     })
 
     it("shows error for invalid base64", () => {
       const { getByText } = renderScreen("!!!not-base64!!!")
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("shows error for valid base64 but invalid JSON", () => {
       const { getByText } = renderScreen(btoa("not json"))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("shows error when config has no valid settings", () => {
       const { getByText } = renderScreen(encode({ unknownKey: "value" }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
       expect(getByText("No valid settings found in configuration")).toBeTruthy()
     })
 
     it("parses valid endpoint config", () => {
       const { getByText } = renderScreen(encode({ endpoint: "https://my-server.com/api" }))
-      expect(getByText("Import Configuration")).toBeTruthy()
+      expect(getByText("Import configuration")).toBeTruthy()
       expect(getByText("Endpoint")).toBeTruthy()
       expect(getByText("https://my-server.com/api")).toBeTruthy()
     })
@@ -161,17 +161,17 @@ describe("SetupImportScreen", () => {
 
     it("rejects invalid interval (negative)", () => {
       const { getByText } = renderScreen(encode({ interval: -5 }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("rejects invalid auth type", () => {
       const { getByText } = renderScreen(encode({ auth: { type: "oauth" } }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("rejects invalid API template", () => {
       const { getByText } = renderScreen(encode({ apiTemplate: "invalid" }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("counts settings correctly in subtitle", () => {
@@ -192,7 +192,7 @@ describe("SetupImportScreen", () => {
       const config = { endpoint: "https://test.com", interval: 15 }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockShowAlert).toHaveBeenCalledWith(
@@ -212,7 +212,7 @@ describe("SetupImportScreen", () => {
       const config = { endpoint: "https://test.com", auth: { type: "bearer", bearerToken: "mytoken" } }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockSaveAuthConfig).toHaveBeenCalledWith(
@@ -224,7 +224,7 @@ describe("SetupImportScreen", () => {
     it("marks hasCompletedSetup as true", async () => {
       const { getByText } = renderScreen(encode({ endpoint: "https://test.com" }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockSetSettings).toHaveBeenCalledWith(expect.objectContaining({ hasCompletedSetup: true }))
@@ -235,7 +235,7 @@ describe("SetupImportScreen", () => {
       const config = { interval: 15, distance: 3, syncInterval: 120 }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockSetSettings).toHaveBeenCalledWith(expect.objectContaining({ syncPreset: "custom" }))
@@ -252,7 +252,7 @@ describe("SetupImportScreen", () => {
       }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockSetSettings).toHaveBeenCalledWith(expect.objectContaining({ syncPreset: "balanced" }))
@@ -263,7 +263,7 @@ describe("SetupImportScreen", () => {
       mockSetSettings.mockRejectedValueOnce(new Error("fail"))
       const { getByText } = renderScreen(encode({ endpoint: "https://test.com" }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to apply configuration. Please try again.", "error")
@@ -280,7 +280,7 @@ describe("SetupImportScreen", () => {
 
     it("navigates to Dashboard on Go Back (error state)", () => {
       const { getByText } = renderScreen()
-      fireEvent.press(getByText("Go Back"))
+      fireEvent.press(getByText("Go back"))
       expect(mockNavigate).toHaveBeenCalledWith("Dashboard")
     })
   })
@@ -297,12 +297,12 @@ describe("SetupImportScreen", () => {
 
     it("rejects a geofence missing required fields", () => {
       const { getByText } = renderScreen(encode({ geofences: [{ name: "X", lat: 52.5 }] }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("rejects a geofence with non-positive radius", () => {
       const { getByText } = renderScreen(encode({ geofences: [{ ...validGeofence, radius: 0 }] }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("skips invalid entries but keeps valid ones", () => {
@@ -317,7 +317,7 @@ describe("SetupImportScreen", () => {
     it("calls createGeofence on apply with defaults filled in", async () => {
       const { getByText } = renderScreen(encode({ geofences: [validGeofence] }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateGeofence).toHaveBeenCalledTimes(1)
@@ -354,7 +354,7 @@ describe("SetupImportScreen", () => {
       }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateGeofence).toHaveBeenCalledTimes(1)
@@ -381,7 +381,7 @@ describe("SetupImportScreen", () => {
       }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateGeofence).toHaveBeenCalledTimes(2)
@@ -393,7 +393,7 @@ describe("SetupImportScreen", () => {
     it("does not call createGeofence when no geofences in config", async () => {
       const { getByText } = renderScreen(encode({ endpoint: "https://test.com" }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockShowAlert).toHaveBeenCalledWith("Configuration Applied", expect.any(String), "success")
@@ -426,7 +426,7 @@ describe("SetupImportScreen", () => {
       mockGetGeofences.mockResolvedValueOnce([{ id: 7, name: "Home", lat: 0, lon: 0, radius: 50, enabled: true }])
       const { getByText } = renderScreen(encode({ geofences: [validGeofence] }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateGeofence).toHaveBeenCalledTimes(1)
@@ -443,7 +443,7 @@ describe("SetupImportScreen", () => {
       const { getByText, getByTestId } = renderScreen(encode({ geofences: [validGeofence] }))
 
       fireEvent(getByTestId("replace-imports-switch"), "valueChange", true)
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateGeofence).toHaveBeenCalledTimes(1)
@@ -457,7 +457,7 @@ describe("SetupImportScreen", () => {
       const { getByText, getByTestId } = renderScreen(encode({ geofences: [validGeofence] }))
 
       fireEvent(getByTestId("replace-imports-switch"), "valueChange", true)
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateGeofence).toHaveBeenCalledTimes(1)
@@ -479,7 +479,7 @@ describe("SetupImportScreen", () => {
       const { getByText, getByTestId } = renderScreen(encode(config))
 
       fireEvent(getByTestId("replace-imports-switch"), "valueChange", true)
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateGeofence).toHaveBeenCalledTimes(2)
@@ -519,19 +519,19 @@ describe("SetupImportScreen", () => {
 
     it("rejects a profile missing name", () => {
       const { getByText } = renderScreen(encode({ profiles: [{ ...validProfile, name: "" }] }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("rejects a profile with unknown condition type", () => {
       const config = { profiles: [{ ...validProfile, condition: { type: "bogus" } }] }
       const { getByText } = renderScreen(encode(config))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("rejects a speed profile missing speedThreshold", () => {
       const config = { profiles: [{ ...validProfile, condition: { type: "speed_above" } }] }
       const { getByText } = renderScreen(encode(config))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("accepts a non-speed condition without speedThreshold", () => {
@@ -544,13 +544,13 @@ describe("SetupImportScreen", () => {
 
     it("rejects a profile with interval < 1", () => {
       const { getByText } = renderScreen(encode({ profiles: [{ ...validProfile, interval: 0 }] }))
-      expect(getByText("Invalid Configuration")).toBeTruthy()
+      expect(getByText("Invalid configuration")).toBeTruthy()
     })
 
     it("calls createProfile on apply with all fields", async () => {
       const { getByText } = renderScreen(encode({ profiles: [validProfile] }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateProfile).toHaveBeenCalledTimes(1)
@@ -578,7 +578,7 @@ describe("SetupImportScreen", () => {
       }
       const { getByText } = renderScreen(encode({ profiles: [minimal] }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateProfile).toHaveBeenCalledTimes(1)
@@ -609,7 +609,7 @@ describe("SetupImportScreen", () => {
       }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateProfile).toHaveBeenCalledTimes(1)
@@ -631,7 +631,7 @@ describe("SetupImportScreen", () => {
       }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateProfile).toHaveBeenCalledTimes(1)
@@ -645,7 +645,7 @@ describe("SetupImportScreen", () => {
       }
       const { getByText } = renderScreen(encode(config))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateProfile).toHaveBeenCalledTimes(2)
@@ -657,7 +657,7 @@ describe("SetupImportScreen", () => {
     it("does not call createProfile when no profiles in config", async () => {
       const { getByText } = renderScreen(encode({ endpoint: "https://test.com" }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockShowAlert).toHaveBeenCalledWith("Configuration Applied", expect.any(String), "success")
@@ -693,7 +693,7 @@ describe("SetupImportScreen", () => {
       const { getByText, getByTestId } = renderScreen(encode({ profiles: [validProfile] }))
 
       fireEvent(getByTestId("replace-imports-switch"), "valueChange", true)
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateProfile).toHaveBeenCalledTimes(1)
@@ -718,7 +718,7 @@ describe("SetupImportScreen", () => {
       ])
       const { getByText } = renderScreen(encode({ profiles: [validProfile] }))
 
-      fireEvent.press(getByText("Apply Configuration"))
+      fireEvent.press(getByText("Apply configuration"))
 
       await waitFor(() => {
         expect(mockCreateProfile).toHaveBeenCalledTimes(1)

--- a/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
@@ -161,10 +161,10 @@ describe("TrackingProfilesScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Create Profile")).toBeTruthy()
+      expect(getByText("Create profile")).toBeTruthy()
     })
 
-    fireEvent.press(getByText("Create Profile"))
+    fireEvent.press(getByText("Create profile"))
 
     expect(mockNavigate).toHaveBeenCalledWith("Profile Editor", {})
   })
@@ -191,7 +191,7 @@ describe("TrackingProfilesScreen", () => {
     fireEvent.press(getByTestId("delete-profile-1"))
 
     await waitFor(() => {
-      expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Delete Profile" }))
+      expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Delete profile" }))
     })
 
     await waitFor(() => {


### PR DESCRIPTION
Android and Material specify sentence case for UI text; the app shipped Title Case in 130 places. Headings, row labels, button titles, dialog titles and the sixteen SCREEN_CONFIG titles now read as sentences. Acronyms and product names keep their capitals, so API, mTLS, GPS, GeoJSON and About Colota are unchanged.

Route names are deliberately excluded. Several of them are the same strings as their display titles, so a blind recase would have rewritten every navigate() call and the colota://setup deep link; the display title and the route key are independent and only the title moves.

This also settles the Accuracy Threshold and Accuracy threshold split, which was two strings for one label.
