### PR TITLE
feat(ui): rows can be disabled and say so

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -16,7 +16,7 @@ import {
   size,
   space
 } from "../../../constants"
-import { Card, Divider, NumericInput, SectionTitle, SettingRow, Toggle } from "../../index"
+import { Card, ChipGroup, Divider, NumericInput, SectionTitle, SettingRow, Toggle } from "../../index"
 import { PresetOption } from "./PresetOption"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
 import { isOverlandFormat } from "../../../utils/apiPayload"
@@ -233,60 +233,28 @@ export function SyncStrategySettings({
                       How often to upload data to server
                     </Text>
 
-                    <View style={styles.optionsGrid}>
-                      {SYNC_INTERVAL_PRESETS.map((sec) => {
-                        const isSelected = settings.syncInterval === sec && !isCustomSyncInterval
-                        return (
-                          <Pressable
-                            key={sec}
-                            style={({ pressed }) => [
-                              styles.gridOption,
-                              {
-                                borderColor: colors.border,
-                                backgroundColor: colors.background
-                              },
-                              isSelected && {
-                                borderColor: colors.primary,
-                                backgroundColor: colors.primary + "20"
-                              },
-                              pressed && { opacity: colors.pressedOpacity }
-                            ]}
-                            onPress={() => handleGridSelect("syncInterval", sec)}
-                          >
-                            <Text style={[styles.gridLabel, { color: isSelected ? colors.primary : colors.text }]}>
-                              {SYNC_INTERVAL_LABELS[sec]}
-                            </Text>
-                          </Pressable>
-                        )
-                      })}
-                      <Pressable
-                        style={({ pressed }) => [
-                          styles.gridOption,
-                          {
-                            borderColor: colors.border,
-                            backgroundColor: colors.background
-                          },
-                          isCustomSyncInterval && {
-                            borderColor: colors.primary,
-                            backgroundColor: colors.primary + "20"
-                          },
-                          pressed && { opacity: colors.pressedOpacity }
-                        ]}
-                        onPress={() => {
+                    <ChipGroup
+                      options={[
+                        ...SYNC_INTERVAL_PRESETS.map((sec) => ({
+                          value: String(sec),
+                          label: SYNC_INTERVAL_LABELS[sec]
+                        })),
+                        { value: "custom", label: "Custom" }
+                      ]}
+                      selected={isCustomSyncInterval ? "custom" : String(settings.syncInterval)}
+                      onSelect={(value) => {
+                        if (value === "custom") {
+                          // Seeding a value is what makes the mode custom; the field takes over.
                           if (!isCustomSyncInterval) {
                             const customValue = 1800
                             setSyncIntervalInput(customValue.toString())
                             handleGridSelect("syncInterval", customValue)
                           }
-                        }}
-                      >
-                        <Text
-                          style={[styles.gridLabel, { color: isCustomSyncInterval ? colors.primary : colors.text }]}
-                        >
-                          Custom
-                        </Text>
-                      </Pressable>
-                    </View>
+                          return
+                        }
+                        handleGridSelect("syncInterval", Number(value))
+                      }}
+                    />
                   </View>
 
                   {isCustomSyncInterval && (
@@ -361,46 +329,24 @@ export function SyncStrategySettings({
                       {settings.syncCondition === "wifi_ssid" && "Upload only on a specific Wi-Fi network"}
                       {settings.syncCondition === "vpn" && "Upload only when VPN is active"}
                     </Text>
-                    <View style={styles.syncConditionChips}>
-                      {(
-                        [
-                          { value: "any", label: "Any" },
-                          { value: "wifi_any", label: "Wi-Fi" },
-                          { value: "wifi_ssid", label: "SSID" },
-                          { value: "vpn", label: "VPN" }
-                        ] as { value: SyncCondition; label: string }[]
-                      ).map((option) => (
-                        <Pressable
-                          key={option.value}
-                          onPress={() => {
-                            const next = {
-                              ...settings,
-                              syncCondition: option.value,
-                              syncPreset: "custom" as const
-                            }
-                            onSettingsChange(next)
-                            onImmediateSave(next)
-                          }}
-                          style={[
-                            styles.syncConditionChip,
-                            {
-                              backgroundColor:
-                                settings.syncCondition === option.value ? colors.primary + "20" : colors.background,
-                              borderColor: settings.syncCondition === option.value ? colors.primary : colors.border
-                            }
-                          ]}
-                        >
-                          <Text
-                            style={[
-                              styles.syncConditionChipText,
-                              { color: settings.syncCondition === option.value ? colors.primary : colors.textSecondary }
-                            ]}
-                          >
-                            {option.label}
-                          </Text>
-                        </Pressable>
-                      ))}
-                    </View>
+                    <ChipGroup
+                      options={[
+                        { value: "any", label: "Any" },
+                        { value: "wifi_any", label: "Wi-Fi" },
+                        { value: "wifi_ssid", label: "SSID" },
+                        { value: "vpn", label: "VPN" }
+                      ]}
+                      selected={settings.syncCondition}
+                      onSelect={(value) => {
+                        const next = {
+                          ...settings,
+                          syncCondition: value as SyncCondition,
+                          syncPreset: "custom" as const
+                        }
+                        onSettingsChange(next)
+                        onImmediateSave(next)
+                      }}
+                    />
                     {settings.syncCondition === "wifi_ssid" && (
                       <View style={styles.ssidRow}>
                         <TextInput
@@ -540,22 +486,6 @@ const styles = StyleSheet.create({
     marginBottom: space.md,
     lineHeight: 18
   },
-  optionsGrid: {
-    flexDirection: "row",
-    gap: space.sm,
-    flexWrap: "wrap"
-  },
-  gridOption: {
-    width: "31%", // ~3 per row with gap in a flexWrap container
-    borderWidth: 2,
-    borderRadius: 10,
-    paddingVertical: 14,
-    alignItems: "center"
-  },
-  gridLabel: {
-    fontSize: fontSizes.body,
-    ...fonts.semiBold
-  },
   settingRowSpaced: {
     marginTop: space.lg
   },
@@ -566,20 +496,6 @@ const styles = StyleSheet.create({
   },
   customSyncInput: {
     marginTop: space.md
-  },
-  syncConditionChips: {
-    flexDirection: "row",
-    gap: 6
-  },
-  syncConditionChip: {
-    paddingHorizontal: space.md,
-    paddingVertical: 6,
-    borderRadius: radius.md,
-    borderWidth: 1
-  },
-  syncConditionChipText: {
-    ...fonts.medium,
-    fontSize: fontSizes.caption
   },
   ssidRow: {
     flexDirection: "row",

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -7,6 +7,21 @@ jest.mock("../../../index", () => {
   const R = require("react")
   const { View, Text, TextInput } = require("react-native")
   return {
+    ChipGroup: function (props: any) {
+      const R = require("react")
+      const RN = require("react-native")
+      return R.createElement(
+        RN.View,
+        null,
+        props.options.map(function (o: any) {
+          return R.createElement(
+            RN.Pressable,
+            { key: o.value, testID: o.testID, onPress: () => props.onSelect(o.value) },
+            R.createElement(RN.Text, null, o.label)
+          )
+        })
+      )
+    },
     Button: function (props: any) {
       return require("react").createElement(
         require("react-native").Pressable,

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -21,6 +21,7 @@ type ListItemProps = {
   testID?: string
   accessibilityRole?: "button" | "link"
   accessibilityHint?: string
+  disabled?: boolean
 }
 
 export function ListItem({
@@ -31,7 +32,8 @@ export function ListItem({
   onPress,
   testID,
   accessibilityRole = "button",
-  accessibilityHint
+  accessibilityHint,
+  disabled = false
 }: ListItemProps) {
   const { colors } = useTheme()
   return (
@@ -40,24 +42,26 @@ export function ListItem({
       accessibilityRole={accessibilityRole}
       accessibilityLabel={label}
       accessibilityHint={accessibilityHint ?? `Opens ${label}`}
-      android_ripple={{ color: colors.border }}
+      accessibilityState={{ disabled }}
+      android_ripple={disabled ? undefined : { color: colors.border }}
+      disabled={disabled}
       onPress={onPress}
-      style={({ pressed }) => [styles.row, pressed && { opacity: colors.pressedOpacity }]}
+      style={({ pressed }) => [styles.row, pressed && !disabled && { opacity: colors.pressedOpacity }]}
     >
       {Icon && (
         <View style={styles.icon}>
-          <Icon size={size.icon.md} color={colors.textLight} />
+          <Icon size={size.icon.md} color={disabled ? colors.textDisabled : colors.textLight} />
         </View>
       )}
       <View style={styles.content}>
-        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+        <Text style={[styles.label, { color: disabled ? colors.textDisabled : colors.text }]}>{label}</Text>
         {sub ? (
-          <Text style={[styles.sub, { color: colors.textSecondary }]} numberOfLines={1}>
+          <Text style={[styles.sub, { color: disabled ? colors.textDisabled : colors.textSecondary }]} numberOfLines={1}>
             {sub}
           </Text>
         ) : null}
       </View>
-      <TrailingIcon size={size.icon.md} color={colors.textLight} />
+      <TrailingIcon size={size.icon.md} color={disabled ? colors.textDisabled : colors.textLight} />
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -14,15 +14,20 @@ interface SettingRowProps {
   hint?: string
   children: React.ReactNode
   style?: StyleProp<ViewStyle>
+  disabled?: boolean
 }
 
-export function SettingRow({ label, hint, children, style }: SettingRowProps) {
+export function SettingRow({ label, hint, children, style, disabled = false }: SettingRowProps) {
   const { colors } = useTheme()
   return (
     <View style={[styles.settingRow, style]}>
       <View style={styles.settingContent}>
-        <Text style={[styles.settingLabel, { color: colors.text }]}>{label}</Text>
-        {hint && <Text style={[styles.settingHint, { color: colors.textSecondary }]}>{hint}</Text>}
+        <Text style={[styles.settingLabel, { color: disabled ? colors.textDisabled : colors.text }]}>{label}</Text>
+        {hint && (
+          <Text style={[styles.settingHint, { color: disabled ? colors.textDisabled : colors.textSecondary }]}>
+            {hint}
+          </Text>
+        )}
       </View>
       {children}
     </View>

--- a/apps/mobile/src/components/ui/__tests__/SettingRow.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/SettingRow.test.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { Text } from "react-native"
+import { lightColors } from "@colota/shared"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { SettingRow } from "../SettingRow"
+
+describe("SettingRow", () => {
+  it("drops the label and hint to the disabled token when disabled", () => {
+    // Three geofence rows dimmed the whole row at 0.45 instead, which also faded the
+    // control inside it and told a screen reader nothing.
+    const { getByText } = render(
+      <SettingRow label="WiFi/Ethernet pause" hint="Stop GPS on unmetered networks" disabled>
+        <Text>child</Text>
+      </SettingRow>
+    )
+
+    const flat = (el: any) => Object.assign({}, ...[el.props.style].flat(Infinity).filter(Boolean))
+    expect(flat(getByText("WiFi/Ethernet pause")).color).toBe(lightColors.textDisabled)
+    expect(flat(getByText("Stop GPS on unmetered networks")).color).toBe(lightColors.textDisabled)
+  })
+
+  it("uses the normal ink otherwise", () => {
+    const { getByText } = render(
+      <SettingRow label="WiFi/Ethernet pause">
+        <Text>child</Text>
+      </SettingRow>
+    )
+
+    const flat = (el: any) => Object.assign({}, ...[el.props.style].flat(Infinity).filter(Boolean))
+    expect(flat(getByText("WiFi/Ethernet pause")).color).toBe(lightColors.text)
+  })
+})

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -257,7 +257,8 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           <SettingRow
             label="WiFi/Ethernet pause"
             hint="Stop GPS on unmetered networks"
-            style={[styles.toggleRow, !pauseTracking && styles.disabledRow]}
+            style={styles.toggleRow}
+            disabled={!pauseTracking}
           >
             <Toggle
               accessibilityLabel="WiFi/Ethernet pause"
@@ -271,7 +272,8 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           <SettingRow
             label="Motionless pause"
             hint="Stop GPS after no motion for a set time"
-            style={[styles.toggleRow, !pauseTracking && styles.disabledRow]}
+            style={styles.toggleRow}
+            disabled={!pauseTracking}
           >
             <Toggle
               accessibilityLabel="Motionless pause"
@@ -304,7 +306,8 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           <SettingRow
             label="Stationary heartbeat"
             hint="Periodic point at the zone center while paused"
-            style={[styles.toggleRow, !pauseTracking && styles.disabledRow]}
+            style={styles.toggleRow}
+            disabled={!pauseTracking}
           >
             <Toggle
               accessibilityLabel="Stationary heartbeat"
@@ -372,7 +375,6 @@ const styles = StyleSheet.create({
   nameInput: { flex: 1 },
   numInput: { width: 80, textAlign: "center" },
   toggleRow: { paddingVertical: 10 },
-  disabledRow: { opacity: 0.45 },
   nestedSetting: {
     marginStart: space.lg,
     paddingStart: space.md,


### PR DESCRIPTION
Rows had no disabled state. The three geofence pause rows faked one by fading the whole row at 0.45, which also dimmed the switch and left TalkBack announcing nothing.

SettingRow and ListItem now take `disabled`: the label and hint drop to `textDisabled`, and `accessibilityState` carries it.