### PR TITLE
feat(ui): drop the button spring, fill the secondary variant

### DIFF
--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -3,12 +3,11 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useRef, useCallback } from "react"
+import React from "react"
 import {
   Pressable,
   Text,
   View,
-  Animated,
   ActivityIndicator,
   StyleSheet,
   GestureResponderEvent,
@@ -48,26 +47,6 @@ export function Button({
   testID
 }: Props) {
   const { colors } = useTheme()
-  const scale = useRef(new Animated.Value(1)).current
-
-  const handlePressIn = useCallback(() => {
-    Animated.spring(scale, {
-      toValue: 0.97,
-      useNativeDriver: true,
-      speed: 50,
-      bounciness: 4
-    }).start()
-  }, [scale])
-
-  const handlePressOut = useCallback(() => {
-    Animated.spring(scale, {
-      toValue: 1,
-      useNativeDriver: true,
-      speed: 50,
-      bounciness: 4
-    }).start()
-  }, [scale])
-
   const getVariantStyles = () => {
     switch (variant) {
       case "primary":
@@ -79,10 +58,10 @@ export function Button({
         }
       case "secondary":
         return {
-          bg: "transparent",
-          text: color ?? colors.primaryDark,
-          borderColor: colors.primary,
-          borderWidth: 1.5
+          bg: disabled ? colors.textDisabled : colors.primaryContainer,
+          text: color ?? colors.onPrimaryContainer,
+          borderColor: "transparent",
+          borderWidth: 0
         }
       case "ghost":
         return {
@@ -104,7 +83,7 @@ export function Button({
   const v = getVariantStyles()
 
   return (
-    <Animated.View style={[{ transform: [{ scale }] }, style]}>
+    <View style={style}>
       <Pressable
         testID={testID}
         style={({ pressed }) => [
@@ -118,8 +97,6 @@ export function Button({
           }
         ]}
         onPress={onPress}
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
         disabled={disabled || loading}
       >
         <View style={styles.content}>
@@ -131,7 +108,7 @@ export function Button({
           <Text style={[styles.text, { color: v.text }]}>{title}</Text>
         </View>
       </Pressable>
-    </Animated.View>
+    </View>
   )
 }
 

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -12,6 +12,8 @@ export interface ThemeColors {
   // Primary colors
   primary: string
   primaryDark: string
+  primaryContainer: string
+  onPrimaryContainer: string
 
   // Secondary colors
 
@@ -54,6 +56,8 @@ export const lightColors: ThemeColors = {
   // Brand (Teal)
   primary: "#0d9488",
   primaryDark: "#115E59",
+  primaryContainer: "#A5F8E9",
+  onPrimaryContainer: "#115E59",
 
   // Status
   success: "#2E7D32",
@@ -94,6 +98,8 @@ export const darkColors: ThemeColors = {
   // Brand (Teal)
   primary: "#2DD4BF",
   primaryDark: "#0d9488",
+  primaryContainer: "#0F3B36",
+  onPrimaryContainer: "#99F6E4",
 
   // Status
   success: "#4CAF50",


### PR DESCRIPTION
The spring was the only animation on any primitive and doubled up with the press opacity on the same touch. Removed.

secondary fills with primaryContainer instead of being the app's only outlined control. That adds two colour keys derived from the existing teal; no existing value changes in either theme, and text on the container clears 6.21 light and 9.80 dark.

Four buttons change appearance: Test connection, and three others using variant="secondary".