### PR TITLE
chore(screens): delete the styles the TextField sweep orphaned

### DIFF
--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -26,7 +26,6 @@ import { logger } from "../utils/logger"
 import { formatExportDateTime, formatBytes } from "../utils/format"
 import { showAlert } from "../services/modalService"
 import { SAVE_SUCCESS_DISPLAY_MS, size, space } from "../constants"
-import { radius } from "@colota/shared"
 
 type ExportInterval = "daily" | "weekly" | "monthly"
 type ExportMode = "all" | "incremental"
@@ -730,14 +729,6 @@ const styles = StyleSheet.create({
     ...fonts.semiBold,
     marginTop: space.md,
     marginBottom: space.sm
-  },
-  templateInput: {
-    fontSize: fontSizes.input,
-    ...fonts.regular,
-    borderWidth: 1,
-    borderRadius: radius.sm,
-    paddingHorizontal: space.md,
-    paddingVertical: 10
   },
   templateHint: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -358,23 +358,6 @@ const styles = StyleSheet.create({
     fontWeight: "500",
     marginBottom: space.sm
   },
-  inputRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    borderWidth: 1,
-    borderRadius: radius.sm,
-    marginBottom: space.sm
-  },
-  inputField: {
-    flex: 1,
-    paddingHorizontal: space.md,
-    paddingVertical: space.md,
-    fontSize: fontSizes.label
-  },
-  eyeButton: {
-    paddingHorizontal: space.md,
-    paddingVertical: space.md
-  },
   strengthRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -16,7 +16,6 @@ import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
 import { parsePositiveInt, isPositiveInt } from "../utils/settingsValidation"
 import type { RootScreenProps } from "../types/navigation"
 import { space } from "../constants"
-import { radius } from "@colota/shared"
 
 declare function requestIdleCallback(callback: () => void): number
 declare function cancelIdleCallback(handle: number): void
@@ -365,12 +364,6 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
 const styles = StyleSheet.create({
   content: { padding: 20, paddingBottom: 40 },
   card: { marginBottom: space.lg },
-  input: {
-    padding: 10,
-    borderWidth: 1.5,
-    borderRadius: radius.sm,
-    fontSize: fontSizes.input
-  },
   nameInput: { flex: 1 },
   numInput: { width: 80, textAlign: "center" },
   toggleRow: { paddingVertical: 10 },

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -379,15 +379,6 @@ const styles = StyleSheet.create({
     flex: 0,
     minWidth: 90
   },
-  label: {
-    fontSize: fontSizes.caption,
-    ...fonts.semiBold,
-    marginBottom: 6
-  },
-  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input },
-  inputCentered: {
-    textAlign: "center"
-  },
   card: { marginBottom: space.md },
   row: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -886,12 +886,6 @@ const styles = StyleSheet.create({
   section: { marginBottom: space.lg },
   hint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18, marginBottom: space.lg },
   inputGroup: { marginBottom: space.lg },
-  label: {
-    fontSize: fontSizes.caption,
-    ...fonts.semiBold,
-    marginBottom: 6
-  },
-  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input },
   sizeEstimate: { fontSize: fontSizes.caption, ...fonts.regular, marginBottom: space.md },
   progressContainer: { gap: 10 },
   progressHeader: { flexDirection: "row", alignItems: "center", gap: 10 },

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -437,12 +437,6 @@ const styles = StyleSheet.create({
   scrollContent: { paddingHorizontal: space.lg, paddingTop: space.lg, paddingBottom: 40 },
   header: { marginBottom: 20 },
   inputGroup: { marginBottom: space.xs },
-  label: {
-    fontSize: fontSizes.caption,
-    ...fonts.semiBold,
-    marginBottom: 6
-  },
-  input: { padding: 14, borderWidth: 1.5, borderRadius: 10, fontSize: fontSizes.input, ...fonts.regular },
   numInput: {
     borderWidth: 1,
     padding: 10,


### PR DESCRIPTION
Thirteen style rules and three imports that nothing references any more, left behind when thirty-three fields moved onto `TextField`. Includes the whole hand-built password row in `BackupRestoreScreen`.

No rendered output changes.