### PR TITLE
test(theme): guard the constants, and delete the dead colour tokens

### DIFF
--- a/apps/docs/src/theme/Root.tsx
+++ b/apps/docs/src/theme/Root.tsx
@@ -14,9 +14,6 @@ function colorVars(colors: ThemeColors) {
     --ifm-color-primary-dark: ${colors.primaryDark};
     --ifm-color-primary-darker: ${colors.primaryDark};
     --ifm-color-primary-darkest: ${colors.primaryDark};
-    --ifm-color-primary-light: ${colors.primaryLight};
-    --ifm-color-primary-lighter: ${colors.primaryLight};
-    --ifm-color-primary-lightest: ${colors.primaryLight};
     --ifm-background-color: ${colors.background};
     --ifm-font-color-base: ${colors.text};
     --ifm-font-color-secondary: ${colors.textSecondary};

--- a/apps/mobile/src/__tests__/designSystemGuard.test.ts
+++ b/apps/mobile/src/__tests__/designSystemGuard.test.ts
@@ -1,0 +1,85 @@
+// The app's tsconfig exposes only the jest globals on purpose, so nothing in src can reach
+// for node. Reading the tree is what this file does, so it declares the corner it needs
+// rather than opening node's globals to every screen.
+declare const __dirname: string
+
+type Entry = { name: string; isDirectory: () => boolean }
+const fs: {
+  readdirSync: (dir: string, options: { withFileTypes: true }) => Entry[]
+  readFileSync: (file: string, encoding: "utf8") => string
+} = require("fs")
+const path: {
+  join: (...parts: string[]) => string
+} = require("path")
+
+/**
+ * A screen writing a number a constant already names forks the system quietly: it renders,
+ * nothing fails, and the next change to that constant misses it.
+ *
+ * Every rule here fires only on a value that HAS a constant. A radius of 10 or an icon at 28
+ * is not a violation, because nothing names those; they are numbers with no home, and rounding
+ * them onto a scale would move the design rather than tidy it. That is why this file needs no
+ * allowlist: the rules describe what the constants cover, so anything they flag is genuinely a
+ * literal written in place of a name.
+ *
+ * Widening a scale means widening the matching rule here, or the new step goes unenforced.
+ */
+const SRC = path.join(__dirname, "..")
+const ROOTS = ["screens", "components/features", "utils"]
+
+const RULES = [
+  { name: "spacing", pattern: /(?:padding|margin|gap|rowGap|columnGap)[A-Za-z]*:\s*(?:4|8|12|16|24|32)\b/ },
+  { name: "radius", pattern: /borderRadius:\s*(?:4|8|12|16)\b/ },
+  { name: "fontSize", pattern: /fontSize:\s*(?:10|11|12|13|14|15|16|18|20|24|28)\b/ },
+  { name: "iconSize", pattern: /size=\{(?:16|20|24)\}/ }
+] as const
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(path.join(SRC, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") walk(rel)
+      } else if (/\.tsx?$/.test(entry.name)) {
+        found.push(rel)
+      }
+    }
+  }
+  ROOTS.forEach(walk)
+  return found.sort()
+}
+
+function violations(file: string): string[] {
+  const source = fs.readFileSync(path.join(SRC, file), "utf8")
+  return RULES.filter((rule) => rule.pattern.test(source)).map((rule) => rule.name)
+}
+
+describe("design system guard", () => {
+  const files = sourceFiles()
+
+  it("scans every screen, feature component and util", () => {
+    expect(files.length).toBeGreaterThan(0)
+    expect(files).toContain("screens/DashboardScreen.tsx")
+    expect(files).toContain("components/features/inspector/TrackMap.tsx")
+    expect(files).toContain("utils/trips.ts")
+  })
+
+  it("flags a value a constant names, and ignores one no constant covers", () => {
+    const caught = (source: string) => RULES.filter((rule) => rule.pattern.test(source)).map((rule) => rule.name)
+
+    expect(caught("{ padding: 16, borderRadius: 8, fontSize: 13 }")).toEqual(["spacing", "radius", "fontSize"])
+    expect(caught("{ padding: space.lg, borderRadius: radius.sm, fontSize: fontSizes.description }")).toEqual([])
+    expect(caught("<Icon size={20} />")).toEqual(["iconSize"])
+    expect(caught("<Icon size={size.icon.md} />")).toEqual([])
+    // No constant names these, so they are not drift and rounding them would move the design.
+    expect(caught("{ padding: 10, marginTop: 20, borderRadius: 10 }")).toEqual([])
+    expect(caught("<Icon size={28} />")).toEqual([])
+  })
+
+  it("keeps screens out of the styling business", () => {
+    const offenders = files.map((file) => ({ file, found: violations(file) })).filter((e) => e.found.length > 0)
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -12,26 +12,14 @@ export interface ThemeColors {
   // Primary colors
   primary: string
   primaryDark: string
-  primaryLight: string
 
   // Secondary colors
-  secondary: string
-  secondaryDark: string
-  secondaryLight: string
 
   // Semantic colors
   success: string
-  successDark: string
-  successLight: string
   warning: string
-  warningDark: string
-  warningLight: string
   error: string
-  errorDark: string
-  errorLight: string
   info: string
-  infoDark: string
-  infoLight: string
 
   // Surfaces & backgrounds
   background: string
@@ -54,12 +42,9 @@ export interface ThemeColors {
   // Interactive elements
   placeholder: string
   link: string
-  linkVisited: string
 
   // Utility
   overlay: string
-  shadow: string
-  transparent: string
   pressedOpacity: number
   borderRadius: number
   textOnPrimary: string
@@ -69,24 +54,12 @@ export const lightColors: ThemeColors = {
   // Brand (Teal)
   primary: "#0d9488",
   primaryDark: "#115E59",
-  primaryLight: "#99F6E4",
-  secondary: "#F59E0B",
-  secondaryDark: "#92400E",
-  secondaryLight: "#FDE68A",
 
   // Status
   success: "#2E7D32",
-  successDark: "#1B5E20",
-  successLight: "#A5D6A7",
   warning: "#C2410C",
-  warningDark: "#9A3412",
-  warningLight: "#FED7AA",
   error: "#D32F2F",
-  errorDark: "#B71C1C",
-  errorLight: "#FFCDD2",
   info: "#1976D2",
-  infoDark: "#0D47A1",
-  infoLight: "#BBDEFB",
 
   // UI
   background: "#f8fafb",
@@ -109,12 +82,9 @@ export const lightColors: ThemeColors = {
   // Interactive
   placeholder: "#9AA0A6",
   link: "#115E59",
-  linkVisited: "#134E4A",
   overlay: "rgba(0, 0, 0, 0.5)",
-  shadow: "rgba(0, 0, 0, 0.1)",
 
   // Special
-  transparent: "transparent",
   pressedOpacity: 0.7,
   borderRadius: 8,
   textOnPrimary: "#FFFFFF"
@@ -124,24 +94,12 @@ export const darkColors: ThemeColors = {
   // Brand (Teal)
   primary: "#2DD4BF",
   primaryDark: "#0d9488",
-  primaryLight: "#99F6E4",
-  secondary: "#FBBF24",
-  secondaryDark: "#F59E0B",
-  secondaryLight: "#FDE68A",
 
   // Status
   success: "#4CAF50",
-  successDark: "#388E3C",
-  successLight: "#C8E6C9",
   warning: "#FB923C",
-  warningDark: "#F97316",
-  warningLight: "#FED7AA",
   error: "#EF5350",
-  errorDark: "#D32F2F",
-  errorLight: "#FFCDD2",
   info: "#4285F4",
-  infoDark: "#1976D2",
-  infoLight: "#BBDEFB",
 
   // UI
   background: "#121212",
@@ -164,12 +122,9 @@ export const darkColors: ThemeColors = {
   // Interactive
   placeholder: "#AAAAAA",
   link: "#2DD4BF",
-  linkVisited: "#14B8A6",
   overlay: "rgba(0, 0, 0, 0.7)",
-  shadow: "rgba(0, 0, 0, 0.3)",
 
   // Special
-  transparent: "transparent",
   pressedOpacity: 0.7,
   borderRadius: 8,
   textOnPrimary: "#121212"


### PR DESCRIPTION
A screen writing a number a constant already names forks the system quietly: it renders, nothing fails, and the next change to that constant misses it. The guard scans screens, feature components and utils and fails on a literal that has a name.

Every rule fires only on a value a constant covers. A radius of 10 or an icon at 28 passes, because nothing names those and rounding them onto a scale would move the design rather than tidy it. That is why there is no allowlist: the rules describe what the constants reach, so anything they flag is genuinely a literal written in place of a name. Widening a scale means widening its rule here, or the new step goes unenforced.

Fifteen colour tokens go with it. Fourteen had no consumer at all. primaryLight fed --ifm-color-primary-light, -lighter and -lightest on the docs site, and nothing reads those: neither Infima's own CSS nor theme-classic nor the site itself, which only ever uses primary and the dark steps.
