### PR TITLE
fix(navigation): restore the History tab route, and type it so it cannot break again

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -42,7 +42,7 @@ import {
   TrackingSyncScreen,
   BackupRestoreScreen
 } from "./src/screens/"
-import { BottomTabBar } from "./src/components"
+import { BottomTabBar, TAB_ROUTES } from "./src/components"
 import { loadDisplayPreferences } from "./src/utils/geo"
 import { registerTileServerUserAgent } from "./src/utils/tileHeaders"
 
@@ -183,7 +183,6 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   }
 ]
 
-const TAB_SCREEN_NAMES = new Set(["Dashboard", "Location History", "Geofences", "Settings"])
 
 function AppNavigator() {
   const { colors, isDark } = useTheme()
@@ -260,7 +259,7 @@ function AppNavigator() {
                   component={screen.component}
                   options={{
                     headerTitle: screen.title,
-                    ...(TAB_SCREEN_NAMES.has(screen.name) && { headerBackVisible: false })
+                    ...(TAB_ROUTES.has(screen.name) && { headerBackVisible: false })
                   }}
                 />
               ))}

--- a/apps/mobile/src/components/index.ts
+++ b/apps/mobile/src/components/index.ts
@@ -34,7 +34,7 @@ export { RadioDot } from "./ui/RadioDot"
 export { SettingRow } from "./ui/SettingRow"
 export { FieldMessage } from "./ui/FieldMessage"
 export { ListItem } from "./ui/ListItem"
-export { BottomTabBar } from "./ui/BottomTabBar"
+export { BottomTabBar, TAB_ROUTES } from "./ui/BottomTabBar"
 
 // ============================================================================
 // Feature Components - Dashboard

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -9,27 +9,29 @@ import { Settings, LucideIcon, House, MapPinHouse, Waypoints } from "lucide-reac
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { size, space } from "../../constants"
+import type { RootStackRoute } from "../../types/navigation"
 
 interface Tab {
   name: string
   label: string
   icon: LucideIcon
-  route: string
+  route: RootStackRoute
 }
 
 const TABS: Tab[] = [
   { name: "dashboard", label: "Dashboard", icon: House, route: "Dashboard" },
-  { name: "history", label: "History", icon: Waypoints, route: "Location history" },
+  { name: "history", label: "History", icon: Waypoints, route: "Location History" },
   { name: "geofences", label: "Geofences", icon: MapPinHouse, route: "Geofences" },
   { name: "settings", label: "Settings", icon: Settings, route: "Settings" }
 ]
 
-/** Routes where the tab bar is visible. */
-const TAB_ROUTES = new Set(TABS.map((t) => t.route))
+/** Routes where the tab bar is visible. The one list; App.tsx reads it rather than repeating it. */
+// Typed loosely on purpose: lookups come from navigation state, which is a bare string.
+export const TAB_ROUTES: Set<string> = new Set(TABS.map((t) => t.route))
 
 interface BottomTabBarProps {
   currentRoute: string | undefined
-  onNavigate: (route: string) => void
+  onNavigate: (route: RootStackRoute) => void
 }
 
 export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
@@ -66,7 +68,6 @@ export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
   )
 }
 
-export { TAB_ROUTES }
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
The sentence-case sweep recased route: "Location History" to "Location history" in the tab bar, so pressing History navigated to a route that does not exist and nothing happened. The pattern that did it matched any key holding a title-case string at the end of an object literal, which is exactly the kind of string that PR set out to leave alone. An audit of its whole diff found no other identifier touched.

Restoring the string is not the fix. Tab.route was string, so no check could see the difference, and no test asserts on route names. It is RootStackRoute now, and onNavigate takes the same, so a bad route fails the type check with the correct spelling suggested.

TAB_SCREEN_NAMES goes with it. The four tab routes were listed twice, once there and once as TABS in the tab bar, which is the duplication that made a silent divergence possible in the first place; App.tsx reads the derived TAB_ROUTES instead.
