### PR TITLE
feat(ui): Appearance adopts ChipGroup, which now reads the theme itself

### DIFF
--- a/apps/mobile/src/components/ui/ChipGroup.tsx
+++ b/apps/mobile/src/components/ui/ChipGroup.tsx
@@ -6,26 +6,31 @@
 import React from "react"
 import { View, Pressable, Text, StyleSheet } from "react-native"
 import { ThemeColors } from "../../types/global"
+import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { space } from "../../constants"
 
 interface ChipGroupProps<T extends string> {
-  options: readonly { value: T; label: string }[]
+  options: readonly { value: T; label: string; testID?: string }[]
   selected: T
   onSelect: (value: T) => void
-  colors: ThemeColors
   disabled?: ReadonlySet<T>
+  /** Ignored: the group reads the theme itself. Kept so existing callers still compile. */
+  colors?: ThemeColors
 }
 
-export function ChipGroup<T extends string>({ options, selected, onSelect, colors, disabled }: ChipGroupProps<T>) {
+export function ChipGroup<T extends string>({ options, selected, onSelect, disabled }: ChipGroupProps<T>) {
+  const { colors } = useTheme()
+
   return (
     <View style={styles.row}>
-      {options.map(({ value, label }) => {
+      {options.map(({ value, label, testID }) => {
         const isSelected = selected === value
         const isDisabled = disabled?.has(value) ?? false
         return (
           <Pressable
             key={value}
+            testID={testID}
             disabled={isDisabled}
             style={({ pressed }) => [
               styles.chip,

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -10,7 +10,7 @@ import { useTheme } from "../hooks/useTheme"
 import { useTranslation } from "../i18n/useTranslation"
 import NativeLocationService from "../services/NativeLocationService"
 import { fontSizes, fonts } from "../styles/typography"
-import { Card, Container, Divider, SettingRow, Toggle } from "../components"
+import { Card, ChipGroup, Container, Divider, SettingRow, Toggle } from "../components"
 import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
@@ -106,55 +106,27 @@ export function AppearanceScreen({}: ScreenProps) {
           <Divider />
 
           <SettingRow label={t("appearance.units")}>
-            <View style={styles.chipGroup}>
-              {(["metric", "imperial"] as const).map((unit) => {
-                const selected = unitSystem === unit
-                return (
-                  <Pressable
-                    key={unit}
-                    testID={`unit-${unit}`}
-                    style={[
-                      styles.chip,
-                      {
-                        backgroundColor: selected ? colors.primary + "15" : colors.background,
-                        borderColor: selected ? colors.primary : colors.border
-                      }
-                    ]}
-                    onPress={() => selectUnitSystem(unit)}
-                  >
-                    <Text style={[styles.chipLabel, { color: selected ? colors.primary : colors.text }]}>
-                      {unit === "metric" ? t("appearance.units.metric") : t("appearance.units.imperial")}
-                    </Text>
-                  </Pressable>
-                )
-              })}
-            </View>
+            <ChipGroup
+              options={[
+                { value: "metric", label: t("appearance.units.metric"), testID: "unit-metric" },
+                { value: "imperial", label: t("appearance.units.imperial"), testID: "unit-imperial" }
+              ]}
+              selected={unitSystem}
+              onSelect={selectUnitSystem}
+            />
           </SettingRow>
 
           <Divider />
 
           <SettingRow label={t("appearance.timeFormat")}>
-            <View style={styles.chipGroup}>
-              {(["24h", "12h"] as const).map((fmt) => {
-                const selected = timeFormat === fmt
-                return (
-                  <Pressable
-                    key={fmt}
-                    testID={`time-format-${fmt}`}
-                    style={[
-                      styles.chip,
-                      {
-                        backgroundColor: selected ? colors.primary + "15" : colors.background,
-                        borderColor: selected ? colors.primary : colors.border
-                      }
-                    ]}
-                    onPress={() => selectTimeFormat(fmt)}
-                  >
-                    <Text style={[styles.chipLabel, { color: selected ? colors.primary : colors.text }]}>{fmt}</Text>
-                  </Pressable>
-                )
-              })}
-            </View>
+            <ChipGroup
+              options={[
+                { value: "24h", label: "24h", testID: "time-format-24h" },
+                { value: "12h", label: "12h", testID: "time-format-12h" }
+              ]}
+              selected={timeFormat}
+              onSelect={selectTimeFormat}
+            />
           </SettingRow>
 
           <Divider />
@@ -259,20 +231,6 @@ const styles = StyleSheet.create({
   linkSub: {
     fontSize: fontSizes.description,
     ...fonts.regular
-  },
-  chipGroup: {
-    flexDirection: "row",
-    gap: space.sm
-  },
-  chip: {
-    paddingHorizontal: 14,
-    paddingVertical: space.sm,
-    borderRadius: 10,
-    borderWidth: 1.5
-  },
-  chipLabel: {
-    fontSize: fontSizes.description,
-    ...fonts.semiBold
   },
   mapTilePanel: {
     marginTop: space.xs,

--- a/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
@@ -45,6 +45,20 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    ChipGroup: function (props: any) {
+      const RN = require("react-native")
+      return R.createElement(
+        View,
+        null,
+        props.options.map(function (o: any) {
+          return R.createElement(
+            RN.Pressable,
+            { key: o.value, testID: o.testID, onPress: () => props.onSelect(o.value) },
+            R.createElement(Text, null, o.label)
+          )
+        })
+      )
+    },
     Button: function (props: any) {
       return require("react").createElement(
         require("react-native").Pressable,


### PR DESCRIPTION
The units and time format rows each built their own chips: 1.5px stroke, radius 10, their own selected colours. They use ChipGroup now.

ChipGroup was the only primitive that made its caller pass colours in. It reads useTheme like every other one; the colors prop stays as optional and ignored so the seven existing callers still compile. Options take a testID, which the two Appearance groups need and which no caller could express before.

Activity Log keeps its own chips. They are multi-select, take a colour per level and carry a count, which is a different control rather than an unmigrated one.
