### PR TITLE
fix(settings): the support row leads with the free options

### DIFF
--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -297,8 +297,8 @@ export function SettingsScreen({ navigation }: Props) {
             <ListItem
               testID="nav-support"
               icon={Heart}
-              label="Support development"
-              sub="Help keep the app free and open"
+              label="Say thanks"
+              sub="Free, one click, or a donation"
               trailingIcon={ExternalLink}
               accessibilityRole="link"
               accessibilityHint="Opens external support page"


### PR DESCRIPTION
Support development reads as a request for payment. The new label and hint put the free options first and the donation last, matching what the page actually offers.
