### PR TITLE
refactor(ui): NumericInput and TimePicker are built on TextField

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -203,7 +203,6 @@ export function SyncStrategySettings({
                 unit="seconds"
                 placeholder="1"
                 hint="How often to capture GPS position"
-                colors={colors}
               />
 
               <NumericInput
@@ -214,7 +213,6 @@ export function SyncStrategySettings({
                 unit={shortDistanceUnit()}
                 placeholder="10"
                 hint="Only record if moved more than this distance"
-                colors={colors}
               />
             </View>
 
@@ -283,7 +281,6 @@ export function SyncStrategySettings({
                         unit="seconds"
                         placeholder="1800"
                         hint="Custom interval in seconds"
-                        colors={colors}
                       />
                     </View>
                   )}
@@ -315,7 +312,6 @@ export function SyncStrategySettings({
                         unit="points"
                         placeholder="50"
                         hint={`Points/upload (${OVERLAND_BATCH_MIN}-${OVERLAND_BATCH_MAX}). Larger = fewer requests, bigger payloads.`}
-                        colors={colors}
                       />
                     </View>
                   )}
@@ -416,7 +412,6 @@ export function SyncStrategySettings({
                     unit={shortDistanceUnit()}
                     placeholder="50"
                     hint="Based on the chip's own estimate, which can be optimistic"
-                    colors={colors}
                   />
                 </View>
               )}

--- a/apps/mobile/src/components/ui/NumericInput.tsx
+++ b/apps/mobile/src/components/ui/NumericInput.tsx
@@ -4,11 +4,11 @@
  */
 
 import React from "react"
-import { View, Text, StyleSheet, TextInput } from "react-native"
-import { ThemeColors } from "../../types/global"
+import { View, Text, StyleSheet } from "react-native"
+import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { space } from "../../constants"
-import { radius } from "@colota/shared"
+import { TextField } from "./TextField"
 
 interface NumericInputProps {
   label: string
@@ -18,21 +18,13 @@ interface NumericInputProps {
   unit: string
   placeholder?: string
   min?: number
-  colors: ThemeColors
   hint?: string
+  testID?: string
 }
 
 /**
- * NumericInput Component
- *
- * A validated numeric input field with:
- * - Label and optional hint text
- * - Unit display (e.g., "seconds", "meters")
- * - Numeric keyboard
- * - Change and blur handlers for validation
- * - Themed styling
- *
- * Used for interval, distance, and threshold inputs.
+ * A validated numeric field with its own label, an optional hint and a unit beside it. The
+ * label stays here rather than on the TextField because the unit sits in the same row.
  */
 export function NumericInput({
   label,
@@ -41,34 +33,27 @@ export function NumericInput({
   onBlur,
   unit,
   placeholder = "0",
-  colors,
-  hint
+  hint,
+  testID
 }: NumericInputProps) {
+  const { colors } = useTheme()
+
   return (
     <View style={styles.container}>
-      {/* Label */}
       <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
-
-      {/* Hint (optional) */}
       {hint && <Text style={[styles.hint, { color: colors.textSecondary }]}>{hint}</Text>}
 
-      {/* Input Row */}
       <View style={styles.inputRow}>
-        <TextInput
-          style={[
-            styles.input,
-            {
-              borderColor: colors.border,
-              color: colors.text,
-              backgroundColor: colors.backgroundElevated
-            }
-          ]}
+        <TextField
+          accessibilityLabel={label}
+          testID={testID}
+          figure
+          style={styles.field}
           keyboardType="numeric"
           value={value}
           onChangeText={onChange}
           onBlur={onBlur}
           placeholder={placeholder}
-          placeholderTextColor={colors.placeholder}
         />
         <Text style={[styles.unit, { color: colors.textSecondary }]}>{unit}</Text>
       </View>
@@ -96,13 +81,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: space.md
   },
-  input: {
-    flex: 1,
-    borderWidth: 1,
-    padding: 14,
-    borderRadius: radius.md,
-    fontSize: fontSizes.input,
-    textAlign: "center"
+  field: {
+    flex: 1
   },
   unit: {
     fontSize: fontSizes.input,

--- a/apps/mobile/src/components/ui/TextField.tsx
+++ b/apps/mobile/src/components/ui/TextField.tsx
@@ -153,7 +153,8 @@ const styles = StyleSheet.create({
   },
   figure: {
     textAlign: "center",
-    ...fonts.medium
+    ...fonts.medium,
+    fontVariant: ["tabular-nums"]
   },
   boxMultiline: {
     alignItems: "flex-start",

--- a/apps/mobile/src/components/ui/TimePicker.tsx
+++ b/apps/mobile/src/components/ui/TimePicker.tsx
@@ -4,17 +4,16 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from "react"
-import { View, Text, TextInput, StyleSheet } from "react-native"
-import { ThemeColors } from "../../types/global"
+import { View, Text, StyleSheet } from "react-native"
+import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { clamp, pad2 } from "../../utils/format"
 import { space } from "../../constants"
-import { radius } from "@colota/shared"
+import { TextField } from "./TextField"
 
 interface TimePickerProps {
   value: string
   onChange: (value: string) => void
-  colors: ThemeColors
 }
 
 const HOUR_MIN = 0
@@ -32,7 +31,8 @@ function format(h: number, m: number): string {
   return `${pad2(h)}:${pad2(m)}`
 }
 
-export function TimePicker({ value, onChange, colors }: TimePickerProps) {
+export function TimePicker({ value, onChange }: TimePickerProps) {
+  const { colors } = useTheme()
   const { h, m } = useMemo(() => parse(value), [value])
 
   const [hourText, setHourText] = useState(pad2(h))
@@ -64,34 +64,30 @@ export function TimePicker({ value, onChange, colors }: TimePickerProps) {
 
   return (
     <View style={styles.row}>
-      <TextInput
+      <TextField
         testID="timepicker-hour-value"
         accessibilityLabel="Hours"
+        figure
+        style={styles.field}
         value={hourText}
         onChangeText={onHourChange}
         onBlur={commitHour}
         keyboardType="number-pad"
         maxLength={2}
         selectTextOnFocus
-        style={[
-          styles.input,
-          { borderColor: colors.border, backgroundColor: colors.backgroundElevated, color: colors.text }
-        ]}
       />
       <Text style={[styles.separator, { color: colors.text }]}>:</Text>
-      <TextInput
+      <TextField
         testID="timepicker-minute-value"
         accessibilityLabel="Minutes"
+        figure
+        style={styles.field}
         value={minuteText}
         onChangeText={onMinuteChange}
         onBlur={commitMinute}
         keyboardType="number-pad"
         maxLength={2}
         selectTextOnFocus
-        style={[
-          styles.input,
-          { borderColor: colors.border, backgroundColor: colors.backgroundElevated, color: colors.text }
-        ]}
       />
     </View>
   )
@@ -104,15 +100,8 @@ const styles = StyleSheet.create({
     gap: space.sm,
     paddingVertical: space.xs
   },
-  input: {
-    minWidth: 64,
-    padding: 14,
-    borderRadius: radius.md,
-    borderWidth: 1,
-    fontSize: fontSizes.input,
-    ...fonts.semiBold,
-    fontVariant: ["tabular-nums"],
-    textAlign: "center"
+  field: {
+    minWidth: 64
   },
   separator: {
     fontSize: fontSizes.input,

--- a/apps/mobile/src/components/ui/__tests__/NumericInput.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/NumericInput.test.tsx
@@ -1,15 +1,10 @@
 import React from "react"
 import { render, fireEvent } from "@testing-library/react-native"
-import { NumericInput } from "../NumericInput"
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
 
-const mockColors = {
-  text: "#000",
-  textLight: "#9ca3af",
-  textSecondary: "#6b7280",
-  border: "#e5e7eb",
-  backgroundElevated: "#f9fafb",
-  placeholder: "#9ca3af"
-} as any
+import { NumericInput } from "../NumericInput"
 
 describe("NumericInput", () => {
   const mockOnChange = jest.fn()
@@ -27,7 +22,6 @@ describe("NumericInput", () => {
         onChange={mockOnChange}
         onBlur={mockOnBlur}
         unit="seconds"
-        colors={mockColors}
         {...overrides}
       />
     )

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -488,14 +488,13 @@ export function AutoExportScreen(_props: ScreenProps) {
                   unit="day"
                   placeholder="1"
                   min={1}
-                  colors={colors}
                   hint="1-31. Falls back to last day in shorter months."
                 />
               </>
             )}
             <Divider />
             <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Time (24h)</Text>
-            <TimePicker value={timeOfDay} onChange={handleTimeChange} colors={colors} />
+            <TimePicker value={timeOfDay} onChange={handleTimeChange} />
           </Card>
         </View>
 
@@ -528,7 +527,6 @@ export function AutoExportScreen(_props: ScreenProps) {
               unit="files"
               placeholder="10"
               min={0}
-              colors={colors}
               hint={
                 filenameTemplate.includes("{device}")
                   ? "Set to 0 for unlimited. Counts only exports named for this device model, so other models sharing the folder are untouched."

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -349,7 +349,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                     unit="seconds"
                     placeholder="1800"
                     hint="Custom interval in seconds"
-                    colors={colors}
                   />
                 </View>
               )}


### PR DESCRIPTION
Both primitives rebuilt the border, radius and padding `TextField` already owns, and both required a `colors` prop that eight call sites passed by hand.

`figure` gains `tabular-nums` on the way, which `TimePicker` had and `NumericInput` did not, so digits no longer jitter while you type. Both boxes inherit `TextField`'s `radius.sm` and fill.

Raw `TextInput` is down to two: the map popup note and the log search bar.