### PR TITLE
fix(a11y): collapsible rows say whether they are open

### DIFF
--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -172,6 +172,8 @@ export function CalendarPicker({
 
         <Pressable
           onPress={toggleExpanded}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: isExpanded }}
           style={({ pressed }) => [styles.dateContainer, pressed && { opacity: colors.pressedOpacity }]}
         >
           <View style={styles.dateLabelRow}>

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -16,7 +16,7 @@ import {
   size,
   space
 } from "../../../constants"
-import { Card, ChipGroup, Divider, NumericInput, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
+import { Card, ChipGroup, Divider, ListItem, NumericInput, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
 import { PresetOption } from "./PresetOption"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
 import { isOverlandFormat } from "../../../utils/apiPayload"
@@ -168,17 +168,13 @@ export function SyncStrategySettings({
 
         <Divider />
 
-        <Pressable
-          style={({ pressed }) => [styles.advancedToggle, pressed && { opacity: colors.pressedOpacity }]}
+        <ListItem
+          testID="advanced-settings-toggle"
+          label="Advanced settings"
+          trailingIcon={showAdvanced ? ChevronUp : ChevronDown}
+          expanded={showAdvanced}
           onPress={() => setShowAdvanced(!showAdvanced)}
-        >
-          <Text style={[styles.advancedText, { color: colors.text }]}>Advanced settings</Text>
-          {showAdvanced ? (
-            <ChevronUp size={size.icon.md} color={colors.textLight} />
-          ) : (
-            <ChevronDown size={size.icon.md} color={colors.textLight} />
-          )}
-        </Pressable>
+        />
 
         {showAdvanced && (
           <View style={styles.advancedPanel}>
@@ -429,16 +425,6 @@ const styles = StyleSheet.create({
   },
   presetSpacer: {
     height: 8
-  },
-  advancedToggle: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: space.md
-  },
-  advancedText: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold
   },
   advancedPanel: {
     marginTop: space.lg

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -7,6 +7,7 @@ jest.mock("../../../index", () => {
   const R = require("react")
   const { View, Text, TextInput } = require("react-native")
   return {
+    ListItem: require("../../../../testing/componentStubs").ListItemStub,
     TextField: require("../../../../testing/componentStubs").TextFieldStub,
     ChipGroup: function (props: any) {
       const R = require("react")

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -31,6 +31,7 @@ type Props = {
   variant?: ButtonVariant
   icon?: LucideIcon
   loading?: boolean
+  expanded?: boolean
   testID?: string
 }
 
@@ -44,6 +45,7 @@ export function Button({
   variant = "primary",
   icon: Icon,
   loading = false,
+  expanded,
   testID
 }: Props) {
   const { colors } = useTheme()
@@ -86,6 +88,8 @@ export function Button({
     <View style={style}>
       <Pressable
         testID={testID}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: disabled || loading, expanded }}
         style={({ pressed }) => [
           styles.button,
           {

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -22,6 +22,7 @@ type ListItemProps = {
   accessibilityRole?: "button" | "link"
   accessibilityHint?: string
   disabled?: boolean
+  expanded?: boolean
 }
 
 export function ListItem({
@@ -33,7 +34,8 @@ export function ListItem({
   testID,
   accessibilityRole = "button",
   accessibilityHint,
-  disabled = false
+  disabled = false,
+  expanded
 }: ListItemProps) {
   const { colors } = useTheme()
   return (
@@ -42,7 +44,7 @@ export function ListItem({
       accessibilityRole={accessibilityRole}
       accessibilityLabel={label}
       accessibilityHint={accessibilityHint ?? `Opens ${label}`}
-      accessibilityState={{ disabled }}
+      accessibilityState={{ disabled, expanded }}
       android_ripple={disabled ? undefined : { color: colors.border }}
       disabled={disabled}
       onPress={onPress}

--- a/apps/mobile/src/components/ui/__tests__/Button.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Button.test.tsx
@@ -29,4 +29,16 @@ describe("Button variants", () => {
 
     expect(flat(getByTestId("save-btn")).minHeight).toBe(48)
   })
+
+  it("says whether the panel it opens is showing", () => {
+    // The Trip Detail export button opens a format row; its TripList twin already announces
+    // this, so a screen reader got two different experiences for the same control.
+    const { getByTestId, rerender } = render(
+      <Button title="Export trip" onPress={jest.fn()} expanded={false} testID="export-btn" />
+    )
+    expect(getByTestId("export-btn").props.accessibilityState.expanded).toBe(false)
+
+    rerender(<Button title="Export trip" onPress={jest.fn()} expanded testID="export-btn" />)
+    expect(getByTestId("export-btn").props.accessibilityState.expanded).toBe(true)
+  })
 })

--- a/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { ListItem } from "../ListItem"
+
+describe("ListItem", () => {
+  it("says whether the panel it opens is showing", () => {
+    // Without the expanded state TalkBack announces a plain button and the panel opening
+    // below is silent. A hint is not a substitute: it is read late and never on the change.
+    const { getByTestId, rerender } = render(
+      <ListItem label="Map tile server" onPress={jest.fn()} expanded={false} testID="row" />
+    )
+    expect(getByTestId("row").props.accessibilityState.expanded).toBe(false)
+
+    rerender(<ListItem label="Map tile server" onPress={jest.fn()} expanded testID="row" />)
+    expect(getByTestId("row").props.accessibilityState.expanded).toBe(true)
+  })
+
+  it("leaves expanded unset on a row that opens nothing", () => {
+    const { getByTestId } = render(<ListItem label="Connection" onPress={jest.fn()} testID="row" />)
+    expect(getByTestId("row").props.accessibilityState.expanded).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -135,7 +135,7 @@ export function AppearanceScreen({}: ScreenProps) {
             label={t("appearance.mapTileServer")}
             sub={t("appearance.mapStyle.subtitle")}
             trailingIcon={showMapTileServer ? ChevronUp : ChevronDown}
-            accessibilityHint={showMapTileServer ? "Collapses the tile server settings" : "Expands the tile server settings"}
+            expanded={showMapTileServer}
             onPress={() => setShowMapTileServer(!showMapTileServer)}
           />
 

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -379,7 +379,12 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
 
         {/* Export */}
         <View style={styles.section}>
-          <Button title="Export trip" icon={Share} onPress={() => setShowExport((prev) => !prev)} />
+          <Button
+            title="Export trip"
+            icon={Share}
+            expanded={showExport}
+            onPress={() => setShowExport((prev) => !prev)}
+          />
 
           {showExport && (
             <View style={styles.exportRow}>

--- a/apps/mobile/src/testing/componentStubs.tsx
+++ b/apps/mobile/src/testing/componentStubs.tsx
@@ -21,9 +21,9 @@ export function TextFieldStub({ label, error, secure: _secure, mono: _mono, styl
 }
 
 /** Mirrors ListItem: label, sub, and the press target the test fires. */
-export function ListItemStub({ label, sub, onPress, testID, disabled }: any) {
+export function ListItemStub({ label, sub, onPress, testID, disabled, expanded }: any) {
   return (
-    <Pressable testID={testID} onPress={onPress} disabled={disabled}>
+    <Pressable testID={testID} onPress={onPress} disabled={disabled} accessibilityState={{ disabled, expanded }}>
       <Text>{label}</Text>
       {sub ? <Text>{sub}</Text> : null}
     </Pressable>


### PR DESCRIPTION
Four of the five collapsibles set no `expanded` state, so TalkBack announced a plain button and said nothing when the panel opened below. Two set no `accessibilityRole` either, so they were not announced as tappable at all.

`ListItem` and `Button` take an `expanded` prop feeding the `accessibilityState` they already build. The Appearance row had an `accessibilityHint` standing in for it, which is read late and never on the change.

Advanced settings was a hand-rolled `Pressable` with a chevron and is now a `ListItem`, so it also picks up the ripple, the touch target and the role. No generic Collapsible: the trigger is the whole variation, so such a wrapper would contribute only `{expanded \&\& children}`.