### PR TITLE
feat(ui): chips fill instead of outlining, and say what is selected

### DIFF
--- a/apps/mobile/src/components/ui/ChipGroup.tsx
+++ b/apps/mobile/src/components/ui/ChipGroup.tsx
@@ -5,10 +5,12 @@
 
 import React from "react"
 import { View, Pressable, Text, StyleSheet } from "react-native"
+import { Check } from "lucide-react-native"
 import { ThemeColors } from "../../types/global"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { space } from "../../constants"
+import { size, space } from "../../constants"
+import { radius } from "@colota/shared"
 
 interface ChipGroupProps<T extends string> {
   options: readonly { value: T; label: string; testID?: string }[]
@@ -32,16 +34,28 @@ export function ChipGroup<T extends string>({ options, selected, onSelect, disab
             key={value}
             testID={testID}
             disabled={isDisabled}
+            accessibilityRole="radio"
+            accessibilityState={{ checked: isSelected, disabled: isDisabled }}
             style={({ pressed }) => [
               styles.chip,
-              { borderColor: colors.border, backgroundColor: colors.background },
-              isSelected && { borderColor: colors.primary, backgroundColor: colors.primary + "20" },
+              { backgroundColor: isSelected ? colors.primaryContainer : colors.well },
               isDisabled && { opacity: 0.4 },
               pressed && !isDisabled && { opacity: colors.pressedOpacity }
             ]}
             onPress={() => onSelect(value)}
           >
-            <Text style={[styles.label, { color: isSelected ? colors.primary : colors.text }]}>{label}</Text>
+            {isSelected ? (
+              <Check size={size.icon.sm} color={colors.onPrimaryContainer} strokeWidth={2} />
+            ) : null}
+            <Text
+              style={[
+                styles.label,
+                isSelected && styles.labelSelected,
+                { color: isSelected ? colors.onPrimaryContainer : colors.text }
+              ]}
+            >
+              {label}
+            </Text>
           </Pressable>
         )
       })}
@@ -56,14 +70,20 @@ const styles = StyleSheet.create({
     gap: space.sm
   },
   chip: {
-    borderWidth: 2,
-    borderRadius: 10,
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    alignItems: "center"
+    flexDirection: "row",
+    alignItems: "center",
+    gap: space.xs,
+    minHeight: size.chip,
+    borderRadius: radius.sm,
+    paddingVertical: space.sm,
+    paddingHorizontal: space.md
   },
   label: {
     fontSize: fontSizes.caption,
-    ...fonts.bold
+    ...fonts.medium
+  },
+  // Selection is a check and a weight step as well as the fill, so it does not rest on colour alone.
+  labelSelected: {
+    ...fonts.semiBold
   }
 })

--- a/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { lightColors } from "@colota/shared"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { ChipGroup } from "../ChipGroup"
+
+const OPTIONS = [
+  { value: "a", label: "None", testID: "chip-a" },
+  { value: "b", label: "Basic auth", testID: "chip-b" }
+] as const
+
+describe("ChipGroup", () => {
+  it("fills the selected chip and recesses the rest, so neither carries a stroke", () => {
+    const { getByTestId } = render(
+      <ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} />
+    )
+
+    const flat = (el: any) => Object.assign({}, ...[el.props.style].flat(Infinity).filter(Boolean))
+    expect(flat(getByTestId("chip-b")).backgroundColor).toBe(lightColors.primaryContainer)
+    expect(flat(getByTestId("chip-a")).backgroundColor).toBe(lightColors.well)
+    expect(flat(getByTestId("chip-a")).borderWidth).toBeUndefined()
+  })
+
+  it("marks selection with a check and a state, not colour alone", () => {
+    // Colour-only selection fails a colour-blind user and is an Accessibility Scanner finding.
+    const { getByTestId } = render(
+      <ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} />
+    )
+
+    expect(getByTestId("chip-b").props.accessibilityState.checked).toBe(true)
+    expect(getByTestId("chip-a").props.accessibilityState.checked).toBe(false)
+  })
+})

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -14,6 +14,7 @@ export interface ThemeColors {
   primaryDark: string
   primaryContainer: string
   onPrimaryContainer: string
+  well: string
 
   // Secondary colors
 
@@ -58,6 +59,7 @@ export const lightColors: ThemeColors = {
   primaryDark: "#115E59",
   primaryContainer: "#A5F8E9",
   onPrimaryContainer: "#115E59",
+  well: "#E9EDF0",
 
   // Status
   success: "#2E7D32",
@@ -100,6 +102,7 @@ export const darkColors: ThemeColors = {
   primaryDark: "#0d9488",
   primaryContainer: "#0F3B36",
   onPrimaryContainer: "#99F6E4",
+  well: "#232323",
 
   // Status
   success: "#4CAF50",


### PR DESCRIPTION
The chip was a 2px outline that turned teal when picked, so selection rested on colour alone: no check, no weight change, no accessibility state. A colour-blind user could not tell, and the Accessibility Scanner flags it.

It fills now. Unselected takes well, selected takes primaryContainer with a check and a weight step, and the stroke goes. The row carries radio semantics and a checked state.

well is new, at #E9EDF0 and #232323. That is a 1.12 and 1.19 step against the ground, which is the plan's 1.14 and 1.17 expressed on this palette. No existing colour changes.
