### PR TITLE
fix(settings): the connection screen said its name twice

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -16,7 +16,7 @@ import { SettingRow } from "../../ui/SettingRow"
 import { useTimeout } from "../../../hooks/useTimeout"
 import { TEST_RESULT_DISPLAY_MS, size, space } from "../../../constants"
 import { logger } from "../../../utils/logger"
-import { Button, Card, Divider, FieldMessage, SectionTitle, TextField, Toggle, ListItem } from "../../index"
+import { Button, Card, Divider, FieldMessage, TextField, Toggle, ListItem } from "../../index"
 import { showChoice } from "../../../services/modalService"
 import { radius } from "@colota/shared"
 
@@ -182,7 +182,6 @@ export function ConnectionSettings({
 
   return (
     <View style={styles.section}>
-      <SectionTitle>Connection</SectionTitle>
       <Card>
         <SettingRow label="Offline mode" hint="Save locally, no network sync">
           <Toggle

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -139,10 +139,10 @@ describe("ConnectionSettings", () => {
     )
   }
 
-  it("renders Connection section title", () => {
-    const { getByText } = renderComponent()
+  it("does not repeat the screen name the header already paints", () => {
+    const { queryByText } = renderComponent()
 
-    expect(getByText("Connection")).toBeTruthy()
+    expect(queryByText("Connection")).toBeNull()
   })
 
   it("shows Offline Mode toggle", () => {


### PR DESCRIPTION
The header paints "Connection" from `SCREEN_CONFIG` and `ConnectionSettings` painted it again as a section title. Its only caller is `ConnectionScreen`, so the word was on screen twice.

#680 missed it because the duplicate sits in a feature component rather than the screen file. All 25 routes were swept against every `SectionTitle`; this was the only one.