### PR TITLE
feat(ui): rows own their padding and the divider separates them

### DIFF
--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -16,6 +16,8 @@ type CardProps = {
   style?: StyleProp<ViewStyle>
   danger?: boolean
   variant?: CardVariant
+  /** Rows manage their own padding, so the card gives them the full width to ripple across. */
+  flush?: boolean
   onPress?: () => void
   onLongPress?: () => void
   accessibilityRole?: AccessibilityRole
@@ -29,6 +31,7 @@ export function Card({
   style,
   danger = false,
   variant = "default",
+  flush = false,
   onPress,
   onLongPress,
   accessibilityRole,
@@ -76,7 +79,7 @@ export function Card({
     }
   }
 
-  const cardView = <View style={[styles.card, getVariantStyles(), style]}>{children}</View>
+  const cardView = <View style={[styles.card, flush && styles.flush, getVariantStyles(), style]}>{children}</View>
 
   if (variant === "interactive" && (onPress || onLongPress)) {
     return (
@@ -103,10 +106,12 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: space.lg,
     borderRadius: radius.md,
-    borderWidth: 1,
     width: "100%",
     // A row inside the card ripples to its own bounds, so the card has to clip the corners.
     overflow: "hidden"
+  },
+  flush: {
+    padding: 0
   },
   pressable: {
     borderRadius: radius.md,

--- a/apps/mobile/src/components/ui/Divider.tsx
+++ b/apps/mobile/src/components/ui/Divider.tsx
@@ -3,19 +3,45 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
+import React from "react"
 import { View, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { space } from "../../constants"
+import { space, size } from "../../constants"
 
-export const Divider = () => {
+/** Where a ListItem's text starts: the row's own padding, its icon and the gap after it. */
+const TEXT_COLUMN = space.lg + size.icon.md + space.lg
+
+type DividerProps = {
+  /** Between rows of one group, where the rows already carry their own vertical padding. */
+  tight?: boolean
+  /** Starts at the text column, for a group whose rows have a leading icon. */
+  inset?: boolean
+}
+
+export const Divider = ({ tight = false, inset = false }: DividerProps) => {
   const { colors } = useTheme()
 
-  return <View style={[styles.divider, { backgroundColor: colors.divider }]} />
+  return (
+    <View
+      style={[
+        styles.divider,
+        tight && styles.tight,
+        inset && styles.inset,
+        { backgroundColor: colors.divider }
+      ]}
+    />
+  )
 }
 
 const styles = StyleSheet.create({
   divider: {
-    height: 1,
+    height: StyleSheet.hairlineWidth,
     marginVertical: space.lg
+  },
+  tight: {
+    marginVertical: 0
+  },
+  inset: {
+    marginStart: TEXT_COLUMN
   }
 })

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -74,6 +74,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     minHeight: 56,
+    paddingHorizontal: space.lg,
     paddingVertical: 10,
     // The row sits inset inside a padded Card, so a square state layer floats as a block.
     borderRadius: radius.sm,

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { View, Text, StyleSheet, type StyleProp, type ViewStyle } from "react-native"
 import { fontSizes, fonts } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
-import { space } from "../../constants"
+import { space, size } from "../../constants"
 
 interface SettingRowProps {
   label: string
@@ -39,7 +39,9 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    paddingVertical: space.xs
+    minHeight: size.row,
+    paddingHorizontal: space.lg,
+    paddingVertical: space.md
   },
   settingContent: {
     flex: 1,

--- a/apps/mobile/src/components/ui/Toggle.tsx
+++ b/apps/mobile/src/components/ui/Toggle.tsx
@@ -7,34 +7,28 @@ import React from "react"
 import { Switch } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
 
-type ToggleTone = "primary" | "warning"
-
 type ToggleProps = {
   value: boolean
   onValueChange: (value: boolean) => void
   /** In the row's own visible words, so Voice Access can resolve it. */
   accessibilityLabel: string
   disabled?: boolean
-  tone?: ToggleTone
   testID?: string
 }
 
 /**
  * The one switch. Thirteen call sites each built the same two colour objects by hand, so the
- * track and thumb live here instead. tone exists because the geofence pause toggle paints
- * warning rather than primary; every other caller takes the default.
+ * track and thumb live here instead. Every switch takes the same hue: a semantic colour marks
+ * a state, and a toggle being on is not a warning.
  */
 export function Toggle({
   value,
   onValueChange,
   accessibilityLabel,
   disabled = false,
-  tone = "primary",
   testID
 }: ToggleProps) {
   const { colors } = useTheme()
-  const hue = tone === "warning" ? colors.warning : colors.primary
-
   return (
     <Switch
       testID={testID}
@@ -42,8 +36,8 @@ export function Toggle({
       onValueChange={onValueChange}
       disabled={disabled}
       accessibilityLabel={accessibilityLabel}
-      trackColor={{ false: undefined, true: hue + "80" }}
-      thumbColor={value ? hue : undefined}
+      trackColor={{ false: undefined, true: colors.primary + "80" }}
+      thumbColor={value ? colors.primary : undefined}
     />
   )
 }

--- a/apps/mobile/src/components/ui/__tests__/Toggle.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Toggle.test.tsx
@@ -33,15 +33,17 @@ describe("Toggle", () => {
     expect(el.props.tintColor).toBeUndefined()
   })
 
-  it("takes the warning hue only when asked", () => {
-    // The geofence pause toggle is the one caller that does; every other keeps primary.
+  it("gives every switch the same hue, because being on is not a warning", () => {
+    // The geofence pause toggle used to paint warning. It was the only one, it was not applied
+    // to the three sibling toggles that also stop GPS, and orange reads as a fault rather than
+    // as the setting working.
     const { getByTestId } = render(
-      <Toggle testID="t" value={true} onValueChange={jest.fn()} accessibilityLabel="Pause" tone="warning" />
+      <Toggle testID="t" value={true} onValueChange={jest.fn()} accessibilityLabel="Pause" />
     )
 
     const el = getByTestId("t")
-    expect(el.props.onTintColor).toBe(lightColors.warning + "80")
-    expect(el.props.thumbTintColor).toBe(lightColors.warning)
+    expect(el.props.onTintColor).toBe(lightColors.primary + "80")
+    expect(el.props.thumbTintColor).toBe(lightColors.primary)
   })
 
   it("reports the change so a caller can persist it", () => {

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -102,7 +102,7 @@ export function AppearanceScreen({}: ScreenProps) {
             />
           </SettingRow>
 
-          <Divider />
+          <Divider tight />
 
           <SettingRow label={t("appearance.units")}>
             <ChipGroup
@@ -115,7 +115,7 @@ export function AppearanceScreen({}: ScreenProps) {
             />
           </SettingRow>
 
-          <Divider />
+          <Divider tight />
 
           <SettingRow label={t("appearance.timeFormat")}>
             <ChipGroup
@@ -128,7 +128,7 @@ export function AppearanceScreen({}: ScreenProps) {
             />
           </SettingRow>
 
-          <Divider />
+          <Divider tight />
 
           <ListItem
             testID="map-tile-server-toggle"

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -291,7 +291,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
 
         <View style={styles.section}>
           <SectionTitle>Client certificate</SectionTitle>
-          <Card>
+          <Card flush>
             <ListItem
               testID="nav-mtls-settings"
               label="Client Certificate (mTLS)"

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -380,7 +380,7 @@ export function AutoExportScreen(_props: ScreenProps) {
         </View>
 
         {/* Enable Toggle */}
-        <Card>
+        <Card flush>
           <SettingRow
             label="Enable Auto-Export"
             hint={enabled ? "Auto-Exports are scheduled" : "Auto-Exports are disabled"}

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -246,7 +246,6 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
               testID="pause-tracking-toggle"
               value={pauseTracking}
               onValueChange={setPauseTracking}
-              tone="warning"
             />
           </SettingRow>
 

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -184,7 +184,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
       >
         {/* Name & Priority */}
         <SectionTitle>Profile</SectionTitle>
-        <Card>
+        <Card flush>
           <View style={styles.inputGroup}>
             <TextField
               testID="profile-name-input"
@@ -396,7 +396,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                 </View>
               </SettingRow>
 
-              <Divider />
+              <Divider tight />
 
               <SettingRow
                 label="Deactivation delay"


### PR DESCRIPTION
Card gains flush so a row carries its own padding and ripples across the full width. SettingRow takes the 56 minimum it never had: it was 4 high. Divider gains tight and inset, at a hairline. Toggle loses tone.