### PR TITLE
refactor(ui): finish the sentence case sweep, and stop the labels shouting

### DIFF
--- a/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
+++ b/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
@@ -38,7 +38,7 @@ export function CoordinateDisplay() {
 
   return (
     <>
-      <SectionTitle>CURRENT LOCATION DATA</SectionTitle>
+      <SectionTitle>Current location data</SectionTitle>
       <View style={styles.container}>
         {/* First Row: Latitude and Longitude */}
         <View style={styles.row}>
@@ -67,9 +67,7 @@ const styles = StyleSheet.create({
   coordLabel: {
     fontSize: fontSizes.micro,
     ...fonts.semiBold,
-    marginBottom: space.xs,
-    letterSpacing: 0.5,
-    textTransform: "uppercase"
+    marginBottom: space.xs
   },
   coordValue: {
     fontSize: fontSizes.input,

--- a/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
+++ b/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
@@ -26,7 +26,7 @@ export const DatabaseStatistics = React.memo(function DatabaseStatistics({ stats
     <>
       {/* Database Statistics */}
       <View style={styles.metricsSection}>
-        <SectionTitle>DATABASE STATISTICS</SectionTitle>
+        <SectionTitle>Database statistics</SectionTitle>
         {!isOfflineMode ? (
           <View style={styles.statsGrid}>
             <Card variant="elevated" style={styles.statCard}>
@@ -87,9 +87,7 @@ const styles = StyleSheet.create({
   statLabel: {
     fontSize: fontSizes.micro,
     ...fonts.semiBold,
-    marginBottom: 6,
-    letterSpacing: 0.5,
-    textTransform: "uppercase"
+    marginBottom: 6
   },
   statValue: {
     fontSize: fontSizes.statValue,

--- a/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
@@ -56,7 +56,7 @@ describe("DatabaseStatistics", () => {
   it("shows section title", () => {
     const { getByText } = render(<DatabaseStatistics stats={baseStats} />)
 
-    expect(getByText("DATABASE STATISTICS")).toBeTruthy()
+    expect(getByText("Database statistics")).toBeTruthy()
   })
 
   describe("online mode (default)", () => {

--- a/apps/mobile/src/components/features/inspector/LocationTable.tsx
+++ b/apps/mobile/src/components/features/inspector/LocationTable.tsx
@@ -179,8 +179,7 @@ const styles = StyleSheet.create({
   },
   headerText: {
     fontSize: fontSizes.small,
-    ...fonts.bold,
-    textTransform: "uppercase"
+    ...fonts.bold
   },
   row: {
     flexDirection: "row",

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -486,7 +486,6 @@ const styles = StyleSheet.create({
   },
   popupLabel: {
     fontSize: fontSizes.small,
-    textTransform: "uppercase",
     fontWeight: "600"
   },
   popupValue: {

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -64,7 +64,7 @@ export function ConnectionSettings({
             const hasEndpoint = !!settings.endpoint
             const buttons = [
               ...(hasEndpoint ? [{ text: "Sync first", style: "primary" as const }] : []),
-              { text: "Keep in Queue", style: "secondary" as const },
+              { text: "Keep in queue", style: "secondary" as const },
               { text: "Cancel", style: "secondary" as const }
             ]
             const choice = await showChoice({
@@ -292,7 +292,7 @@ export function ConnectionSettings({
               onPress={() => navigation.navigate("Auth Settings")}
             >
               <View style={styles.linkContent}>
-                <Text style={[styles.linkLabel, { color: colors.text }]}>Authentication & Headers</Text>
+                <Text style={[styles.linkLabel, { color: colors.text }]}>Authentication & headers</Text>
                 <Text style={[styles.linkSub, { color: colors.textSecondary }]}>
                   Basic auth, bearer tokens, custom headers
                 </Text>

--- a/apps/mobile/src/components/features/settings/PresetOption.tsx
+++ b/apps/mobile/src/components/features/settings/PresetOption.tsx
@@ -61,7 +61,11 @@ export function PresetOption({ preset, isSelected, isOfflineMode, onSelect }: Pr
                 {config.label}
               </Text>
               {showRecommendedBadge && (
-                <Badge icon={<Check size={size.icon.sm} color={colors.success} />} label="Recommended" color={colors.success} />
+                <Badge
+                  icon={<Check size={size.icon.sm} color={colors.success} />}
+                  label="Recommended"
+                  color={colors.success}
+                />
               )}
               {showWarningBadge && (
                 <Badge

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -197,8 +197,6 @@ const styles = StyleSheet.create({
   statLabel: {
     fontSize: fontSizes.caption,
     ...fonts.semiBold,
-    textTransform: "uppercase",
-    letterSpacing: 0.8,
     marginBottom: space.sm
   },
   statValue: {

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -8,7 +8,14 @@ import { Text, StyleSheet, Switch, View, Pressable, TextInput, AppState } from "
 import { Lightbulb, ChevronDown, ChevronUp } from "lucide-react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
 import { fonts, fontSizes } from "../../../styles/typography"
-import { OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, size, space } from "../../../constants"
+import {
+  OVERLAND_BATCH_MAX,
+  OVERLAND_BATCH_MIN,
+  SYNC_INTERVAL_LABELS,
+  SYNC_INTERVAL_PRESETS,
+  size,
+  space
+} from "../../../constants"
 import { SectionTitle, Card, Divider, NumericInput, SettingRow } from "../../index"
 import { PresetOption } from "./PresetOption"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
@@ -520,8 +527,6 @@ const styles = StyleSheet.create({
   paramGroupTitle: {
     fontSize: fontSizes.description,
     ...fonts.bold,
-    textTransform: "uppercase",
-    letterSpacing: 1,
     marginBottom: space.lg,
     opacity: 0.6
   },

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -157,7 +157,7 @@ describe("ConnectionSettings", () => {
     it("shows Authentication & Headers link", () => {
       const { getByText } = renderComponent()
 
-      expect(getByText("Authentication & Headers")).toBeTruthy()
+      expect(getByText("Authentication & headers")).toBeTruthy()
     })
 
     it("shows HTTPS badge for https endpoint", () => {
@@ -189,7 +189,7 @@ describe("ConnectionSettings", () => {
     it("hides Authentication & Headers link", () => {
       const { queryByText } = renderComponent({ isOfflineMode: true })
 
-      expect(queryByText("Authentication & Headers")).toBeNull()
+      expect(queryByText("Authentication & headers")).toBeNull()
     })
   })
 

--- a/apps/mobile/src/components/ui/SectionTitle.tsx
+++ b/apps/mobile/src/components/ui/SectionTitle.tsx
@@ -28,9 +28,7 @@ export function SectionTitle({ children, style, color }: SectionTitleProps) {
 const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: fontSizes.small,
-    textTransform: "uppercase",
     ...fonts.bold,
-    letterSpacing: 1.2,
     marginBottom: space.md,
     paddingHorizontal: space.xs
   }

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -306,7 +306,7 @@ export function AboutScreen({}: ScreenProps) {
           <Divider />
           <LinkRow
             icon={MessageCircle}
-            title="Report a Bug"
+            title="Report a bug"
             subtitle="github.com/dietrichmax/colota/issues"
             url={ISSUES_URL}
             colors={colors}
@@ -370,7 +370,11 @@ export function AboutScreen({}: ScreenProps) {
                 ]}
                 onPress={handleCopyDebugInfo}
               >
-                {copied ? <Check size={size.icon.sm} color={colors.success} /> : <Copy size={size.icon.sm} color={colors.primaryDark} />}
+                {copied ? (
+                  <Check size={size.icon.sm} color={colors.success} />
+                ) : (
+                  <Copy size={size.icon.sm} color={colors.primaryDark} />
+                )}
                 <Text style={[styles.copyButtonText, { color: copied ? colors.success : colors.primaryDark }]}>
                   {copied ? "Copied!" : "Copy debug info"}
                 </Text>

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -474,7 +474,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
 
         {/* Template Selector */}
         <View style={styles.section}>
-          <SectionTitle>BACKEND TEMPLATE</SectionTitle>
+          <SectionTitle>Backend template</SectionTitle>
           <ChipGroup
             options={TEMPLATE_OPTIONS}
             selected={localTemplate}
@@ -492,7 +492,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Overland template is POST-only by spec; no need to expose the choice */}
         {localTemplate !== "overland" && (
           <View style={styles.section}>
-            <SectionTitle>HTTP METHOD</SectionTitle>
+            <SectionTitle>HTTP method</SectionTitle>
             <ChipGroup
               options={HTTP_METHOD_OPTIONS}
               selected={localHttpMethod}
@@ -510,7 +510,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Dawarich Mode Selector (Dawarich template only) */}
         {showDawarichChip && (
           <View style={styles.section}>
-            <SectionTitle>DAWARICH MODE</SectionTitle>
+            <SectionTitle>Dawarich mode</SectionTitle>
             <ChipGroup
               options={DAWARICH_MODE_OPTIONS}
               selected={localDawarichMode}
@@ -539,13 +539,13 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Field Mapping Section */}
         <View style={styles.fieldsSection}>
           <View style={styles.sectionHeader}>
-            <SectionTitle>FIELD MAPPINGS</SectionTitle>
+            <SectionTitle>Field mappings</SectionTitle>
             {hasModifications && (
               <Pressable
                 onPress={handleResetAll}
                 style={({ pressed }) => [styles.resetAllButton, pressed && { opacity: colors.pressedOpacity }]}
               >
-                <Text style={[styles.resetAllText, { color: colors.primaryDark }]}>RESET ALL</Text>
+                <Text style={[styles.resetAllText, { color: colors.primaryDark }]}>Reset all</Text>
               </Pressable>
             )}
           </View>
@@ -623,7 +623,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {/* Custom Fields Section */}
         <View style={styles.fieldsSection}>
           <View style={styles.sectionHeader}>
-            <SectionTitle>CUSTOM FIELDS</SectionTitle>
+            <SectionTitle>Custom fields</SectionTitle>
           </View>
 
           <View style={[styles.fieldsCard, { backgroundColor: colors.card, borderColor: colors.border }]}>

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -156,7 +156,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
       >
         {/* Header */}
         <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>Authentication & Headers</Text>
+          <Text style={[styles.title, { color: colors.text }]}>Authentication & headers</Text>
           <Text style={[styles.subtitle, { color: colors.textSecondary }]}>Secure your endpoint connection</Text>
         </View>
 

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -760,8 +760,6 @@ const styles = StyleSheet.create({
   fieldLabel: {
     fontSize: fontSizes.caption,
     ...fonts.semiBold,
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
     marginTop: space.md,
     marginBottom: space.sm
   },

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -337,7 +337,7 @@ export function BackupRestoreScreen({}: Props) {
         </View>
 
         <View style={styles.section}>
-          <SectionTitle>Restore from Backup</SectionTitle>
+          <SectionTitle>Restore from backup</SectionTitle>
           <Card>
             <Text style={[styles.intro, { color: colors.textSecondary }]}>
               Replace all current data with a previous .colota backup file. You'll be asked for the backup password

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -278,7 +278,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
           {/* Stats */}
           <View style={styles.section}>
-            <SectionTitle>DATABASE STATISTICS</SectionTitle>
+            <SectionTitle>Database statistics</SectionTitle>
             <Card>
               {[
                 ["Total locations", stats.total.toLocaleString(), colors.text],
@@ -305,7 +305,7 @@ export function DataManagementScreen({}: ScreenProps) {
           {/* Queue Actions */}
           {!isOfflineMode && (
             <View style={styles.section}>
-              <SectionTitle>QUEUE ACTIONS</SectionTitle>
+              <SectionTitle>Queue actions</SectionTitle>
               <Card>
                 <Button onPress={handleManualFlush} disabled={isProcessing || stats.queued === 0} title="Sync now" />
                 <Text style={[styles.hint, { color: colors.textLight }]}>
@@ -319,7 +319,7 @@ export function DataManagementScreen({}: ScreenProps) {
 
           {/* Cleanup Actions */}
           <View style={styles.section}>
-            <SectionTitle>CLEANUP ACTIONS</SectionTitle>
+            <SectionTitle>Cleanup actions</SectionTitle>
             <Card>
               {!isOfflineMode ? (
                 <>
@@ -415,7 +415,7 @@ export function DataManagementScreen({}: ScreenProps) {
           {/* Dev Tools */}
           {debugMode && (
             <View style={styles.section}>
-              <SectionTitle>DEV TOOLS</SectionTitle>
+              <SectionTitle>Dev tools</SectionTitle>
               <Card>
                 <View style={styles.actionColumn}>
                   <Text style={[styles.actionLabel, { color: colors.text }]}>Insert dummy data</Text>

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -174,8 +174,6 @@ const styles = StyleSheet.create({
   statLabel: {
     fontSize: fontSizes.caption,
     ...fonts.semiBold,
-    textTransform: "uppercase",
-    letterSpacing: 0.8,
     marginBottom: space.sm
   },
   statValue: {

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -376,7 +376,13 @@ const styles = StyleSheet.create({
   numInput: { width: 80, textAlign: "center" },
   toggleRow: { paddingVertical: 10 },
   disabledRow: { opacity: 0.45 },
-  nestedSetting: { marginLeft: space.lg, paddingLeft: space.md, borderLeftWidth: 3, marginTop: space.xs, marginBottom: space.xs },
+  nestedSetting: {
+    marginLeft: space.lg,
+    paddingLeft: space.md,
+    borderLeftWidth: 3,
+    marginTop: space.xs,
+    marginBottom: space.xs
+  },
   combinedNote: {
     marginTop: space.sm,
     paddingTop: space.md,

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -13,7 +13,16 @@ import { useTracking, useCoords } from "../contexts/TrackingProvider"
 import { fontSizes, fonts } from "../styles/typography"
 import { ChevronRight, Wifi, PersonStanding, MapPinHouse, Share2 } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
-import { DEFAULT_MAP_ZOOM, GEOFENCE_ZOOM_PADDING, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM, WORLD_MAP_ZOOM, size, space } from "../constants"
+import {
+  DEFAULT_MAP_ZOOM,
+  GEOFENCE_ZOOM_PADDING,
+  HIT_SLOP_MD,
+  MAP_ANIMATION_DURATION_MS,
+  MAX_MAP_ZOOM,
+  WORLD_MAP_ZOOM,
+  size,
+  space
+} from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { buildGeofencesGeoJSON } from "../components/features/map/mapUtils"
@@ -401,9 +410,7 @@ const styles = StyleSheet.create({
   label: {
     fontSize: fontSizes.caption,
     ...fonts.semiBold,
-    marginBottom: 6,
-    textTransform: "uppercase",
-    letterSpacing: 0.5
+    marginBottom: 6
   },
   input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input },
   inputCentered: {

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -237,7 +237,7 @@ export function ImportLocationsScreen({}: ScreenProps) {
 
         {/* Import action */}
         <View style={styles.section}>
-          <SectionTitle>Import from File</SectionTitle>
+          <SectionTitle>Import from file</SectionTitle>
           <Card>
             <Text style={[styles.intro, { color: colors.textSecondary }]}>
               Merge location history from external files into your Colota database. Duplicates are skipped
@@ -280,8 +280,6 @@ const styles = StyleSheet.create({
   statLabel: {
     fontSize: fontSizes.caption,
     ...fonts.semiBold,
-    textTransform: "uppercase",
-    letterSpacing: 0.8,
     marginBottom: space.sm
   },
   statValue: {
@@ -327,8 +325,7 @@ const styles = StyleSheet.create({
   },
   extensionText: {
     fontSize: fontSizes.micro,
-    ...fonts.bold,
-    letterSpacing: 0.3
+    ...fonts.bold
   },
   formatDescription: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -297,8 +297,7 @@ const styles = StyleSheet.create({
   },
   summaryLabel: {
     fontSize: fontSizes.micro,
-    ...fonts.semiBold,
-    textTransform: "uppercase"
+    ...fonts.semiBold
   },
   dayCard: {
     marginBottom: space.sm,

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -15,7 +15,14 @@ import { fontSizes, fonts } from "../styles/typography"
 import { X, CircleCheckBig, RefreshCw, TriangleAlert } from "lucide-react-native"
 import { Container, SectionTitle, Card } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
-import { DEFAULT_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT, WORLD_MAP_ZOOM, size, space } from "../constants"
+import {
+  DEFAULT_MAP_ZOOM,
+  MAP_ANIMATION_DURATION_MS,
+  MAP_STYLE_URL_LIGHT,
+  WORLD_MAP_ZOOM,
+  size,
+  space
+} from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { logger } from "../utils/logger"
@@ -892,9 +899,7 @@ const styles = StyleSheet.create({
   label: {
     fontSize: fontSizes.caption,
     ...fonts.semiBold,
-    marginBottom: 6,
-    textTransform: "uppercase",
-    letterSpacing: 0.5
+    marginBottom: 6
   },
   input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input },
   sizeEstimate: { fontSize: fontSizes.caption, ...fonts.regular, marginBottom: space.md },
@@ -922,7 +927,13 @@ const styles = StyleSheet.create({
   areaName: { fontSize: fontSizes.input, ...fonts.semiBold },
   areaSub: { fontSize: fontSizes.caption },
   areaSubDate: { fontSize: fontSizes.small, ...fonts.regular, marginTop: 2, opacity: 0.7 },
-  savedAreasMeta: { fontSize: fontSizes.caption, ...fonts.regular, marginTop: 2, marginBottom: space.md, paddingHorizontal: space.xs },
+  savedAreasMeta: {
+    fontSize: fontSizes.caption,
+    ...fonts.regular,
+    marginTop: 2,
+    marginBottom: space.md,
+    paddingHorizontal: space.xs
+  },
   actionBtns: { flexDirection: "row", gap: 6, alignItems: "center" },
   actionBtn: {
     width: 32,

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -15,7 +15,16 @@ import { Container, SectionTitle, Card, Divider, SettingRow, NumericInput, Field
 import { Check } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
-import { MS_TO_KMH, PROFILE_CONDITIONS, STATIONARY_MAX_INTERVAL_SECONDS, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, defaultProfileDelays, size, space } from "../constants"
+import {
+  MS_TO_KMH,
+  PROFILE_CONDITIONS,
+  STATIONARY_MAX_INTERVAL_SECONDS,
+  SYNC_INTERVAL_LABELS,
+  SYNC_INTERVAL_PRESETS,
+  defaultProfileDelays,
+  size,
+  space
+} from "../constants"
 import type { RootScreenProps } from "../types/navigation"
 import { radius } from "@colota/shared"
 
@@ -494,9 +503,7 @@ const styles = StyleSheet.create({
   label: {
     fontSize: fontSizes.caption,
     ...fonts.semiBold,
-    marginBottom: 6,
-    textTransform: "uppercase",
-    letterSpacing: 0.5
+    marginBottom: 6
   },
   input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input, ...fonts.regular },
   numInput: {

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -127,7 +127,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-tracking-sync"
               icon={Navigation}
-              label="Tracking & Sync"
+              label="Tracking & sync"
               sub={syncSummary}
               onPress={() => navigation.navigate("Tracking & Sync")}
             />
@@ -205,7 +205,7 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-backup-restore"
               icon={ShieldCheck}
-              label="Backup & Restore"
+              label="Backup & restore"
               sub="Encrypted backup of all your data"
               onPress={() => navigation.navigate("Backup & Restore")}
             />

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -256,7 +256,7 @@ const styles = StyleSheet.create({
   nameRow: { flexDirection: "row", alignItems: "center", gap: space.sm, marginBottom: 2 },
   name: { fontSize: fontSizes.input, ...fonts.semiBold },
   activeBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },
-  activeBadgeText: { fontSize: fontSizes.micro, ...fonts.semiBold, textTransform: "uppercase" },
+  activeBadgeText: { fontSize: fontSizes.micro, ...fonts.semiBold },
   priorityBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },
   priorityText: { fontSize: fontSizes.micro, ...fonts.semiBold },
   condition: { fontSize: fontSizes.description, ...fonts.medium, marginBottom: 2 },

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -495,8 +495,7 @@ const styles = StyleSheet.create({
   },
   statLabel: {
     fontSize: fontSizes.small,
-    ...fonts.regular,
-    textTransform: "uppercase"
+    ...fonts.regular
   },
   chartCard: {
     padding: space.md

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -241,7 +241,7 @@ describe("ApiSettingsScreen", () => {
       const latInput = getByDisplayValue("lat")
       fireEvent.changeText(latInput, "latitude")
 
-      expect(getByText("RESET ALL")).toBeTruthy()
+      expect(getByText("Reset all")).toBeTruthy()
     })
   })
 

--- a/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
@@ -112,7 +112,7 @@ describe("AuthSettingsScreen", () => {
       const { getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Authentication & Headers")).toBeTruthy()
+        expect(getByText("Authentication & headers")).toBeTruthy()
       })
     })
   })

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -252,7 +252,7 @@ describe("DataManagementScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("DEV TOOLS")).toBeTruthy()
+      expect(getByText("Dev tools")).toBeTruthy()
       expect(getByText("Insert dummy data")).toBeTruthy()
     })
   })
@@ -263,7 +263,7 @@ describe("DataManagementScreen", () => {
     const { queryByText } = renderScreen()
 
     await waitFor(() => {
-      expect(queryByText("DEV TOOLS")).toBeNull()
+      expect(queryByText("Dev tools")).toBeNull()
       expect(queryByText("Insert dummy data")).toBeNull()
     })
   })
@@ -311,7 +311,7 @@ describe("DataManagementScreen", () => {
         expect(getByText("Data management")).toBeTruthy()
       })
 
-      expect(queryByText("QUEUE ACTIONS")).toBeNull()
+      expect(queryByText("Queue actions")).toBeNull()
       expect(queryByText("Sync now")).toBeNull()
     })
 

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -172,7 +172,7 @@ describe("SettingsScreen", () => {
   it("navigates to Tracking & Sync", () => {
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    fireEvent.press(getByText("Tracking & Sync"))
+    fireEvent.press(getByText("Tracking & sync"))
 
     expect(mockNavigate).toHaveBeenCalledWith("Tracking & Sync")
   })


### PR DESCRIPTION
Seven labels joined by a connector escaped the recase in #675, because the pattern required consecutive capitalised words: Backup & Restore, Tracking & Sync, Authentication & Headers, Keep in Queue, Report a Bug, Restore from Backup and Import from File. Welcome to Colota and About Colota keep their capitals, because Colota is a name.

The larger half is that a fifth of #675 never reached the screen. SectionTitle carried textTransform uppercase, so every heading it wraps rendered in caps whatever the source said, and Select format still read SELECT FORMAT. That transform and the 1.2 tracking that made caps legible are gone, along with the same pair on sixteen other label styles and the profile Active badge. Eleven rules lose the positive tracking that only ever existed to space out capitals; the negative tracking on display figures stays, because that is type fitting rather than shouting.

Seventeen strings were capitals in the source rather than in a style, so recasing them is the only way they change: CURRENT LOCATION DATA, DATABASE STATISTICS, QUEUE ACTIONS, CLEANUP ACTIONS, DEV TOOLS, FIELD MAPPINGS, BACKEND TEMPLATE, HTTP METHOD, DAWARICH MODE, CUSTOM FIELDS and RESET ALL. Acronyms keep their case.

All-caps headers are the Material 2 idiom; Material 3 and Android's writing style both specify sentence case. The brand colour on section headings is left alone, because that is a palette decision.
