### PR TITLE
refactor(ui): size section headings for sentence case

### DIFF
--- a/apps/mobile/src/components/ui/SectionTitle.tsx
+++ b/apps/mobile/src/components/ui/SectionTitle.tsx
@@ -27,8 +27,8 @@ export function SectionTitle({ children, style, color }: SectionTitleProps) {
 
 const styles = StyleSheet.create({
   sectionTitle: {
-    fontSize: fontSizes.small,
-    ...fonts.bold,
+    fontSize: fontSizes.heading,
+    ...fonts.semiBold,
     marginBottom: space.md,
     paddingHorizontal: space.xs
   }


### PR DESCRIPTION
SectionTitle was 11px bold, which read as a label only because it was rendered in capitals with 1.2 tracking. #676 removed the capitals and left the size, so a heading now sits smaller than the 15 and 16 rows inside the card it titles.

It moves to the heading step at 18. Not the 20 of cardTitle, which is for one-off moments like a modal title or an empty state, because this repeats several times down a screen. The weight drops from bold to semiBold for the same reason.
