### PR TITLE
fix(theme): green marks status, teal carries emphasis

### DIFF
--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -35,14 +35,7 @@ function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps
   const content = (
     <View style={styles.checklistItem}>
       <View
-        style={[
-          styles.checkCircle,
-          // eslint-disable-next-line react-native/no-inline-styles
-          {
-            borderColor: completed ? colors.success : colors.border,
-            backgroundColor: completed ? colors.success + "20" : "transparent"
-          }
-        ]}
+        style={[styles.checkCircle, { borderColor: colors.border }]}
       >
         {completed && <Check size={size.icon.sm} color={colors.success} />}
       </View>

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -204,7 +204,7 @@ export function ConnectionSettings({
                       styles.protocolBadge,
                       {
                         backgroundColor: endpointInput.startsWith("https://")
-                          ? colors.success + "20"
+                          ? colors.well
                           : colors.warning + "20"
                       }
                     ]}
@@ -213,7 +213,7 @@ export function ConnectionSettings({
                       style={[
                         styles.protocolText,
                         {
-                          color: endpointInput.startsWith("https://") ? colors.success : colors.warning
+                          color: endpointInput.startsWith("https://") ? colors.textSecondary : colors.warning
                         }
                       ]}
                     >
@@ -260,13 +260,13 @@ export function ConnectionSettings({
                 style={[
                   styles.responseBox,
                   {
-                    borderColor: testError ? colors.error : colors.success,
-                    backgroundColor: (testError ? colors.error : colors.success) + "15"
+                    borderColor: testError ? colors.error : colors.border,
+                    backgroundColor: testError ? colors.error + "15" : colors.well
                   }
                 ]}
               >
                 {!testError && <CircleCheckBig size={size.icon.sm} color={colors.success} />}
-                <Text style={[styles.responseText, { color: testError ? colors.error : colors.success }]}>
+                <Text style={[styles.responseText, { color: testError ? colors.error : colors.text }]}>
                   {testResponse}
                 </Text>
               </View>

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -315,12 +315,14 @@ const styles = StyleSheet.create({
   responseRow: {
     marginTop: space.md,
     flexDirection: "row",
-    alignItems: "flex-start",
+    alignItems: "center",
+    justifyContent: "center",
     gap: space.sm
   },
   responseText: {
-    flex: 1,
+    flexShrink: 1,
     fontSize: fontSizes.description,
+    textAlign: "center",
     ...fonts.regular
   },
 })

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useCallback, useEffect, useRef } from "react"
 import { Text, StyleSheet, View } from "react-native"
-import { CircleCheckBig } from "lucide-react-native"
+import { CircleAlert, CircleCheckBig } from "lucide-react-native"
 import { Settings, ThemeColors } from "../../../types/global"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { isEndpointAllowed } from "../../../utils/settingsValidation"
@@ -256,17 +256,13 @@ export function ConnectionSettings({
             />
 
             {testResponse && (
-              <View
-                style={[
-                  styles.responseBox,
-                  {
-                    borderColor: testError ? colors.error : colors.border,
-                    backgroundColor: testError ? colors.error + "15" : colors.well
-                  }
-                ]}
-              >
-                {!testError && <CircleCheckBig size={size.icon.sm} color={colors.success} />}
-                <Text style={[styles.responseText, { color: testError ? colors.error : colors.text }]}>
+              <View style={styles.responseRow}>
+                {testError ? (
+                  <CircleAlert size={size.icon.sm} color={colors.error} />
+                ) : (
+                  <CircleCheckBig size={size.icon.sm} color={colors.success} />
+                )}
+                <Text style={[styles.responseText, { color: testError ? colors.error : colors.textSecondary }]}>
                   {testResponse}
                 </Text>
               </View>
@@ -316,18 +312,15 @@ const styles = StyleSheet.create({
   testButton: {
     marginTop: space.md
   },
-  responseBox: {
+  responseRow: {
     marginTop: space.md,
-    padding: 14,
-    borderWidth: 1.5,
-    borderRadius: radius.md,
     flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
+    alignItems: "flex-start",
     gap: space.sm
   },
   responseText: {
-    fontSize: fontSizes.body,
-    ...fonts.semiBold
+    flex: 1,
+    fontSize: fontSizes.description,
+    ...fonts.regular
   },
 })

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -208,11 +208,6 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.label,
     ...fonts.medium
   },
-  disabledHint: {
-    fontSize: fontSizes.small,
-    marginTop: 2,
-    fontStyle: "italic"
-  },
   divider: {
     width: 1,
     marginHorizontal: space.md,

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -49,15 +49,6 @@ jest.mock("../../../ui/SettingRow", () => {
   }
 })
 
-jest.mock("lucide-react-native", () => {
-  const R = require("react")
-  const { View } = require("react-native")
-  return {
-    CircleCheckBig: () => R.createElement(View, null),
-    ChevronRight: () => R.createElement(View, null)
-  }
-})
-
 const mockGetStats = jest.fn().mockResolvedValue({ queued: 0, sent: 0, total: 0, today: 0, databaseSizeMB: 0 })
 const mockManualFlush = jest.fn().mockResolvedValue(undefined)
 const mockClearQueue = jest.fn().mockResolvedValue(5)

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -476,10 +476,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: space.lg,
     paddingBottom: 40
   },
-  header: {
-    marginTop: 20,
-    marginBottom: space.xl
-  },
   section: {
     marginBottom: space.xl
   },

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -434,7 +434,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
 const styles = StyleSheet.create({
   scrollContent: { paddingHorizontal: space.lg, paddingTop: space.lg, paddingBottom: 40 },
-  header: { marginBottom: 20 },
   inputGroup: { marginBottom: space.xs },
   numInput: {
     width: 64

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -126,8 +126,9 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
               <View style={styles.nameRow}>
                 <Text style={[styles.name, { color: colors.text }]}>{item.name}</Text>
                 {isActive && (
-                  <View style={[styles.activeBadge, { backgroundColor: colors.success + "20" }]}>
-                    <Text style={[styles.activeBadgeText, { color: colors.success }]}>Active</Text>
+                  <View style={[styles.activeBadge, { backgroundColor: colors.border }]}>
+                    <View style={[styles.activeDot, { backgroundColor: colors.success }]} />
+                    <Text style={[styles.activeBadgeText, { color: colors.textSecondary }]}>Active</Text>
                   </View>
                 )}
                 <View style={[styles.priorityBadge, { backgroundColor: colors.border }]}>
@@ -242,7 +243,15 @@ const styles = StyleSheet.create({
   info: { flex: 1, marginEnd: space.md },
   nameRow: { flexDirection: "row", alignItems: "center", gap: space.sm, marginBottom: 2 },
   name: { fontSize: fontSizes.input, ...fonts.semiBold },
-  activeBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },
+  activeBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: space.xs,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: radius.xs
+  },
+  activeDot: { width: 6, height: 6, borderRadius: 3 },
   activeBadgeText: { fontSize: fontSizes.micro, ...fonts.semiBold },
   priorityBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },
   priorityText: { fontSize: fontSizes.micro, ...fonts.semiBold },


### PR DESCRIPTION
`success` is hue 123; `primary`, `primaryDark`, `primaryContainer` and `onPrimaryContainer` are all teal at 169-176. Nothing is wrong with the palette, but four places used `success` as a *fill* on chip- and button-shaped elements, which is what read as "sometimes teal, sometimes green".

The clearest case: the Active profile badge was green while the priority badge built identically beside it was neutral.

Each now keeps green as a dot or an icon on a neutral surface. The HTTPS badge goes neutral so only HTTP is coloured, which means colour marks the case that needs attention.