### PR TITLE
feat(ui): the two add rows are buttons, not dashed boxes

### DIFF
--- a/apps/mobile/src/components/ui/__tests__/Button.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { StyleSheet } from "react-native"
+import { lightColors } from "@colota/shared"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { Button } from "../Button"
+
+const flat = (el: any) => StyleSheet.flatten(el.props.style)
+
+describe("Button variants", () => {
+  it("fills a secondary rather than outlining it", () => {
+    // The two + Add controls were dashed boxes, which is the one border style the app had
+    // nowhere else. A fill keeps them reading as controls without inventing a stroke.
+    const { getByTestId } = render(
+      <Button title="+ Add Header" onPress={jest.fn()} variant="secondary" testID="add-btn" />
+    )
+
+    const style = flat(getByTestId("add-btn"))
+    expect(style.backgroundColor).toBe(lightColors.primaryContainer)
+    expect(style.borderWidth).toBe(0)
+  })
+
+  it("keeps the touch target at the Android minimum", () => {
+    const { getByTestId } = render(<Button title="Save profile" onPress={jest.fn()} testID="save-btn" />)
+
+    expect(flat(getByTestId("save-btn")).minHeight).toBe(48)
+  })
+})

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -21,7 +21,7 @@ import { useTimeout } from "../hooks/useTimeout"
 import { useTracking } from "../contexts/TrackingProvider"
 import NativeLocationService from "../services/NativeLocationService"
 import { fontSizes, fonts } from "../styles/typography"
-import { SectionTitle, FloatingSaveIndicator, Container, Divider, ChipGroup } from "../components"
+import { SectionTitle, FloatingSaveIndicator, Container, Divider, ChipGroup, Button } from "../components"
 import { findDuplicates } from "../utils/settingsValidation"
 import {
   buildTraccarJsonPayload,
@@ -684,16 +684,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
               })
             )}
 
-            <Pressable
-              onPress={handleAddCustomField}
-              style={({ pressed }) => [
-                styles.addButton,
-                { borderColor: colors.border },
-                pressed && { opacity: colors.pressedOpacity }
-              ]}
-            >
-              <Text style={[styles.addButtonText, { color: colors.primaryDark }]}>+ Add Field</Text>
-            </Pressable>
+            <Button title="+ Add Field" onPress={handleAddCustomField} variant="secondary" />
           </View>
         </View>
 
@@ -876,18 +867,6 @@ const styles = StyleSheet.create({
   removeButtonText: {
     fontSize: fontSizes.description,
     ...fonts.bold
-  },
-  addButton: {
-    paddingVertical: space.md,
-    alignItems: "center",
-    borderRadius: 10,
-    borderWidth: 1.5,
-    borderStyle: "dashed",
-    marginTop: space.sm
-  },
-  addButtonText: {
-    fontSize: fontSizes.body,
-    ...fonts.semiBold
   },
   emptyHint: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -11,7 +11,7 @@ import { useTheme } from "../hooks/useTheme"
 import { useAutoSave } from "../hooks/useAutoSave"
 import { useTracking } from "../contexts/TrackingProvider"
 import { fonts, fontSizes } from "../styles/typography"
-import { SectionTitle, FloatingSaveIndicator, Container, Card, Divider, ChipGroup } from "../components"
+import { SectionTitle, FloatingSaveIndicator, Container, Card, Divider, ChipGroup, Button } from "../components"
 import NativeLocationService from "../services/NativeLocationService"
 import { logger } from "../utils/logger"
 import { findDuplicates } from "../utils/settingsValidation"
@@ -310,16 +310,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
 
             {localHeaders.length > 0 && <Divider />}
 
-            <Pressable
-              style={({ pressed }) => [
-                styles.addButton,
-                { borderColor: colors.primary },
-                pressed && { opacity: colors.pressedOpacity }
-              ]}
-              onPress={addHeader}
-            >
-              <Text style={[styles.addButtonText, { color: colors.primaryDark }]}>+ Add Header</Text>
-            </Pressable>
+            <Button title="+ Add Header" onPress={addHeader} variant="secondary" />
 
             <Text style={[styles.hint, { color: colors.textSecondary }]}>
               e.g., CF-Access-Client-Id for Cloudflare Access
@@ -448,18 +439,6 @@ const styles = StyleSheet.create({
   removeButtonText: {
     fontSize: fontSizes.body,
     ...fonts.bold
-  },
-  addButton: {
-    paddingVertical: 14,
-    alignItems: "center",
-    borderRadius: radius.md,
-    borderWidth: 1.5,
-    borderStyle: "dashed",
-    marginTop: space.xs
-  },
-  addButtonText: {
-    fontSize: fontSizes.input,
-    ...fonts.semiBold
   },
   hint: {
     fontSize: fontSizes.caption,


### PR DESCRIPTION
The two `+ Add` controls were the only dashed borders in the app, and each rebuilt the same full-width box by hand with its own radius, border width and font size.

They are `secondary` Buttons now: same footprint, container fill instead of the dashed stroke.