### PR TITLE
fix(settings): the API row was the last label still in title case

### DIFF
--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -146,7 +146,7 @@ export function SettingsScreen({ navigation }: Props) {
                 <ListItem
                   testID="nav-api-config"
                   icon={Braces}
-                  label="API Field Mapping"
+                  label="API field mapping"
                   sub={apiSummary}
                   onPress={() => navigation.navigate("API Config")}
                 />

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -215,19 +215,19 @@ describe("SettingsScreen", () => {
   it("navigates to API Config", () => {
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    fireEvent.press(getByText("API Field Mapping"))
+    fireEvent.press(getByText("API field mapping"))
 
     expect(mockNavigate).toHaveBeenCalledWith("API Config")
   })
 
   // --- Offline mode ---
 
-  it("hides API Field Mapping link when offline mode is enabled", () => {
+  it("hides the API field mapping link when offline mode is enabled", () => {
     mockSettings = { ...DEFAULT_SETTINGS, isOfflineMode: true }
 
     const { queryByText } = render(<SettingsScreen {...mockProps} />)
 
-    expect(queryByText("API Field Mapping")).toBeNull()
+    expect(queryByText("API field mapping")).toBeNull()
   })
 
   it("still shows Connection, Tracking Profiles and Data Management in offline mode", () => {


### PR DESCRIPTION
The sentence-case sweep missed it, so the row read API Field Mapping while the screen it opens is titled API config. The test now presses the sentence-case label, which is what fails if the two drift apart again.
