### PR TITLE
fix(screens): number inputs drew two borders

### DIFF
--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -580,6 +580,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
                           accessibilityLabel={key}
                           testID={`field-${key}`}
                           style={styles.fieldInput}
+                          mono
                           error={isDuplicate}
                           value={localFieldMap[key]}
                           onChangeText={(text) => handleFieldChange(key, text)}
@@ -627,6 +628,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
                         accessibilityLabel="Custom field key"
                         testID={`custom-key-${field.id}`}
                         style={styles.customFieldInput}
+                        mono
                         error={isDuplicate}
                         value={field.key}
                         onChangeText={(text) => handleCustomFieldChange(field.id, "key", text)}
@@ -638,6 +640,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
                         accessibilityLabel="Custom field value"
                         testID={`custom-value-${field.id}`}
                         style={styles.customFieldInput}
+                        mono
                         value={field.value}
                         onChangeText={(text) => handleCustomFieldChange(field.id, "value", text)}
                         placeholder="Value"
@@ -797,13 +800,7 @@ const styles = StyleSheet.create({
     gap: 6
   },
   fieldInput: {
-    flex: 1,
-    borderWidth: 1.5,
-    paddingHorizontal: 10,
-    paddingVertical: space.sm,
-    borderRadius: radius.sm,
-    fontSize: fontSizes.body,
-    fontFamily: "monospace"
+    flex: 1
   },
   customFieldRow: {
     flexDirection: "row",
@@ -812,13 +809,7 @@ const styles = StyleSheet.create({
     paddingVertical: space.sm
   },
   customFieldInput: {
-    flex: 1,
-    borderWidth: 1.5,
-    paddingHorizontal: 10,
-    paddingVertical: space.sm,
-    borderRadius: radius.sm,
-    fontSize: fontSizes.body,
-    fontFamily: "monospace"
+    flex: 1
   },
   emptyHint: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -545,12 +545,7 @@ const styles = StyleSheet.create({
     gap: space.sm
   },
   daysInput: {
-    flex: 1,
-    borderWidth: 1,
-    padding: 10,
-    borderRadius: radius.sm,
-    fontSize: fontSizes.input,
-    textAlign: "center"
+    flex: 1
   },
   hintRow: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -365,7 +365,7 @@ const styles = StyleSheet.create({
   content: { padding: 20, paddingBottom: 40 },
   card: { marginBottom: space.lg },
   nameInput: { flex: 1 },
-  numInput: { width: 80, textAlign: "center" },
+  numInput: { width: 80 },
   toggleRow: { paddingVertical: 10 },
   nestedSetting: {
     marginStart: space.lg,

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -437,13 +437,7 @@ const styles = StyleSheet.create({
   header: { marginBottom: 20 },
   inputGroup: { marginBottom: space.xs },
   numInput: {
-    borderWidth: 1,
-    padding: 10,
-    borderRadius: 10,
-    fontSize: fontSizes.input,
-    textAlign: "center",
-    width: 64,
-    ...fonts.regular
+    width: 64
   },
   inputWithUnit: { flexDirection: "row", alignItems: "center", gap: 6 },
   unit: { fontSize: fontSizes.body, ...fonts.medium, minWidth: 28 },


### PR DESCRIPTION
`TextField`'s `style` lands on the wrapper, not the input. The adoption PR passed the old style rules straight through, so four fields painted a second border, radius and padding around `TextField`'s own box: the retention days input, both API field-map inputs and the profile numeric inputs.

Only layout survives now. The two API inputs also carried `fontFamily: "monospace"`, which silently stopped applying once it sat on the wrapper, so they take `mono` instead.