### PR TITLE
feat(settings): connection and tracking say what they are for

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -182,6 +182,7 @@ export function ConnectionSettings({
 
   return (
     <View style={styles.section}>
+      <Text style={[styles.intro, { color: colors.textSecondary }]}>Where your locations are sent</Text>
       <Card>
         <SettingRow label="Offline mode" hint="Save locally, no network sync">
           <Toggle
@@ -284,6 +285,12 @@ export function ConnectionSettings({
 }
 
 const styles = StyleSheet.create({
+  intro: {
+    fontSize: fontSizes.body,
+    ...fonts.regular,
+    lineHeight: 20,
+    marginBottom: space.lg
+  },
   section: {
     marginBottom: space.xl
   },

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -150,6 +150,9 @@ export function SyncStrategySettings({
 
   return (
     <View style={styles.section}>
+      <Text style={[styles.intro, { color: colors.textSecondary }]}>
+        How often a fix is recorded, and when it uploads
+      </Text>
       <SectionTitle>Tracking configuration</SectionTitle>
       <Card>
         <View accessibilityRole="radiogroup">
@@ -420,6 +423,12 @@ export function SyncStrategySettings({
 }
 
 const styles = StyleSheet.create({
+  intro: {
+    fontSize: fontSizes.body,
+    ...fonts.regular,
+    lineHeight: 20,
+    marginBottom: space.lg
+  },
   section: {
     marginBottom: space.xl
   },


### PR DESCRIPTION
Both screens are reached from a row whose `sub` is a dynamic state summary - the host and queue depth for Connection, the cadence for Tracking & sync - so nothing has ever told the user what the screen is for.

Screens whose entry row already carries a description are left alone: a caption there would repeat the row one tap later.