### PR TITLE
fix(ui): a disabled chip recolours instead of fading

### DIFF
--- a/apps/mobile/src/components/ui/ChipGroup.tsx
+++ b/apps/mobile/src/components/ui/ChipGroup.tsx
@@ -29,6 +29,9 @@ export function ChipGroup<T extends string>({ options, selected, onSelect, disab
       {options.map(({ value, label, testID }) => {
         const isSelected = selected === value
         const isDisabled = disabled?.has(value) ?? false
+        // Disabled recolours the content rather than fading the chip, so the fill still reads
+        // as a chip and the selected one still says which it is.
+        const content = isDisabled ? colors.textDisabled : isSelected ? colors.onPrimaryContainer : colors.text
         return (
           <Pressable
             key={value}
@@ -39,23 +42,12 @@ export function ChipGroup<T extends string>({ options, selected, onSelect, disab
             style={({ pressed }) => [
               styles.chip,
               { backgroundColor: isSelected ? colors.primaryContainer : colors.well },
-              isDisabled && { opacity: 0.4 },
               pressed && !isDisabled && { opacity: colors.pressedOpacity }
             ]}
             onPress={() => onSelect(value)}
           >
-            {isSelected ? (
-              <Check size={size.icon.sm} color={colors.onPrimaryContainer} strokeWidth={2} />
-            ) : null}
-            <Text
-              style={[
-                styles.label,
-                isSelected && styles.labelSelected,
-                { color: isSelected ? colors.onPrimaryContainer : colors.text }
-              ]}
-            >
-              {label}
-            </Text>
+            {isSelected ? <Check size={size.icon.sm} color={content} strokeWidth={2} /> : null}
+            <Text style={[styles.label, isSelected && styles.labelSelected, { color: content }]}>{label}</Text>
           </Pressable>
         )
       })}

--- a/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
@@ -15,9 +15,7 @@ const OPTIONS = [
 
 describe("ChipGroup", () => {
   it("fills the selected chip and recesses the rest, so neither carries a stroke", () => {
-    const { getByTestId } = render(
-      <ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} />
-    )
+    const { getByTestId } = render(<ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} />)
 
     const flat = (el: any) => Object.assign({}, ...[el.props.style].flat(Infinity).filter(Boolean))
     expect(flat(getByTestId("chip-b")).backgroundColor).toBe(lightColors.primaryContainer)
@@ -25,11 +23,20 @@ describe("ChipGroup", () => {
     expect(flat(getByTestId("chip-a")).borderWidth).toBeUndefined()
   })
 
+  it("recolours a disabled chip instead of fading the whole thing", () => {
+    const { getByTestId, getByText } = render(
+      <ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} disabled={new Set(["a"] as const)} />
+    )
+
+    const flat = (el: any) => Object.assign({}, ...[el.props.style].flat(Infinity).filter(Boolean))
+    expect(flat(getByTestId("chip-a")).opacity).toBeUndefined()
+    expect(flat(getByTestId("chip-a")).backgroundColor).toBe(lightColors.well)
+    expect(flat(getByText("None")).color).toBe(lightColors.textDisabled)
+  })
+
   it("marks selection with a check and a state, not colour alone", () => {
     // Colour-only selection fails a colour-blind user and is an Accessibility Scanner finding.
-    const { getByTestId } = render(
-      <ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} />
-    )
+    const { getByTestId } = render(<ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} />)
 
     expect(getByTestId("chip-b").props.accessibilityState.checked).toBe(true)
     expect(getByTestId("chip-a").props.accessibilityState.checked).toBe(false)


### PR DESCRIPTION
The chip was the one primitive that drew disabled as a blanket `opacity: 0.4`, which faded the fill along with the label. A disabled chip stopped reading as a chip, and a disabled selected one stopped showing its check.

It now drops its content to `colors.textDisabled` like every other primitive. That was also the last literal opacity in `components/ui`.