### PR TITLE
fix(ui): an off switch had no visible thumb

### DIFF
--- a/apps/mobile/src/components/ui/Toggle.tsx
+++ b/apps/mobile/src/components/ui/Toggle.tsx
@@ -42,8 +42,8 @@ export function Toggle({
       onValueChange={onValueChange}
       disabled={disabled}
       accessibilityLabel={accessibilityLabel}
-      trackColor={{ false: colors.border, true: hue + "80" }}
-      thumbColor={value ? hue : colors.border}
+      trackColor={{ false: undefined, true: hue + "80" }}
+      thumbColor={value ? hue : undefined}
     />
   )
 }

--- a/apps/mobile/src/components/ui/__tests__/Toggle.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Toggle.test.tsx
@@ -9,24 +9,28 @@ jest.mock("../../../hooks/useTheme", () => ({
 import { Toggle } from "../Toggle"
 
 describe("Toggle", () => {
-  it("paints the track and thumb from the primary hue, which is what the twelve call sites each built by hand", () => {
+  it("paints the on state from the primary hue, which is what the twelve call sites each built by hand", () => {
     const { getByTestId } = render(
       <Toggle testID="t" value={true} onValueChange={jest.fn()} accessibilityLabel="Offline mode" />
     )
 
-    // RN resolves trackColor and thumbColor into these three before they reach the platform.
+    // RN resolves trackColor and thumbColor into these before they reach the platform.
     const el = getByTestId("t")
-    expect(el.props.tintColor).toBe(lightColors.border)
     expect(el.props.onTintColor).toBe(lightColors.primary + "80")
     expect(el.props.thumbTintColor).toBe(lightColors.primary)
   })
 
-  it("moves the thumb to the border colour when off, so an off switch reads as unset rather than tinted", () => {
+  it("leaves the off state to Android, so the thumb is not the colour of its own track", () => {
+    // Tinting both with colors.border made them identical at 1.00:1, so an off switch was a
+    // uniform pill with no visible thumb. Undefined clears the colour filter and restores the
+    // platform drawable, which also fixes how a disabled switch renders.
     const { getByTestId } = render(
       <Toggle testID="t" value={false} onValueChange={jest.fn()} accessibilityLabel="Offline mode" />
     )
 
-    expect(getByTestId("t").props.thumbTintColor).toBe(lightColors.border)
+    const el = getByTestId("t")
+    expect(el.props.thumbTintColor).toBeUndefined()
+    expect(el.props.tintColor).toBeUndefined()
   })
 
   it("takes the warning hue only when asked", () => {


### PR DESCRIPTION
The off track and the off thumb were both `colors.border` - the same colour, 1.00:1 - so an off switch was a uniform pill with no readable thumb. Disabled had the same problem for the same reason.

Passing `undefined` clears RN's colour filter and restores Android's own switch drawable: readable by construction, follows night mode and the system high-contrast setting, and familiar because it is the switch in every other app. Only the on state stays tinted.

The mockup's fix needs an `outline` token we do not have; with our palette the closest equivalent reaches only 1.24:1, so this is both better for users and free of the deferred palette work.