### PR TITLE
feat(ui): six buttons adopt the Button primitive

### DIFF
--- a/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DatabaseStatistics.test.tsx
@@ -29,6 +29,13 @@ jest.mock("../../../index", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -7,6 +7,13 @@ jest.mock("../../../index", () => {
   const R = require("react")
   const { View, Text, TextInput } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -32,6 +32,7 @@ type Props = {
   variant?: ButtonVariant
   icon?: LucideIcon
   loading?: boolean
+  testID?: string
 }
 
 export function Button({
@@ -43,7 +44,8 @@ export function Button({
   color,
   variant = "primary",
   icon: Icon,
-  loading = false
+  loading = false,
+  testID
 }: Props) {
   const { colors } = useTheme()
   const scale = useRef(new Animated.Value(1)).current
@@ -104,6 +106,7 @@ export function Button({
   return (
     <Animated.View style={[{ transform: [{ scale }] }, style]}>
       <Pressable
+        testID={testID}
         style={({ pressed }) => [
           styles.button,
           {
@@ -134,6 +137,9 @@ export function Button({
 
 const styles = StyleSheet.create({
   button: {
+    // Android's minimum touch target; padding alone leaves this at about 43.
+    minHeight: size.touch,
+    justifyContent: "center",
     paddingVertical: space.md,
     paddingHorizontal: space.xl,
     alignItems: "center",

--- a/apps/mobile/src/components/ui/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ui/ErrorBoundary.tsx
@@ -3,13 +3,13 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 import React, { Component } from "react"
-import { View, Text, StyleSheet, Pressable } from "react-native"
+import { View, Text, StyleSheet } from "react-native"
 import { ThemeColors } from "../../types/global"
 import { useTheme } from "../../hooks/useTheme"
 import { logger } from "../../utils/logger"
 import { fonts, fontSizes } from "../../styles/typography"
-import { space } from "../../constants"
-import { radius } from "@colota/shared"
+
+import { Button } from "./Button"
 
 interface ErrorBoundaryInternalProps {
   children: React.ReactNode
@@ -49,16 +49,7 @@ class ErrorBoundaryInternal extends Component<ErrorBoundaryInternalProps, ErrorB
           <Text style={[styles.errorMessage, { color: colors.textSecondary }]}>
             {this.state.error?.message || "An unexpected error occurred"}
           </Text>
-          <Pressable
-            style={({ pressed }) => [
-              styles.errorButton,
-              { backgroundColor: colors.primary },
-              pressed && { opacity: colors.pressedOpacity }
-            ]}
-            onPress={this.handleReset}
-          >
-            <Text style={[styles.errorButtonText, { color: colors.textOnPrimary }]}>Try again</Text>
-          </Pressable>
+          <Button title="Try again" onPress={this.handleReset} />
         </View>
       )
     }
@@ -93,14 +84,5 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginBottom: 20,
     paddingHorizontal: 20
-  },
-  errorButton: {
-    paddingHorizontal: space.xl,
-    paddingVertical: space.md,
-    borderRadius: radius.sm
-  },
-  errorButtonText: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold
   }
 })

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -12,7 +12,7 @@ import { Geofence, ScreenProps } from "../types/global"
 import { useTracking, useCoords } from "../contexts/TrackingProvider"
 import { fontSizes, fonts } from "../styles/typography"
 import { ChevronRight, Wifi, PersonStanding, MapPinHouse, Share2 } from "lucide-react-native"
-import { Container, SectionTitle, Card } from "../components"
+import { Button, Card, Container, SectionTitle } from "../components"
 import {
   DEFAULT_MAP_ZOOM,
   GEOFENCE_ZOOM_PADDING,
@@ -31,7 +31,6 @@ import { UserLocationOverlay } from "../components/features/map/UserLocationOver
 import { logger } from "../utils/logger"
 import { formatShortDistance, shortDistanceUnit, inputToMeters } from "../utils/geo"
 import { buildGeofencesLink } from "../utils/setupLink"
-import { radius } from "@colota/shared"
 
 const GeofenceMap = React.memo(function GeofenceMap({
   tracking,
@@ -345,20 +344,11 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
                   </View>
                 </View>
 
-                <Pressable
-                  testID="place-geofence-btn"
-                  style={({ pressed }) => [
-                    styles.placeBtn,
-                    { backgroundColor: colors.primary },
-                    pressed && { opacity: colors.pressedOpacity }
-                  ]}
-                  onPress={startPlacingGeofence}
+                <Button
+                  title={placingGeofence ? "Tap Map to Place..." : "Place geofence"}
                   disabled={placingGeofence}
-                >
-                  <Text style={[styles.placeBtnText, { color: colors.textOnPrimary }]}>
-                    {placingGeofence ? "Tap Map to Place..." : "Place geofence"}
-                  </Text>
-                </Pressable>
+                  onPress={startPlacingGeofence}
+                />
               </Card>
             </View>
 
@@ -416,8 +406,6 @@ const styles = StyleSheet.create({
   inputCentered: {
     textAlign: "center"
   },
-  placeBtn: { padding: space.lg, borderRadius: radius.md, alignItems: "center" },
-  placeBtnText: { fontSize: fontSizes.input, ...fonts.semiBold },
   card: { marginBottom: space.md },
   row: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -13,7 +13,7 @@ import { ScreenProps } from "../types/global"
 import { useCoords } from "../contexts/TrackingProvider"
 import { fontSizes, fonts } from "../styles/typography"
 import { X, CircleCheckBig, RefreshCw, TriangleAlert } from "lucide-react-native"
-import { Container, SectionTitle, Card } from "../components"
+import { Button, Card, Container, SectionTitle } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
 import {
   DEFAULT_MAP_ZOOM,
@@ -167,18 +167,12 @@ const DownloadForm = memo(
                 </Pressable>
               </View>
             ) : (
-              <Pressable
+              <Button
                 testID="download-btn"
-                style={({ pressed }) => [
-                  styles.downloadBtn,
-                  { backgroundColor: estimatedSizeLabel ? colors.primary : colors.border },
-                  pressed && { opacity: colors.pressedOpacity }
-                ]}
-                onPress={onDownload}
+                title="Download area"
                 disabled={!estimatedSizeLabel}
-              >
-                <Text style={[styles.downloadBtnText, { color: colors.textOnPrimary }]}>Download area</Text>
-              </Pressable>
+                onPress={onDownload}
+              />
             )}
 
             {downloadError && <Text style={[styles.errorText, { color: colors.error }]}>{downloadError}</Text>}
@@ -903,8 +897,6 @@ const styles = StyleSheet.create({
   },
   input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input },
   sizeEstimate: { fontSize: fontSizes.caption, ...fonts.regular, marginBottom: space.md },
-  downloadBtn: { padding: space.lg, borderRadius: radius.md, alignItems: "center" },
-  downloadBtnText: { fontSize: fontSizes.label, ...fonts.semiBold },
   progressContainer: { gap: 10 },
   progressHeader: { flexDirection: "row", alignItems: "center", gap: 10 },
   progressLabel: { fontSize: fontSizes.body, ...fonts.semiBold },

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -11,7 +11,7 @@ import { ProfileService } from "../services/ProfileService"
 import { showAlert } from "../services/modalService"
 import { TrackingProfile, ProfileConditionType } from "../types/global"
 import { fontSizes, fonts } from "../styles/typography"
-import { Container, SectionTitle, Card, Divider, SettingRow, NumericInput, FieldMessage } from "../components"
+import { Button, Card, Container, Divider, FieldMessage, NumericInput, SectionTitle, SettingRow } from "../components"
 import { Check } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
@@ -475,21 +475,13 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         </Card>
 
         {/* Save Button */}
-        <Pressable
-          style={({ pressed }) => [
-            styles.saveBtn,
-            { backgroundColor: colors.primary },
-            saving && styles.saveBtnDisabled,
-            pressed && { opacity: colors.pressedOpacity }
-          ]}
+        <Button
+          title={saving ? "Saving…" : isEditing ? "Save changes" : "Create profile"}
+          icon={Check}
+          loading={saving}
+          style={styles.saveBtn}
           onPress={handleSave}
-          disabled={saving}
-        >
-          <Check size={size.icon.md} color={colors.textOnPrimary} />
-          <Text style={[styles.saveBtnText, { color: colors.textOnPrimary }]}>
-            {saving ? "Saving..." : isEditing ? "Save changes" : "Create profile"}
-          </Text>
-        </Pressable>
+        />
       </ScrollView>
     </Container>
   )
@@ -547,7 +539,5 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     marginTop: space.lg
   },
-  saveBtnText: { fontSize: fontSizes.label, ...fonts.semiBold },
-  saveBtnDisabled: { opacity: 0.6 },
   sectionGap: { marginTop: space.xl }
 })

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -11,7 +11,7 @@ import { ProfileService } from "../services/ProfileService"
 import { showAlert, showConfirm } from "../services/modalService"
 import { SavedTrackingProfile, ScreenProps } from "../types/global"
 import { fontSizes, fonts } from "../styles/typography"
-import { Card, Container, SectionTitle, Toggle } from "../components"
+import { Button, Card, Container, SectionTitle, Toggle } from "../components"
 import { Plus, X, Zap, Share2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { buildProfilesLink } from "../utils/setupLink"
@@ -182,17 +182,12 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
               </Text>
             </View>
 
-            <Pressable
-              style={({ pressed }) => [
-                styles.createBtn,
-                { backgroundColor: colors.primary },
-                pressed && { opacity: colors.pressedOpacity }
-              ]}
+            <Button
+              title="Create profile"
+              icon={Plus}
+              style={styles.createBtn}
               onPress={() => navigation.navigate("Profile Editor", {})}
-            >
-              <Plus size={size.icon.md} color={colors.textOnPrimary} />
-              <Text style={[styles.createBtnText, { color: colors.textOnPrimary }]}>Create profile</Text>
-            </Pressable>
+            />
 
             {profiles.length > 0 && (
               <View style={styles.activeHeader}>
@@ -237,7 +232,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     marginBottom: space.xl
   },
-  createBtnText: { fontSize: fontSizes.input, ...fonts.semiBold },
   card: { marginBottom: space.md },
   activeCard: { borderWidth: 2 },
   row: { flexDirection: "row", alignItems: "center" },

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react-native"
 import { useTheme } from "../hooks/useTheme"
 import { fontSizes, fonts } from "../styles/typography"
+import { Button } from "../components/ui/Button"
 import { Card } from "../components/ui/Card"
 import { Container } from "../components/ui/Container"
 import { TrackMap } from "../components/features/inspector/TrackMap"
@@ -378,17 +379,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
 
         {/* Export */}
         <View style={styles.section}>
-          <Pressable
-            onPress={() => setShowExport((prev) => !prev)}
-            style={({ pressed }) => [
-              styles.exportBtn,
-              { backgroundColor: colors.primary, borderRadius: colors.borderRadius },
-              pressed && { opacity: colors.pressedOpacity }
-            ]}
-          >
-            <Share size={size.icon.sm} color={colors.textOnPrimary} />
-            <Text style={[styles.exportBtnText, { color: colors.textOnPrimary }]}>Export trip</Text>
-          </Pressable>
+          <Button title="Export trip" icon={Share} onPress={() => setShowExport((prev) => !prev)} />
 
           {showExport && (
             <View style={styles.exportRow}>
@@ -523,17 +514,6 @@ const styles = StyleSheet.create({
   chartLabel: {
     fontSize: fontSizes.micro,
     ...fonts.regular
-  },
-  exportBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: space.sm,
-    paddingVertical: 14
-  },
-  exportBtnText: {
-    fontSize: fontSizes.input,
-    ...fonts.semiBold
   },
   exportRow: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
@@ -84,6 +84,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -61,6 +61,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text, Pressable } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
@@ -45,6 +45,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
@@ -127,6 +127,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -84,6 +84,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -139,6 +139,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -79,6 +79,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -63,6 +63,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text, Pressable } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
@@ -83,6 +83,13 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    Button: function (props: any) {
+      return require("react").createElement(
+        require("react-native").Pressable,
+        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        require("react").createElement(require("react-native").Text, null, props.title)
+      )
+    },
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {
         testID: props.testID,

--- a/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
@@ -74,6 +74,16 @@ jest.mock("../../components/ui/Container", () => {
   return { Container: ({ children }: any) => R.createElement(View, null, children) }
 })
 
+jest.mock("../../components/ui/Button", () => ({
+  Button: function (props: any) {
+    return require("react").createElement(
+      require("react-native").Pressable,
+      { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+      require("react").createElement(require("react-native").Text, null, props.title)
+    )
+  }
+}))
+
 jest.mock("../../components/ui/Card", () => {
   const R = require("react")
   const { View } = require("react-native")


### PR DESCRIPTION
Six full-size primary actions that each hand-rolled their own padding and radius now use Button. Button gains a 48dp minimum height, which Android requires and padding alone did not reach, so every button grows slightly.

Eighteen small inline buttons are left alone; Button has no size variant and adding one is a design decision.

Green on tsc, eslint and 1023 tests.