### PR TITLE
chore(ui): one press opacity, no dead shadows, logical directions

### DIFF
--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -116,7 +116,7 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: radius.xs,
-    marginRight: space.md
+    marginEnd: space.md
   },
   host: {
     flex: 1,
@@ -126,6 +126,6 @@ const styles = StyleSheet.create({
   status: {
     fontSize: fontSizes.caption,
     ...fonts.medium,
-    marginRight: space.sm
+    marginEnd: space.sm
   }
 })

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -164,7 +164,7 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     justifyContent: "center",
     alignItems: "center",
-    marginRight: space.md
+    marginEnd: space.md
   },
   checklistLabel: {
     fontSize: fontSizes.input,

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -458,10 +458,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     borderWidth: 1,
     elevation: 6,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.2,
-    shadowRadius: 6,
     zIndex: 10
   },
   popupHeader: {
@@ -525,10 +521,6 @@ const styles = StyleSheet.create({
     padding: space.sm,
     gap: space.xs,
     elevation: 4,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.15,
-    shadowRadius: 4,
     zIndex: 10
   },
   legendItem: {

--- a/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
+++ b/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
@@ -185,7 +185,7 @@ const styles = StyleSheet.create({
   },
   toggleLabel: {
     flex: 1,
-    paddingRight: space.md
+    paddingEnd: space.md
   },
   section: {
     paddingVertical: space.xs

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -268,17 +268,13 @@ const styles = StyleSheet.create({
   attributionPopup: {
     maxWidth: 320,
     width: "100%",
-    paddingLeft: space.lg,
-    paddingRight: 36,
+    paddingStart: space.lg,
+    paddingEnd: 36,
     paddingVertical: 14,
     borderRadius: 10,
     borderWidth: 1,
     gap: space.sm,
-    elevation: 8,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 6
+    elevation: 8
   },
   attributionPopupText: {
     fontSize: fontSizes.description

--- a/apps/mobile/src/components/features/map/MapActionButton.tsx
+++ b/apps/mobile/src/components/features/map/MapActionButton.tsx
@@ -48,10 +48,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     elevation: 5,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
     zIndex: 10
   },
   right: { right: 16 },

--- a/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
+++ b/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
@@ -87,10 +87,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     borderWidth: 3,
     borderColor: "white",
-    elevation: 4,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.3,
-    shadowRadius: 4
+    elevation: 4
   }
 })

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -238,7 +238,7 @@ const styles = StyleSheet.create({
   },
   warningText: {
     flex: 1,
-    marginLeft: space.md
+    marginStart: space.md
   },
   warningTitle: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -561,7 +561,7 @@ const styles = StyleSheet.create({
   },
   nestedSetting: {
     marginTop: space.md,
-    paddingLeft: space.lg,
+    paddingStart: space.lg,
     borderLeftWidth: 3
   },
   customSyncInput: {

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -143,11 +143,7 @@ const styles = StyleSheet.create({
   card: {
     width: "100%",
     padding: space.xl,
-    elevation: 8,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.2,
-    shadowRadius: 12
+    elevation: 8
   },
   iconContainer: {
     width: 56,

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -56,7 +56,7 @@ export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
         return (
           <Pressable
             key={tab.name}
-            style={({ pressed }) => [styles.tab, pressed && { opacity: 0.6 }]}
+            style={({ pressed }) => [styles.tab, pressed && { opacity: colors.pressedOpacity }]}
             onPress={() => onNavigate(tab.route)}
           >
             <tab.icon size={size.icon.md} color={color} />
@@ -74,9 +74,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     paddingTop: space.sm,
     paddingBottom: 6,
-    elevation: 0,
-    shadowOpacity: 0,
-    shadowRadius: 0
+    elevation: 0
   },
   tab: {
     flex: 1,

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -149,6 +149,6 @@ const styles = StyleSheet.create({
     ...fonts.semiBold
   },
   icon: {
-    marginRight: 0
+    marginEnd: 0
   }
 })

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -59,11 +59,7 @@ export function Card({
           backgroundColor: colors.cardElevated,
           borderColor: "transparent",
           borderWidth: 0,
-          elevation: 1,
-          shadowColor: "#000",
-          shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.15,
-          shadowRadius: 6
+          elevation: 1
         }
       case "outlined":
         return {

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -117,11 +117,7 @@ const styles = StyleSheet.create({
   card: {
     width: "100%",
     padding: space.xl,
-    elevation: 8,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.2,
-    shadowRadius: 12
+    elevation: 8
   },
   iconContainer: {
     width: 56,

--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -53,8 +53,7 @@ export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, messag
         style={[
           styles.badge,
           {
-            backgroundColor: saving ? colors.info : isError ? colors.error : colors.success,
-            shadowColor: saving ? colors.info : isError ? colors.error : colors.success
+            backgroundColor: saving ? colors.info : isError ? colors.error : colors.success
           }
         ]}
       >
@@ -86,9 +85,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: space.md,
     borderRadius: 24,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
     elevation: 8
   },
   text: { fontSize: fontSizes.body, ...fonts.semiBold }

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -70,11 +70,11 @@ const styles = StyleSheet.create({
     paddingVertical: 10
   },
   icon: {
-    marginRight: space.lg
+    marginEnd: space.lg
   },
   content: {
     flex: 1,
-    paddingRight: space.sm
+    paddingEnd: space.sm
   },
   label: {
     fontSize: fontSizes.label,

--- a/apps/mobile/src/components/ui/LoadingOverlay.tsx
+++ b/apps/mobile/src/components/ui/LoadingOverlay.tsx
@@ -44,9 +44,6 @@ const styles = StyleSheet.create({
     padding: space.xxl,
     borderRadius: radius.lg,
     alignItems: "center",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
     elevation: 8,
     minWidth: 240
   },

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
   },
   settingContent: {
     flex: 1,
-    marginRight: space.lg
+    marginEnd: space.lg
   },
   settingLabel: {
     fontSize: fontSizes.label,

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -243,13 +243,13 @@ export function AboutScreen({}: ScreenProps) {
         {/* Header */}
         <View style={styles.header}>
           <Pressable
-            style={({ pressed }) => [styles.appIconContainer, pressed && { opacity: 0.8 }]}
+            style={({ pressed }) => [styles.appIconContainer, pressed && { opacity: colors.pressedOpacity }]}
             onPress={handleVersionTap}
           >
             <Image source={icon} style={styles.appIcon} resizeMode="contain" />
           </Pressable>
           <Text style={[styles.title, { color: colors.text }]}>Colota</Text>
-          <Pressable onPress={handleVersionTap} style={({ pressed }) => pressed && { opacity: 0.8 }}>
+          <Pressable onPress={handleVersionTap} style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}>
             <Text style={[styles.version, { color: colors.textSecondary }]}>Version {buildConfig.VERSION_NAME}</Text>
           </Pressable>
 

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -399,11 +399,7 @@ const styles = StyleSheet.create({
     borderRadius: 22,
     alignItems: "center",
     justifyContent: "center",
-    elevation: 4,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4
+    elevation: 4
   },
   followingBadge: {
     position: "absolute",

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -633,7 +633,7 @@ export function AutoExportScreen(_props: ScreenProps) {
                       </Text>
                     </View>
                     <Pressable
-                      style={({ pressed }) => [styles.shareButton, pressed && { opacity: 0.5 }]}
+                      style={({ pressed }) => [styles.shareButton, pressed && { opacity: colors.pressedOpacity }]}
                       onPress={() => handleShareFile(file)}
                     >
                       <Share2 size={size.icon.md} color={colors.primary} />
@@ -699,7 +699,7 @@ const styles = StyleSheet.create({
     ...fonts.semiBold,
     flexShrink: 1,
     textAlign: "right",
-    marginLeft: space.md
+    marginStart: space.md
   },
   errorRow: {
     flexDirection: "row",
@@ -720,7 +720,7 @@ const styles = StyleSheet.create({
   },
   modeContent: {
     flex: 1,
-    marginRight: space.lg
+    marginEnd: space.lg
   },
   fileRow: {
     flexDirection: "row",
@@ -729,7 +729,7 @@ const styles = StyleSheet.create({
   },
   fileInfo: {
     flex: 1,
-    marginRight: space.md
+    marginEnd: space.md
   },
   fileName: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -302,8 +302,7 @@ const styles = StyleSheet.create({
   controlButton: {
     borderRadius: 28,
     elevation: 4,
-    minWidth: 200,
-    shadowColor: "#000"
+    minWidth: 200
   },
   content: {
     flex: 1,

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -454,21 +454,25 @@ const ActionRow = ({
   value: string
   onPress: () => void
   disabled: boolean
-}) => (
-  <Pressable
-    style={({ pressed }) => [styles.actionRow, pressed && { opacity: 0.7 }]}
-    onPress={onPress}
-    disabled={disabled}
-  >
-    <View style={styles.actionInfo}>
-      <Text style={[styles.actionLabel, { color }]}>{label}</Text>
-      <Text style={[styles.actionHint, { color: textColor }]}>{hint}</Text>
-    </View>
-    <View style={[styles.actionBadge, { backgroundColor: color + "20", borderColor: color }]}>
-      <Text style={[styles.actionBadgeText, { color }]}>{value}</Text>
-    </View>
-  </Pressable>
-)
+}) => {
+  const { colors } = useTheme()
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.actionRow, pressed && { opacity: colors.pressedOpacity }]}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      <View style={styles.actionInfo}>
+        <Text style={[styles.actionLabel, { color }]}>{label}</Text>
+        <Text style={[styles.actionHint, { color: textColor }]}>{hint}</Text>
+      </View>
+      <View style={[styles.actionBadge, { backgroundColor: color + "20", borderColor: color }]}>
+        <Text style={[styles.actionBadgeText, { color }]}>{value}</Text>
+      </View>
+    </Pressable>
+  )
+}
 
 const styles = StyleSheet.create({
   keyboardAvoid: {

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -374,8 +374,8 @@ const styles = StyleSheet.create({
   toggleRow: { paddingVertical: 10 },
   disabledRow: { opacity: 0.45 },
   nestedSetting: {
-    marginLeft: space.lg,
-    paddingLeft: space.md,
+    marginStart: space.lg,
+    paddingStart: space.md,
     borderLeftWidth: 3,
     marginTop: space.xs,
     marginBottom: space.xs

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -424,11 +424,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between"
   },
-  zoomBtn: { padding: space.xs, marginRight: space.lg },
+  zoomBtn: { padding: space.xs, marginEnd: space.lg },
   activeHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
   shareBtn: { padding: space.xs, marginBottom: space.md },
   editBtn: { flex: 1, flexDirection: "row", alignItems: "center" },
-  info: { flex: 1, marginRight: space.md },
+  info: { flex: 1, marginEnd: space.md },
   name: { fontSize: fontSizes.input, ...fonts.semiBold, marginBottom: 2 },
   radiusRow: { flexDirection: "row", alignItems: "center", gap: space.xs },
   radius: { fontSize: fontSizes.caption },

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -503,11 +503,7 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     paddingHorizontal: space.xl,
     paddingVertical: space.md,
-    elevation: 4,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4
+    elevation: 4
   },
   floatingPillText: {
     fontSize: fontSizes.label,

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -922,7 +922,7 @@ const styles = StyleSheet.create({
   errorText: { fontSize: fontSizes.description, ...fonts.regular, marginTop: 10 },
   card: { marginBottom: space.md },
   row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  info: { flex: 1, marginRight: space.md },
+  info: { flex: 1, marginEnd: space.md },
   nameRow: { flexDirection: "row", alignItems: "center", gap: 6, marginBottom: 2 },
   areaName: { fontSize: fontSizes.input, ...fonts.semiBold },
   areaSub: { fontSize: fontSizes.caption },
@@ -960,7 +960,6 @@ const styles = StyleSheet.create({
     padding: space.md,
     borderRadius: radius.md,
     elevation: 8,
-    shadowOpacity: 0.2,
     zIndex: 5,
     alignItems: "center"
   },

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -247,9 +247,9 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     alignItems: "center",
     justifyContent: "center",
-    marginRight: space.md
+    marginEnd: space.md
   },
-  info: { flex: 1, marginRight: space.md },
+  info: { flex: 1, marginEnd: space.md },
   nameRow: { flexDirection: "row", alignItems: "center", gap: space.sm, marginBottom: 2 },
   name: { fontSize: fontSizes.input, ...fonts.semiBold },
   activeBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -383,7 +383,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
             style={({ pressed }) => [
               styles.exportBtn,
               { backgroundColor: colors.primary, borderRadius: colors.borderRadius },
-              pressed && { opacity: 0.8 }
+              pressed && { opacity: colors.pressedOpacity }
             ]}
           >
             <Share size={size.icon.sm} color={colors.textOnPrimary} />
@@ -518,7 +518,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     marginTop: space.xs,
-    paddingLeft: 40
+    paddingStart: 40
   },
   chartLabel: {
     fontSize: fontSizes.micro,


### PR DESCRIPTION
Fifty-one shadow props sit beside an elevation and render nothing: React Native maps them to iOS only and this app is Android-only. Deleted.

Six Pressables dimmed by 0.5, 0.6, 0.7 or 0.8 on press while thirty-three other files read colors.pressedOpacity. They read the token now, so the same gesture feels the same everywhere. Five of the six change slightly; that is the fix rather than a side effect.

Twenty-three marginLeft-family props become their logical equivalents. Identical under LTR, and cheaper now than after another twenty screens are written against the physical ones.
