### PR TITLE
fix(ui): delete two lines that never did anything

### DIFF
--- a/apps/mobile/src/components/features/settings/PresetOption.tsx
+++ b/apps/mobile/src/components/features/settings/PresetOption.tsx
@@ -19,7 +19,7 @@ interface BadgeProps {
 
 function Badge({ icon, label, color }: BadgeProps) {
   return (
-    <View style={[styles.badge, { backgroundColor: color + "20", borderColor: color + "40" }]}>
+    <View style={[styles.badge, { backgroundColor: color + "20" }]}>
       <View style={styles.badgeContent}>
         {icon}
         <Text style={[styles.badgeText, { color }]}>{label}</Text>

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -54,8 +54,8 @@ export function ExportLocationsScreen({}: ScreenProps) {
         return
       }
 
-      setExportProgress(`Exported ${result.rowCount.toLocaleString()} locations`)
-
+      // Dismissed here rather than in the finally, which would not run until the share
+      // sheet is closed and would leave the overlay sitting behind it.
       setExporting(false)
       setExportProgress("")
 


### PR DESCRIPTION
The preset badge computed a borderColor on a style with no borderWidth, so React Native drew no border and the value was discarded every render.

The export handler set a progress message and then, in the same tick with no await between, cleared it and hid the overlay that displayed it. React coalesced the three into one render and the message never reached the screen.

Neither changes what the app does. The comment left behind marks why the dismissal below it cannot move into the finally: that block does not run until the share sheet closes, which would leave the overlay behind it.
