### PR TITLE
feat(screens): six link rows use ListItem

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -4,8 +4,8 @@
  */
 
 import React, { useState, useCallback, useEffect, useRef } from "react"
-import { Text, StyleSheet, View, Pressable } from "react-native"
-import { CircleCheckBig, ChevronRight } from "lucide-react-native"
+import { Text, StyleSheet, View } from "react-native"
+import { CircleCheckBig } from "lucide-react-native"
 import { Settings, ThemeColors } from "../../../types/global"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { isEndpointAllowed } from "../../../utils/settingsValidation"
@@ -16,7 +16,7 @@ import { SettingRow } from "../../ui/SettingRow"
 import { useTimeout } from "../../../hooks/useTimeout"
 import { TEST_RESULT_DISPLAY_MS, size, space } from "../../../constants"
 import { logger } from "../../../utils/logger"
-import { Button, Card, Divider, FieldMessage, SectionTitle, TextField, Toggle } from "../../index"
+import { Button, Card, Divider, FieldMessage, SectionTitle, TextField, Toggle, ListItem } from "../../index"
 import { showChoice } from "../../../services/modalService"
 import { radius } from "@colota/shared"
 
@@ -275,18 +275,12 @@ export function ConnectionSettings({
 
             <Divider />
 
-            <Pressable
-              style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
+            <ListItem
+              testID="nav-auth-settings"
+              label="Authentication & headers"
+              sub="Basic auth, bearer tokens, custom headers"
               onPress={() => navigation.navigate("Auth Settings")}
-            >
-              <View style={styles.linkContent}>
-                <Text style={[styles.linkLabel, { color: colors.text }]}>Authentication & headers</Text>
-                <Text style={[styles.linkSub, { color: colors.textSecondary }]}>
-                  Basic auth, bearer tokens, custom headers
-                </Text>
-              </View>
-              <ChevronRight size={size.icon.md} color={colors.textLight} />
-            </Pressable>
+            />
           </>
         )}
       </Card>
@@ -337,22 +331,4 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.body,
     ...fonts.semiBold
   },
-  linkRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: space.md
-  },
-  linkContent: {
-    flex: 1
-  },
-  linkLabel: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold,
-    marginBottom: 2
-  },
-  linkSub: {
-    fontSize: fontSizes.description,
-    ...fonts.regular
-  }
 })

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -6,6 +6,7 @@ jest.mock("../../../index", () => {
   const R = require("react")
   const { View, Text, Pressable } = require("react-native")
   return {
+    ListItem: require("../../../../testing/componentStubs").ListItemStub,
     TextField: require("../../../../testing/componentStubs").TextFieldStub,
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -5,11 +5,11 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from "react"
 import { Text, StyleSheet, View, ScrollView, Linking, Pressable, Image } from "react-native"
-import { ScreenProps, ThemeColors } from "../types/global"
+import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
-import { ExternalLink, Bug, FileText, Code, ScrollText, MessageCircle, Copy, Check } from "lucide-react-native"
+import { ExternalLink, Bug, FileText, Code, ScrollText, MessageCircle, Copy, Check, type LucideIcon } from "lucide-react-native"
 import { fontSizes, fonts } from "../styles/typography"
-import { Card, Container, Divider, SectionTitle, Footer } from "../components"
+import { Card, Container, Divider, SectionTitle, Footer, ListItem } from "../components"
 import { useTimeout } from "../hooks/useTimeout"
 import NativeLocationService from "../services/NativeLocationService"
 import icon from "../assets/icons/icon.png"
@@ -54,27 +54,23 @@ const LinkRow = ({
   title,
   subtitle,
   url,
-  colors,
   onOpenURL
 }: {
-  icon: React.ComponentType<{ size: number; color: string }>
+  icon: LucideIcon
   title: string
   subtitle: string
   url: string
-  colors: ThemeColors
   onOpenURL: (url: string) => void
 }) => (
-  <Pressable
-    style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
+  <ListItem
+    label={title}
+    sub={subtitle}
+    icon={Icon}
+    trailingIcon={ExternalLink}
+    accessibilityRole="link"
+    accessibilityHint={`Opens ${title} in a browser`}
     onPress={() => onOpenURL(url)}
-  >
-    <Icon size={size.icon.md} color={colors.textLight} />
-    <View style={styles.linkTextContainer}>
-      <Text style={[styles.linkTitle, { color: colors.text }]}>{title}</Text>
-      <Text style={[styles.linkSubtitle, { color: colors.textLight }]}>{subtitle}</Text>
-    </View>
-    <ExternalLink size={size.icon.md} color={colors.textLight} />
-  </Pressable>
+  />
 )
 
 const DEBUG_MODE_SETTING_KEY = "debug_mode_enabled"
@@ -282,7 +278,6 @@ export function AboutScreen({}: ScreenProps) {
             title="Privacy policy"
             subtitle={PRIVACY_POLICY_URL}
             url={PRIVACY_POLICY_URL}
-            colors={colors}
             onOpenURL={handleOpenURL}
           />
           <Divider />
@@ -291,7 +286,6 @@ export function AboutScreen({}: ScreenProps) {
             title="Source code"
             subtitle="github.com/dietrichmax/colota"
             url={REPO_URL}
-            colors={colors}
             onOpenURL={handleOpenURL}
           />
           <Divider />
@@ -300,7 +294,6 @@ export function AboutScreen({}: ScreenProps) {
             title="License"
             subtitle="GNU AGPLv3"
             url={`${REPO_URL}/blob/main/LICENSE`}
-            colors={colors}
             onOpenURL={handleOpenURL}
           />
           <Divider />
@@ -309,7 +302,6 @@ export function AboutScreen({}: ScreenProps) {
             title="Report a bug"
             subtitle="github.com/dietrichmax/colota/issues"
             url={ISSUES_URL}
-            colors={colors}
             onOpenURL={handleOpenURL}
           />
         </Card>
@@ -318,31 +310,23 @@ export function AboutScreen({}: ScreenProps) {
         <View style={styles.section}>
           <SectionTitle>Map data</SectionTitle>
           <Card>
-            <Pressable
-              style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
+            <ListItem
+              label="Colota tiles"
+              sub="Self-hosted map tile server - configure your own"
+              trailingIcon={ExternalLink}
+              accessibilityRole="link"
+              accessibilityHint="Opens Colota tiles in a browser"
               onPress={() => handleOpenURL(TILE_SERVER_DOCS_URL)}
-            >
-              <View style={styles.linkTextContainer}>
-                <Text style={[styles.linkTitle, { color: colors.text }]}>Colota tiles</Text>
-                <Text style={[styles.linkSubtitle, { color: colors.textLight }]}>
-                  Self-hosted map tile server - configure your own
-                </Text>
-              </View>
-              <ExternalLink size={size.icon.md} color={colors.textLight} />
-            </Pressable>
+            />
             <Divider />
-            <Pressable
-              style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
+            <ListItem
+              label="OpenStreetMap"
+              sub="Map data by OpenStreetMap contributors"
+              trailingIcon={ExternalLink}
+              accessibilityRole="link"
+              accessibilityHint="Opens OpenStreetMap in a browser"
               onPress={() => handleOpenURL("https://www.openstreetmap.org/copyright")}
-            >
-              <View style={styles.linkTextContainer}>
-                <Text style={[styles.linkTitle, { color: colors.text }]}>OpenStreetMap</Text>
-                <Text style={[styles.linkSubtitle, { color: colors.textLight }]}>
-                  Map data by OpenStreetMap contributors
-                </Text>
-              </View>
-              <ExternalLink size={size.icon.md} color={colors.textLight} />
-            </Pressable>
+            />
           </Card>
         </View>
 
@@ -425,23 +409,6 @@ const styles = StyleSheet.create({
   version: {
     fontSize: fontSizes.description,
     ...fonts.regular
-  },
-  linkRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 14,
-    gap: space.md
-  },
-  linkTextContainer: {
-    flex: 1
-  },
-  linkTitle: {
-    fontSize: fontSizes.input,
-    ...fonts.semiBold
-  },
-  linkSubtitle: {
-    fontSize: fontSizes.caption,
-    marginTop: 1
   },
   techRow: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -10,12 +10,12 @@ import { useTheme } from "../hooks/useTheme"
 import { useTranslation } from "../i18n/useTranslation"
 import NativeLocationService from "../services/NativeLocationService"
 import { fontSizes, fonts } from "../styles/typography"
-import { Card, ChipGroup, Container, Divider, SettingRow, Toggle, TextField } from "../components"
+import { Card, ChipGroup, Container, Divider, SettingRow, Toggle, TextField, ListItem } from "../components"
 import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
 import type { UnitSystem, TimeFormat } from "../utils/geo"
-import { size, space } from "../constants"
+import { space } from "../constants"
 
 export function AppearanceScreen({}: ScreenProps) {
   const { mode, toggleTheme, colors } = useTheme()
@@ -130,21 +130,14 @@ export function AppearanceScreen({}: ScreenProps) {
 
           <Divider />
 
-          <Pressable
+          <ListItem
             testID="map-tile-server-toggle"
-            style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
+            label={t("appearance.mapTileServer")}
+            sub={t("appearance.mapStyle.subtitle")}
+            trailingIcon={showMapTileServer ? ChevronUp : ChevronDown}
+            accessibilityHint={showMapTileServer ? "Collapses the tile server settings" : "Expands the tile server settings"}
             onPress={() => setShowMapTileServer(!showMapTileServer)}
-          >
-            <View style={styles.linkContent}>
-              <Text style={[styles.linkLabel, { color: colors.text }]}>{t("appearance.mapTileServer")}</Text>
-              <Text style={[styles.linkSub, { color: colors.textSecondary }]}>{t("appearance.mapStyle.subtitle")}</Text>
-            </View>
-            {showMapTileServer ? (
-              <ChevronUp size={size.icon.md} color={colors.textLight} />
-            ) : (
-              <ChevronDown size={size.icon.md} color={colors.textLight} />
-            )}
-          </Pressable>
+          />
 
           {showMapTileServer && (
             <View style={styles.mapTilePanel}>
@@ -208,24 +201,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: space.lg,
     paddingTop: space.lg,
     paddingBottom: space.lg
-  },
-  linkRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: space.md
-  },
-  linkContent: {
-    flex: 1
-  },
-  linkLabel: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold,
-    marginBottom: 2
-  },
-  linkSub: {
-    fontSize: fontSizes.description,
-    ...fonts.regular
   },
   mapTilePanel: {
     marginTop: space.xs,

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -5,17 +5,16 @@
 
 import React, { useState, useCallback, useEffect, useRef, useMemo } from "react"
 import { Text, StyleSheet, View, ScrollView, Pressable } from "react-native"
-import { ChevronRight } from "lucide-react-native"
 import { AuthConfig, AuthType, DEFAULT_AUTH_CONFIG, ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
 import { useAutoSave } from "../hooks/useAutoSave"
 import { useTracking } from "../contexts/TrackingProvider"
 import { fonts, fontSizes } from "../styles/typography"
-import { SectionTitle, FloatingSaveIndicator, Container, Card, Divider, ChipGroup, Button, TextField } from "../components"
+import { SectionTitle, FloatingSaveIndicator, Container, Card, Divider, ChipGroup, Button, TextField, ListItem } from "../components"
 import NativeLocationService from "../services/NativeLocationService"
 import { logger } from "../utils/logger"
 import { findDuplicates } from "../utils/settingsValidation"
-import { size, space } from "../constants"
+import { space } from "../constants"
 import { radius } from "@colota/shared"
 
 const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
@@ -295,18 +294,12 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
         <View style={styles.section}>
           <SectionTitle>Client certificate</SectionTitle>
           <Card>
-            <Pressable
-              style={({ pressed }) => [styles.linkRow, pressed && { opacity: colors.pressedOpacity }]}
+            <ListItem
+              testID="nav-mtls-settings"
+              label="Client Certificate (mTLS)"
+              sub="Authenticate to servers that require a client certificate"
               onPress={() => navigation.navigate("mTLS Settings")}
-            >
-              <View style={styles.linkContent}>
-                <Text style={[styles.linkLabel, { color: colors.text }]}>Client Certificate (mTLS)</Text>
-                <Text style={[styles.linkSub, { color: colors.textSecondary }]}>
-                  Authenticate to servers that require a client certificate
-                </Text>
-              </View>
-              <ChevronRight size={size.icon.md} color={colors.textLight} />
-            </Pressable>
+            />
           </Card>
         </View>
 
@@ -404,22 +397,4 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.small,
     textAlign: "center"
   },
-  linkRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: space.md
-  },
-  linkContent: {
-    flex: 1
-  },
-  linkLabel: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold,
-    marginBottom: 2
-  },
-  linkSub: {
-    fontSize: fontSizes.description,
-    ...fonts.regular
-  }
 })

--- a/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
@@ -84,6 +84,7 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    ListItem: require("../../testing/componentStubs").ListItemStub,
     Button: function (props: any) {
       return require("react").createElement(
         require("react-native").Pressable,

--- a/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
@@ -45,6 +45,7 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text } = require("react-native")
   return {
+    ListItem: require("../../testing/componentStubs").ListItemStub,
     TextField: require("../../testing/componentStubs").TextFieldStub,
     ChipGroup: function (props: any) {
       const RN = require("react-native")

--- a/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AuthSettingsScreen.test.tsx
@@ -61,6 +61,7 @@ jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text, Pressable } = require("react-native")
   return {
+    ListItem: require("../../testing/componentStubs").ListItemStub,
     TextField: require("../../testing/componentStubs").TextFieldStub,
     Toggle: function (props: any) {
       return require("react").createElement(require("react-native").Switch, {

--- a/apps/mobile/src/testing/componentStubs.tsx
+++ b/apps/mobile/src/testing/componentStubs.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from "react"
-import { View, Text, TextInput } from "react-native"
+import { View, Text, TextInput, Pressable } from "react-native"
 
 /** Mirrors TextField: the label above, the input, and the message only when error is a string. */
 export function TextFieldStub({ label, error, secure: _secure, mono: _mono, style: _style, ...rest }: any) {
@@ -17,5 +17,15 @@ export function TextFieldStub({ label, error, secure: _secure, mono: _mono, styl
       <TextInput {...rest} />
       {typeof error === "string" ? <Text>{error}</Text> : null}
     </View>
+  )
+}
+
+/** Mirrors ListItem: label, sub, and the press target the test fires. */
+export function ListItemStub({ label, sub, onPress, testID, disabled }: any) {
+  return (
+    <Pressable testID={testID} onPress={onPress} disabled={disabled}>
+      <Text>{label}</Text>
+      {sub ? <Text>{sub}</Text> : null}
+    </Pressable>
   )
 }


### PR DESCRIPTION
`ListItem` had one consumer, `SettingsScreen`, while eight other rows rebuilt label, sub, chevron and press state by hand in four slightly different ways.

Six of them now use it: Connection, Auth settings, Appearance and the three About rows. Sixteen orphaned style rules go with them.

Two are left alone on purpose: WelcomeCard's is a flex container holding two inline text links, and DataManagement's carries a coloured value badge `ListItem` has no slot for.