### PR TITLE
fix(settings): disable the test button instead of dimming it

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -96,8 +96,11 @@ export function ConnectionSettings({
     [settings, onSettingsChange]
   )
 
+  const canTestEndpoint = Boolean(endpointInput) && isEndpointAllowed(endpointInput)
+
   const handleTestEndpoint = useCallback(async () => {
-    if (!endpointInput) return
+    // Guards here as well as on the button: disabled stops the press, this stops a caller.
+    if (!canTestEndpoint) return
     setTesting(true)
     setTestResponse(null)
     setTestError(false)
@@ -175,7 +178,7 @@ export function ConnectionSettings({
       setTesting(false)
       timeout.set(() => setTestResponse(null), TEST_RESULT_DISPLAY_MS)
     }
-  }, [endpointInput, settings, onSettingsChange, timeout])
+  }, [canTestEndpoint, endpointInput, settings, onSettingsChange, timeout])
 
   return (
     <View style={styles.section}>
@@ -253,14 +256,9 @@ export function ConnectionSettings({
             </View>
 
             <Button
-              style={[
-                styles.testButton,
-                (!endpointInput || !isEndpointAllowed(endpointInput)) && styles.disabledButton
-              ]}
-              onPress={() => {
-                if (!endpointInput || !isEndpointAllowed(endpointInput)) return
-                handleTestEndpoint()
-              }}
+              style={styles.testButton}
+              disabled={!canTestEndpoint}
+              onPress={handleTestEndpoint}
               title={testing ? "Testing..." : "Test connection"}
             />
 
@@ -337,9 +335,6 @@ const styles = StyleSheet.create({
   },
   testButton: {
     marginTop: space.md
-  },
-  disabledButton: {
-    opacity: 0.5
   },
   responseBox: {
     marginTop: space.md,

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -318,6 +318,29 @@ describe("ConnectionSettings", () => {
       bearing: 0
     }
 
+    it("disables the test button on an empty endpoint rather than dimming it", () => {
+      // It used to carry a 0.5 opacity and guard inside onPress, so it took the press,
+      // rippled, did nothing, and announced itself as enabled to TalkBack.
+      const { getByText } = renderComponent({}, "")
+
+      // The prop, not the behaviour: a guard inside onPress also stops the call, and that
+      // is the bug this replaced. Only disabled makes the control announce itself correctly.
+      // accessibilityState is what TalkBack reads, and it is only set when disabled is
+      // passed. A guard inside onPress also stops the call, which is the bug this replaced,
+      // but leaves the control announcing itself as enabled.
+      let node: any = getByText("Test connection")
+      while (node && !node.props?.accessibilityState) node = node.parent
+      expect(node?.props.accessibilityState.disabled).toBe(true)
+    })
+
+    it("does not call testEndpoint when the endpoint is not allowed", () => {
+      const { getByText } = renderComponent({}, "http://example.com/api")
+
+      fireEvent.press(getByText("Test connection"))
+
+      expect(mockTestEndpoint).not.toHaveBeenCalled()
+    })
+
     it("shows native error message when testEndpoint rejects the protocol", async () => {
       mockGetMostRecentLocation.mockResolvedValue(location)
       mockTestEndpoint.mockResolvedValue({


### PR DESCRIPTION
The button carried opacity 0.5 and guarded inside onPress, so it took the press, rippled, did nothing, and announced itself as enabled. It is disabled now.

handleTestEndpoint only checked for an empty endpoint and left isEndpointAllowed to the button, so both now share one predicate and a non-button caller cannot slip past.

Two tests, one asserting accessibilityState rather than the behaviour, because a guard inside onPress also stops the call and that is the bug being replaced.