### PR TITLE
refactor(screens): let the header own the screen name

### DIFF
--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -464,9 +464,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
-        {/* Header */}
         <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>API Field Mapping</Text>
           <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
             Customize field names sent to your server
           </Text>
@@ -756,12 +754,6 @@ const styles = StyleSheet.create({
   header: {
     marginTop: 20,
     marginBottom: 20
-  },
-  title: {
-    fontSize: fontSizes.screenTitle,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    marginBottom: space.xs
   },
   subtitle: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -154,9 +154,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {/* Header */}
         <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>Authentication & headers</Text>
           <Text style={[styles.subtitle, { color: colors.textSecondary }]}>Secure your endpoint connection</Text>
         </View>
 
@@ -388,12 +386,6 @@ const styles = StyleSheet.create({
   },
   header: {
     marginBottom: 20
-  },
-  title: {
-    fontSize: fontSizes.screenTitle,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    marginBottom: space.xs
   },
   subtitle: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -271,11 +271,6 @@ export function DataManagementScreen({}: ScreenProps) {
     <Container>
       <KeyboardAvoidingView style={styles.keyboardAvoid} behavior={Platform.OS === "ios" ? "padding" : undefined}>
         <ScrollView contentContainerStyle={styles.scrollContent}>
-          {/* Header */}
-          <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.text }]}>Data management</Text>
-          </View>
-
           {/* Stats */}
           <View style={styles.section}>
             <SectionTitle>Database statistics</SectionTitle>
@@ -486,11 +481,6 @@ const styles = StyleSheet.create({
   header: {
     marginTop: 20,
     marginBottom: space.xl
-  },
-  title: {
-    fontSize: fontSizes.screenTitle,
-    ...fonts.bold,
-    marginBottom: space.xs
   },
   section: {
     marginBottom: space.xl

--- a/apps/mobile/src/screens/MtlsSettingsScreen.tsx
+++ b/apps/mobile/src/screens/MtlsSettingsScreen.tsx
@@ -23,7 +23,6 @@ export function MtlsSettingsScreen({}: ScreenProps) {
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>Client Certificate (mTLS)</Text>
           <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
             For endpoints behind a reverse proxy that requires mutual TLS authentication
           </Text>
@@ -43,12 +42,6 @@ const styles = StyleSheet.create({
   },
   header: {
     marginBottom: 20
-  },
-  title: {
-    fontSize: fontSizes.screenTitle,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    marginBottom: space.xs
   },
   subtitle: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useEffect, useCallback } from "react"
+import React, { useState, useEffect, useLayoutEffect, useCallback } from "react"
 import { View, Text, StyleSheet, ScrollView, TextInput, Pressable } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
@@ -60,6 +60,10 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
   const [activationDelayStr, setActivationDelayStr] = useState("0")
   const [delayStr, setDelayStr] = useState("60")
   const [syncIntervalStr, setSyncIntervalStr] = useState(String(settings.syncInterval))
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerTitle: isEditing ? "Edit profile" : "New profile" })
+  }, [navigation, isEditing])
 
   useEffect(() => {
     if (!profileId) return
@@ -191,10 +195,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>{isEditing ? "Edit profile" : "New profile"}</Text>
-        </View>
-
         {/* Name & Priority */}
         <SectionTitle>Profile</SectionTitle>
         <Card>
@@ -498,7 +498,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 const styles = StyleSheet.create({
   scrollContent: { paddingHorizontal: space.lg, paddingTop: space.lg, paddingBottom: 40 },
   header: { marginBottom: 20 },
-  title: { fontSize: fontSizes.screenTitle, ...fonts.bold, letterSpacing: -0.5 },
   inputGroup: { marginBottom: space.xs },
   label: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -186,7 +186,6 @@ export function SetupImportScreen({ route, navigation }: any) {
           <View style={styles.headerRow}>
             <Import size={28} color={colors.primary} />
             <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.text }]}>Import configuration</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 A setup link wants to apply {result.entries.length} setting{result.entries.length !== 1 ? "s" : ""}
               </Text>

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -127,7 +127,6 @@ export function ShareSetupScreen() {
           <View style={styles.headerRow}>
             <Share2 size={28} color={colors.primary} />
             <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.text }]}>Share setup</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 Choose what to bundle into a setup link, then share it. The recipient opens it to apply the same
                 configuration.
@@ -207,10 +206,6 @@ const styles = StyleSheet.create({
   },
   headerText: {
     flex: 1
-  },
-  title: {
-    fontSize: fontSizes.heading,
-    ...fonts.bold
   },
   subtitle: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -178,7 +178,6 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
         ListHeaderComponent={
           <>
             <View style={styles.header}>
-              <Text style={[styles.title, { color: colors.text }]}>Tracking profiles</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 Auto-switch GPS settings based on charging, Android Auto, or speed
               </Text>
@@ -229,7 +228,6 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
 const styles = StyleSheet.create({
   list: { padding: space.lg, paddingBottom: 40 },
   header: { marginBottom: 20 },
-  title: { fontSize: fontSizes.screenTitle, ...fonts.bold, letterSpacing: -0.5, marginBottom: 6 },
   subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: 20 },
   createBtn: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
@@ -112,7 +112,8 @@ describe("AuthSettingsScreen", () => {
       const { getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Authentication & headers")).toBeTruthy()
+        // The screen name lives in the navigation header now, so anchor on the body's own caption.
+        expect(getByText("Secure your endpoint connection")).toBeTruthy()
       })
     })
   })

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -168,7 +168,7 @@ describe("DataManagementScreen", () => {
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Data management")).toBeTruthy()
+      expect(getByText("Database statistics")).toBeTruthy()
     })
   })
 
@@ -308,7 +308,7 @@ describe("DataManagementScreen", () => {
       const { queryByText, getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Data management")).toBeTruthy()
+        expect(getByText("Database statistics")).toBeTruthy()
       })
 
       expect(queryByText("Queue actions")).toBeNull()
@@ -319,7 +319,7 @@ describe("DataManagementScreen", () => {
       const { queryByText, getByText } = renderScreen()
 
       await waitFor(() => {
-        expect(getByText("Data management")).toBeTruthy()
+        expect(getByText("Database statistics")).toBeTruthy()
       })
 
       expect(queryByText("Clear sent history")).toBeNull()

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -97,8 +97,10 @@ jest.mock("../../components", () => {
 
 const mockGoBack = jest.fn()
 
+const mockSetOptions = jest.fn()
 const mockNavigation = {
-  goBack: mockGoBack
+  goBack: mockGoBack,
+  setOptions: mockSetOptions
 }
 
 import { ProfileEditorScreen } from "../ProfileEditorScreen"
@@ -119,9 +121,10 @@ describe("ProfileEditorScreen", () => {
 
   // --- New Profile Mode ---
 
-  it("renders new profile title", () => {
-    const { getByText } = renderNewProfile()
-    expect(getByText("New profile")).toBeTruthy()
+  it("names the new profile in the header rather than in the body", () => {
+    renderNewProfile()
+    // New versus edit is carried by the header title, not by a second title in the body.
+    expect(mockSetOptions).toHaveBeenCalledWith({ headerTitle: "New profile" })
   })
 
   it("shows Create Profile button for new profile", () => {
@@ -223,11 +226,11 @@ describe("ProfileEditorScreen", () => {
 
   // --- Edit Mode ---
 
-  it("renders edit profile title when editing", async () => {
-    const { getByText } = renderEditProfile()
+  it("names the edited profile in the header rather than in the body", async () => {
+    renderEditProfile()
 
     await waitFor(() => {
-      expect(getByText("Edit profile")).toBeTruthy()
+      expect(mockSetOptions).toHaveBeenCalledWith({ headerTitle: "Edit profile" })
     })
   })
 

--- a/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
@@ -129,7 +129,6 @@ describe("SetupImportScreen", () => {
 
     it("parses valid endpoint config", () => {
       const { getByText } = renderScreen(encode({ endpoint: "https://my-server.com/api" }))
-      expect(getByText("Import configuration")).toBeTruthy()
       expect(getByText("Endpoint")).toBeTruthy()
       expect(getByText("https://my-server.com/api")).toBeTruthy()
     })


### PR DESCRIPTION
Nine screens printed their own name in the body under a header already showing it. Seven of those titles go, and the one-line caption under each stays, because that is the line the screen actually needs.

Profile Editor keeps its wording but moves it: the body title carried new versus edit, which the static header title cannot, so it now sets headerTitle instead. Its test asserts that call rather than a rendered string, so it tests what the screen does.

About keeps its two Colota texts, which name the app beside its icon rather than repeating the screen, and Setup Import keeps Invalid configuration, which is an error state and not the screen name.

Four tests anchored a smoke check on a title that is gone; they now anchor on a caption or a section heading that is actually on the page. The seven style rules the deletions orphaned go too.
