### PR TITLE
feat(ui): presses ripple instead of fading

### DIFF
--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -10,7 +10,7 @@ import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { radius } from "@colota/shared"
 import { type ModalRequest, type AlertVariant, registerModalHandler } from "../../services/modalService"
-import { space } from "../../constants"
+import { space, STATE_LAYER_ALPHA } from "../../constants"
 
 const VARIANT_ICONS = {
   info: Info,
@@ -78,11 +78,11 @@ export function AppModal() {
               return (
                 <Pressable
                   key={i}
-                  style={({ pressed }) => [
+                  android_ripple={{ color: btnStyles.text.color + STATE_LAYER_ALPHA }}
+                  style={[
                     styles.button,
                     current.buttons.length > 2 && styles.buttonFullWidth,
-                    btnStyles.container,
-                    pressed && { opacity: colors.pressedOpacity }
+                    btnStyles.container
                   ]}
                   onPress={() => handlePress(i)}
                 >
@@ -181,6 +181,7 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingVertical: 14,
     borderRadius: radius.sm,
+    overflow: "hidden",
     alignItems: "center"
   },
   buttonText: {

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -8,7 +8,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Settings, LucideIcon, House, MapPinHouse, Waypoints } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { size, space } from "../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
 import type { RootStackRoute } from "../../types/navigation"
 
 interface Tab {
@@ -56,7 +56,8 @@ export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
         return (
           <Pressable
             key={tab.name}
-            style={({ pressed }) => [styles.tab, pressed && { opacity: colors.pressedOpacity }]}
+            android_ripple={{ color: colors.text + STATE_LAYER_ALPHA, borderless: true, radius: size.touch / 2 }}
+            style={styles.tab}
             onPress={() => onNavigate(tab.route)}
           >
             <tab.icon size={size.icon.md} color={color} />

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -17,7 +17,7 @@ import {
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { type LucideIcon } from "lucide-react-native"
-import { size, space } from "../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
 
 type ButtonVariant = "primary" | "secondary" | "ghost" | "danger"
 
@@ -26,7 +26,6 @@ type Props = {
   onPress: (event: GestureResponderEvent) => void
   disabled?: boolean
   style?: StyleProp<ViewStyle>
-  activeOpacity?: number
   color?: string
   variant?: ButtonVariant
   icon?: LucideIcon
@@ -40,7 +39,6 @@ export function Button({
   onPress,
   disabled = false,
   style,
-  activeOpacity,
   color,
   variant = "primary",
   icon: Icon,
@@ -90,14 +88,14 @@ export function Button({
         testID={testID}
         accessibilityRole="button"
         accessibilityState={{ disabled: disabled || loading, expanded }}
-        style={({ pressed }) => [
+        android_ripple={disabled || loading ? undefined : { color: v.text + STATE_LAYER_ALPHA }}
+        style={[
           styles.button,
           {
             backgroundColor: v.bg,
             borderColor: v.borderColor,
             borderWidth: v.borderWidth,
-            borderRadius: colors.borderRadius,
-            opacity: pressed ? (activeOpacity ?? colors.pressedOpacity) : 1
+            borderRadius: colors.borderRadius
           }
         ]}
         onPress={onPress}
@@ -120,6 +118,7 @@ const styles = StyleSheet.create({
   button: {
     // Android's minimum touch target; padding alone leaves this at about 43.
     minHeight: size.touch,
+    overflow: "hidden",
     justifyContent: "center",
     paddingVertical: space.md,
     paddingHorizontal: space.xl,

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@
 import React from "react"
 import { View, Pressable, StyleSheet, ViewStyle, StyleProp, AccessibilityRole, AccessibilityState } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { space } from "../../constants"
+import { space, STATE_LAYER_ALPHA } from "../../constants"
 import { radius } from "@colota/shared"
 
 type CardVariant = "default" | "elevated" | "outlined" | "interactive"
@@ -87,7 +87,8 @@ export function Card({
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
         accessibilityState={accessibilityState}
-        style={({ pressed }) => ({ opacity: pressed ? colors.pressedOpacity : 1 })}
+        android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+        style={styles.pressable}
       >
         {cardView}
       </Pressable>
@@ -103,6 +104,12 @@ const styles = StyleSheet.create({
     padding: space.lg,
     borderRadius: radius.md,
     borderWidth: 1,
-    width: "100%"
+    width: "100%",
+    // A row inside the card ripples to its own bounds, so the card has to clip the corners.
+    overflow: "hidden"
+  },
+  pressable: {
+    borderRadius: radius.md,
+    overflow: "hidden"
   }
 })

--- a/apps/mobile/src/components/ui/ChipGroup.tsx
+++ b/apps/mobile/src/components/ui/ChipGroup.tsx
@@ -9,7 +9,7 @@ import { Check } from "lucide-react-native"
 import { ThemeColors } from "../../types/global"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { size, space } from "../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
 import { radius } from "@colota/shared"
 
 interface ChipGroupProps<T extends string> {
@@ -39,11 +39,8 @@ export function ChipGroup<T extends string>({ options, selected, onSelect, disab
             disabled={isDisabled}
             accessibilityRole="radio"
             accessibilityState={{ checked: isSelected, disabled: isDisabled }}
-            style={({ pressed }) => [
-              styles.chip,
-              { backgroundColor: isSelected ? colors.primaryContainer : colors.well },
-              pressed && !isDisabled && { opacity: colors.pressedOpacity }
-            ]}
+            android_ripple={isDisabled ? undefined : { color: content + STATE_LAYER_ALPHA }}
+            style={[styles.chip, { backgroundColor: isSelected ? colors.primaryContainer : colors.well }]}
             onPress={() => onSelect(value)}
           >
             {isSelected ? <Check size={size.icon.sm} color={content} strokeWidth={2} /> : null}
@@ -62,6 +59,7 @@ const styles = StyleSheet.create({
     gap: space.sm
   },
   chip: {
+    overflow: "hidden",
     flexDirection: "row",
     alignItems: "center",
     gap: space.xs,

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -8,7 +8,7 @@ import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-nat
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { radius } from "@colota/shared"
-import { space } from "../../constants"
+import { space, STATE_LAYER_ALPHA } from "../../constants"
 
 interface DisclosureModalProps {
   icon: React.ReactNode
@@ -78,24 +78,16 @@ export function DisclosureModal({ icon, title, paragraphs, confirmLabel, registe
           {/* Buttons */}
           <View style={styles.buttons}>
             <Pressable
-              style={({ pressed }) => [
-                styles.button,
-                styles.secondaryButton,
-                { borderColor: colors.border },
-                pressed && { opacity: colors.pressedOpacity }
-              ]}
+              android_ripple={{ color: colors.textSecondary + STATE_LAYER_ALPHA }}
+              style={[styles.button, styles.secondaryButton, { borderColor: colors.border }]}
               onPress={handleNotNow}
             >
               <Text style={[styles.buttonText, { color: colors.textSecondary }]}>Not now</Text>
             </Pressable>
 
             <Pressable
-              style={({ pressed }) => [
-                styles.button,
-                styles.primaryButton,
-                { backgroundColor: colors.primary },
-                pressed && { opacity: colors.pressedOpacity }
-              ]}
+              android_ripple={{ color: colors.textOnPrimary + STATE_LAYER_ALPHA }}
+              style={[styles.button, styles.primaryButton, { backgroundColor: colors.primary }]}
               onPress={handleConfirm}
             >
               <Text style={[styles.buttonText, { color: colors.textOnPrimary }]}>{confirmLabel}</Text>
@@ -151,6 +143,7 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingVertical: 14,
     borderRadius: radius.sm,
+    overflow: "hidden",
     alignItems: "center"
   },
   primaryButton: {},

--- a/apps/mobile/src/components/ui/FormatOption.tsx
+++ b/apps/mobile/src/components/ui/FormatOption.tsx
@@ -9,7 +9,8 @@ import type { LucideIcon } from "lucide-react-native"
 import { fontSizes, fonts } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
 import { RadioDot } from "./RadioDot"
-import { size, space } from "../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+import { radius } from "@colota/shared"
 
 export const FormatOption = ({
   icon: Icon,
@@ -32,7 +33,8 @@ export const FormatOption = ({
 
   return (
     <Pressable
-      style={({ pressed }) => [styles.formatOption, pressed && { opacity: colors.pressedOpacity }]}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+      style={styles.formatOption}
       onPress={onPress}
       accessibilityRole="radio"
       accessibilityState={{ checked: selected }}
@@ -75,7 +77,9 @@ export const FormatOption = ({
 
 const styles = StyleSheet.create({
   formatOption: {
-    paddingVertical: space.sm
+    paddingVertical: space.sm,
+    borderRadius: radius.sm,
+    overflow: "hidden"
   },
   formatContent: {
     flexDirection: "row",

--- a/apps/mobile/src/components/ui/IconButton.tsx
+++ b/apps/mobile/src/components/ui/IconButton.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { Pressable, ActivityIndicator, StyleSheet, StyleProp, ViewStyle } from "react-native"
 import { type LucideIcon } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { size, space, HIT_SLOP_MD } from "../../constants"
+import { size, space, HIT_SLOP_MD, STATE_LAYER_ALPHA } from "../../constants"
 import { radius } from "@colota/shared"
 
 type IconButtonTone = "neutral" | "primary" | "danger"
@@ -52,12 +52,12 @@ export function IconButton({
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
       accessibilityState={{ disabled: disabled || loading }}
-      style={({ pressed }) => [
-        styles.button,
-        { backgroundColor: fill },
-        pressed && !disabled && { opacity: colors.pressedOpacity },
-        style
-      ]}
+      android_ripple={
+        disabled || loading
+          ? undefined
+          : { color: content + STATE_LAYER_ALPHA, borderless: true, radius: size.touch / 2 }
+      }
+      style={[styles.button, { backgroundColor: fill }, style]}
     >
       {loading ? (
         <ActivityIndicator size="small" color={content} />

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -8,7 +8,8 @@ import { Text, StyleSheet, View, Pressable } from "react-native"
 import { ChevronRight } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { size, space } from "../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+import { radius } from "@colota/shared"
 
 type IconComponent = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
 
@@ -45,10 +46,10 @@ export function ListItem({
       accessibilityLabel={label}
       accessibilityHint={accessibilityHint ?? `Opens ${label}`}
       accessibilityState={{ disabled, expanded }}
-      android_ripple={disabled ? undefined : { color: colors.border }}
+      android_ripple={disabled ? undefined : { color: colors.text + STATE_LAYER_ALPHA }}
       disabled={disabled}
       onPress={onPress}
-      style={({ pressed }) => [styles.row, pressed && !disabled && { opacity: colors.pressedOpacity }]}
+      style={styles.row}
     >
       {Icon && (
         <View style={styles.icon}>
@@ -73,7 +74,10 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     minHeight: 56,
-    paddingVertical: 10
+    paddingVertical: 10,
+    // The row sits inset inside a padded Card, so a square state layer floats as a block.
+    borderRadius: radius.sm,
+    overflow: "hidden"
   },
   icon: {
     marginEnd: space.lg

--- a/apps/mobile/src/components/ui/RadioRow.tsx
+++ b/apps/mobile/src/components/ui/RadioRow.tsx
@@ -8,7 +8,8 @@ import { View, Pressable, Text, StyleSheet } from "react-native"
 import { type LucideIcon } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { size, space } from "../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+import { radius } from "@colota/shared"
 import { RadioDot } from "./RadioDot"
 
 type RadioRowProps = {
@@ -37,7 +38,8 @@ export function RadioRow({ label, selected, onPress, sub, icon: Icon, divider = 
         accessibilityRole="radio"
         accessibilityState={{ checked: selected }}
         accessibilityLabel={sub ? `${label}, ${sub}` : label}
-        style={({ pressed }) => [styles.row, pressed && { opacity: colors.pressedOpacity }]}
+        android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+        style={styles.row}
       >
         <RadioDot selected={selected} />
         {Icon ? <Icon size={size.icon.md} color={colors.textSecondary} /> : null}
@@ -57,7 +59,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: space.md,
     minHeight: size.row,
-    paddingVertical: space.md
+    paddingVertical: space.md,
+    borderRadius: radius.sm,
+    overflow: "hidden"
   },
   text: {
     flex: 1

--- a/apps/mobile/src/components/ui/Tab.tsx
+++ b/apps/mobile/src/components/ui/Tab.tsx
@@ -7,7 +7,8 @@ import React from "react"
 import { Pressable, Text, StyleSheet } from "react-native"
 import { fontSizes, fonts } from "../../styles/typography"
 import { ThemeColors } from "../../types/global"
-import { space } from "../../constants"
+import { space, STATE_LAYER_ALPHA } from "../../constants"
+import { radius } from "@colota/shared"
 
 interface TabProps {
   label: string
@@ -22,7 +23,8 @@ export function Tab({ label, active, onPress, colors }: TabProps) {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [styles.tab, { borderBottomColor }, pressed && { opacity: colors.pressedOpacity }]}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+      style={[styles.tab, { borderBottomColor }]}
     >
       <Text style={[styles.tabText, active ? styles.tabTextActive : styles.tabTextInactive, { color: textColor }]}>
         {label}
@@ -36,7 +38,11 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     padding: space.md,
-    borderBottomWidth: 2
+    borderBottomWidth: 2,
+    // Top corners only: the bottom rule is the active indicator and must stay square.
+    borderTopLeftRadius: radius.sm,
+    borderTopRightRadius: radius.sm,
+    overflow: "hidden"
   },
   tabText: {
     fontSize: fontSizes.body

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -32,6 +32,13 @@ export const size = {
   icon: { sm: 16, md: 20, lg: 24 }
 } as const
 
+/**
+ * Material's pressed state layer: 10 percent of the element's own content colour, concatenated
+ * onto a hex token. Android draws it as a ripple from the touch point, which an opacity fade
+ * of the whole element is not.
+ */
+export const STATE_LAYER_ALPHA = "1A"
+
 export const HIT_SLOP_SM = { top: 6, right: 6, bottom: 6, left: 6 } as const
 export const HIT_SLOP_MD = { top: 8, right: 8, bottom: 8, left: 8 } as const
 export const HIT_SLOP_LG = { top: 12, right: 12, bottom: 12, left: 12 } as const

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -232,7 +232,6 @@ export function DashboardScreen({ navigation }: ScreenProps) {
               variant={tracking ? "danger" : "primary"}
               icon={tracking ? Square : Play}
               onPress={tracking ? handleStop : handleStart}
-              activeOpacity={0.9}
               disabled={!tracking && (isBatteryCritical || !settingsHydrated)}
               title={tracking ? "Stop tracking" : "Start tracking"}
             />


### PR DESCRIPTION
The app had 63 opacity fades and one ripple. Fading the whole element to `0.7` is the iOS `TouchableOpacity` idiom: it dims the text and icons along with the surface, and has no touch-point origin.

Every `ui/` primitive now uses `android_ripple` with a new `STATE_LAYER_ALPHA` over its own content colour, borderless for `IconButton` and `BottomTabBar`. `ListItem`'s existing ripple was a hairline grey with a fade on top of it.

A bounded ripple clips to the view's own outline, so it painted a rectangle wherever that view had no radius. `Card` was the worst: the radius sat on the inner `View`, so the state layer squared off a rounded card. Rows are the general case, since `ListItem` and `RadioRow` sit inset in a padded card where a square layer floats as a block. `Tab` rounds its top corners only, because the bottom rule is the active indicator.

`Button.activeOpacity` goes: an iOS knob with a single caller. 54 fades remain in screens that have not adopted a primitive; the guide now says new code ripples.