### PR TITLE
chore: clear the twelve lint warnings

### DIFF
--- a/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
+++ b/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
@@ -16,7 +16,7 @@ type DatabaseStatisticsProps = {
   stats: DatabaseStats
 }
 
-export const DatabaseStatistics = React.memo(function DatabaseStatistics({ stats }: DatabaseStatisticsProps) {
+export const DatabaseStatistics = React.memo(function DatabaseStatisticsView({ stats }: DatabaseStatisticsProps) {
   const { settings } = useTracking()
   const isOfflineMode = settings.isOfflineMode
   const { colors } = useTheme()

--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -36,7 +36,7 @@ interface TripRowProps {
   onLongPress: (trip: Trip) => void
 }
 
-const TripRow = React.memo(function TripRow({
+const TripRow = React.memo(function TripRowItem({
   trip,
   colors,
   stats,

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -70,7 +70,7 @@ interface Props {
   children?: React.ReactNode
 }
 
-export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapView(
+export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapViewInner(
   { initialCenter, initialZoom = DEFAULT_MAP_ZOOM, onPress, onRegionDidChange, onMapReady, style, children },
   ref
 ) {
@@ -123,8 +123,8 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
     const controller = new AbortController()
     fetch(mapStyle, { signal: controller.signal })
       .then((r) => r.json())
-      .then((style: { sources?: unknown }) => {
-        const parsed = parseStyleAttribution(style?.sources)
+      .then((loadedStyle: { sources?: unknown }) => {
+        const parsed = parseStyleAttribution(loadedStyle?.sources)
         setAttributionLinks(parsed.length > 0 ? parsed : FALLBACK_ATTRIBUTION_LINKS)
       })
       .catch((err) => {

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -10,7 +10,6 @@ jest.mock("../../../index", () => {
     ListItem: require("../../../../testing/componentStubs").ListItemStub,
     TextField: require("../../../../testing/componentStubs").TextFieldStub,
     ChipGroup: function (props: any) {
-      const R = require("react")
       const RN = require("react-native")
       return R.createElement(
         RN.View,

--- a/apps/mobile/src/components/ui/TextField.tsx
+++ b/apps/mobile/src/components/ui/TextField.tsx
@@ -37,7 +37,7 @@ type BaseProps = Omit<TextInputProps, "style" | "editable" | "secureTextEntry"> 
 type TextFieldProps = BaseProps &
   ({ label: string; accessibilityLabel?: string } | { label?: undefined; accessibilityLabel: string })
 
-export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function TextField(
+export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function TextFieldInput(
   {
   label,
   accessibilityLabel,

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -32,7 +32,7 @@ import { logger } from "../utils/logger"
 import { formatShortDistance, shortDistanceUnit, inputToMeters } from "../utils/geo"
 import { buildGeofencesLink } from "../utils/setupLink"
 
-const GeofenceMap = React.memo(function GeofenceMap({
+const GeofenceMap = React.memo(function GeofenceMapView({
   tracking,
   geofenceData,
   currentPauseZone,

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -130,8 +130,6 @@ jest.mock("../../components", () => {
   return {
     TextField: require("../../testing/componentStubs").TextFieldStub,
     RadioRow: function (props: any) {
-      const R = require("react")
-      const RN = require("react-native")
       return R.createElement(
         RN.Pressable,
         { testID: props.testID, onPress: props.onPress, accessibilityState: { checked: props.selected } },

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -81,7 +81,6 @@ jest.mock("../../components", () => {
   return {
     TextField: require("../../testing/componentStubs").TextFieldStub,
     RadioRow: function (props: any) {
-      const R = require("react")
       const RN = require("react-native")
       return R.createElement(
         RN.Pressable,
@@ -91,7 +90,6 @@ jest.mock("../../components", () => {
       )
     },
     ChipGroup: function (props: any) {
-      const R = require("react")
       const RN = require("react-native")
       return R.createElement(
         RN.View,

--- a/apps/mobile/src/types/navigation.ts
+++ b/apps/mobile/src/types/navigation.ts
@@ -41,7 +41,6 @@ export type RootStackRoute = keyof RootStackParamList
 export type RootScreenProps<Route extends RootStackRoute> = NativeStackScreenProps<RootStackParamList, Route>
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace ReactNavigation {
     interface RootParamList extends RootStackParamList {}
   }


### PR DESCRIPTION
Lint goes from 12 warnings to none.

**One was a real bug.** `ColotaMapView`'s map-style fetch callback took a parameter named `style`, shadowing the component's own `style` prop, and the body read `style?.sources` through that shadow. Renaming the parameter without fixing the usage would have pointed attribution parsing at the prop instead of the fetched JSON.

The rest were benign: five `memo`/`forwardRef` inner names matching their own `const` (renamed rather than suppressed, so DevTools keeps a name), five test stubs re-requiring `react` inside a `jest.mock` factory that already had it in scope, and one `eslint-disable` suppressing nothing.