### PR TITLE
fix(ui): rows fill the card they sit in

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -183,7 +183,7 @@ export function ConnectionSettings({
   return (
     <View style={styles.section}>
       <Text style={[styles.intro, { color: colors.textSecondary }]}>Where your locations are sent</Text>
-      <Card>
+      <Card rows>
         <SettingRow label="Offline mode" hint="Save locally, no network sync">
           <Toggle
             accessibilityLabel="Offline mode"

--- a/apps/mobile/src/components/features/settings/PresetOption.tsx
+++ b/apps/mobile/src/components/features/settings/PresetOption.tsx
@@ -9,7 +9,7 @@ import { SelectablePreset, TRACKING_PRESETS } from "../../../types/global"
 import { fontSizes, fonts } from "../../../styles/typography"
 import { useTheme } from "../../../hooks/useTheme"
 import { RadioDot } from "../../ui/RadioDot"
-import { size, space } from "../../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../../constants"
 
 interface BadgeProps {
   icon: React.ReactElement
@@ -43,7 +43,8 @@ export function PresetOption({ preset, isSelected, isOfflineMode, onSelect }: Pr
 
   return (
     <Pressable
-      style={({ pressed }) => [pressed && { opacity: colors.pressedOpacity }]}
+      style={styles.row}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
       onPress={() => onSelect(preset)}
       accessibilityRole="radio"
       accessibilityState={{ checked: isSelected }}
@@ -88,10 +89,15 @@ export function PresetOption({ preset, isSelected, isOfflineMode, onSelect }: Pr
 }
 
 const styles = StyleSheet.create({
+  // See ListItem: the card's inset is cancelled and reapplied so a press fills its width.
+  row: {
+    marginHorizontal: -space.lg,
+    paddingHorizontal: space.lg
+  },
   content: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: space.md
+    paddingVertical: space.lg
   },
   leftContent: {
     flex: 1

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -154,7 +154,7 @@ export function SyncStrategySettings({
         How often a fix is recorded, and when it uploads
       </Text>
       <SectionTitle>Tracking configuration</SectionTitle>
-      <Card>
+      <Card rows>
         <View accessibilityRole="radiogroup">
           {(Object.keys(TRACKING_PRESETS) as SelectablePreset[]).map((preset, index) => (
             <View key={preset}>

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -16,8 +16,9 @@ type CardProps = {
   style?: StyleProp<ViewStyle>
   danger?: boolean
   variant?: CardVariant
-  /** Rows manage their own padding, so the card gives them the full width to ripple across. */
-  flush?: boolean
+  /** A card that is nothing but rows: it gives up its vertical padding so the first and last
+   *  row's state layer reaches its edge. The rows already carry the spacing. */
+  rows?: boolean
   onPress?: () => void
   onLongPress?: () => void
   accessibilityRole?: AccessibilityRole
@@ -31,7 +32,7 @@ export function Card({
   style,
   danger = false,
   variant = "default",
-  flush = false,
+  rows = false,
   onPress,
   onLongPress,
   accessibilityRole,
@@ -79,7 +80,7 @@ export function Card({
     }
   }
 
-  const cardView = <View style={[styles.card, flush && styles.flush, getVariantStyles(), style]}>{children}</View>
+  const cardView = <View style={[styles.card, rows && styles.rowsCard, getVariantStyles(), style]}>{children}</View>
 
   if (variant === "interactive" && (onPress || onLongPress)) {
     return (
@@ -110,8 +111,8 @@ const styles = StyleSheet.create({
     // A row inside the card ripples to its own bounds, so the card has to clip the corners.
     overflow: "hidden"
   },
-  flush: {
-    padding: 0
+  rowsCard: {
+    paddingVertical: 0
   },
   pressable: {
     borderRadius: radius.md,

--- a/apps/mobile/src/components/ui/Divider.tsx
+++ b/apps/mobile/src/components/ui/Divider.tsx
@@ -8,8 +8,8 @@ import { View, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { space, size } from "../../constants"
 
-/** Where a ListItem's text starts: the row's own padding, its icon and the gap after it. */
-const TEXT_COLUMN = space.lg + size.icon.md + space.lg
+/** Where a ListItem's text starts inside its card: past the icon and the gap after it. */
+const TEXT_COLUMN = size.icon.md + space.lg
 
 type DividerProps = {
   /** Between rows of one group, where the rows already carry their own vertical padding. */

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -9,7 +9,6 @@ import { ChevronRight } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { size, space, STATE_LAYER_ALPHA } from "../../constants"
-import { radius } from "@colota/shared"
 
 type IconComponent = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
 
@@ -73,12 +72,12 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     alignItems: "center",
-    minHeight: 56,
-    paddingHorizontal: space.lg,
-    paddingVertical: 10,
-    // The row sits inset inside a padded Card, so a square state layer floats as a block.
-    borderRadius: radius.sm,
-    overflow: "hidden"
+    minHeight: size.row,
+    paddingVertical: space.lg,
+    // The card pads its content, so the row cancels that inset and reapplies it: the content
+    // lands where the card put it while the ripple still reaches the card's own edge.
+    marginHorizontal: -space.lg,
+    paddingHorizontal: space.lg
   },
   icon: {
     marginEnd: space.lg

--- a/apps/mobile/src/components/ui/RadioRow.tsx
+++ b/apps/mobile/src/components/ui/RadioRow.tsx
@@ -9,7 +9,6 @@ import { type LucideIcon } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { size, space, STATE_LAYER_ALPHA } from "../../constants"
-import { radius } from "@colota/shared"
 import { RadioDot } from "./RadioDot"
 
 type RadioRowProps = {
@@ -59,9 +58,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: space.md,
     minHeight: size.row,
-    paddingVertical: space.md,
-    borderRadius: radius.sm,
-    overflow: "hidden"
+    paddingVertical: space.lg,
+    // See ListItem: the card's inset is cancelled and reapplied so a press fills its width.
+    marginHorizontal: -space.lg,
+    paddingHorizontal: space.lg
   },
   text: {
     flex: 1

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -40,8 +40,10 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "center",
     minHeight: size.row,
-    paddingHorizontal: space.lg,
-    paddingVertical: space.md
+    paddingVertical: space.lg,
+    // See ListItem: the inset is cancelled and reapplied so a press fills the card's width.
+    marginHorizontal: -space.lg,
+    paddingHorizontal: space.lg
   },
   settingContent: {
     flex: 1,

--- a/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import { render } from "@testing-library/react-native"
+import { StyleSheet } from "react-native"
+import { space } from "../../../constants"
 
 jest.mock("../../../hooks/useTheme", () => ({
   useTheme: () => ({ colors: require("@colota/shared").lightColors })
@@ -23,5 +25,17 @@ describe("ListItem", () => {
   it("leaves expanded unset on a row that opens nothing", () => {
     const { getByTestId } = render(<ListItem label="Connection" onPress={jest.fn()} testID="row" />)
     expect(getByTestId("row").props.accessibilityState.expanded).toBeUndefined()
+  })
+
+  it("cancels the card's inset and reapplies it, so a press fills the card's width", () => {
+    // The two must stay equal and opposite. If Card's padding ever stops being space.lg the
+    // row silently shifts, which is the failure this pins: the content sits where the card
+    // put it, and only the ripple reaches further.
+    const { getByTestId } = render(<ListItem label="Connection" onPress={jest.fn()} testID="row" />)
+    const style = StyleSheet.flatten(getByTestId("row").props.style)
+
+    expect(style.marginHorizontal).toBe(-space.lg)
+    expect(style.paddingHorizontal).toBe(space.lg)
+    expect(style.marginHorizontal + style.paddingHorizontal).toBe(0)
   })
 })

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -92,7 +92,7 @@ export function AppearanceScreen({}: ScreenProps) {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Card>
+        <Card rows style={styles.cardTail}>
           <SettingRow label={t("appearance.darkMode")}>
             <Toggle
               accessibilityLabel={t("appearance.darkMode")}
@@ -197,6 +197,9 @@ export function AppearanceScreen({}: ScreenProps) {
 }
 
 const styles = StyleSheet.create({
+  // rows drops the card\'s vertical padding for the first row; the last child
+  // here is not a row, so it takes the bottom inset back.
+  cardTail: { paddingBottom: space.lg },
   scrollContent: {
     paddingHorizontal: space.lg,
     paddingTop: space.lg,

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -291,7 +291,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
 
         <View style={styles.section}>
           <SectionTitle>Client certificate</SectionTitle>
-          <Card flush>
+          <Card rows>
             <ListItem
               testID="nav-mtls-settings"
               label="Client Certificate (mTLS)"

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -380,7 +380,7 @@ export function AutoExportScreen(_props: ScreenProps) {
         </View>
 
         {/* Enable Toggle */}
-        <Card flush>
+        <Card rows>
           <SettingRow
             label="Enable Auto-Export"
             hint={enabled ? "Auto-Exports are scheduled" : "Auto-Exports are disabled"}
@@ -501,7 +501,7 @@ export function AutoExportScreen(_props: ScreenProps) {
         {/* Export Range */}
         <View style={styles.section}>
           <SectionTitle>Export range</SectionTitle>
-          <Card>
+          <Card rows>
             {MODE_OPTIONS.map((option, i) => (
               <RadioRow
                 key={option.key}

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -213,7 +213,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
     <Container>
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <SectionTitle>General</SectionTitle>
-        <Card style={styles.card}>
+        <Card rows style={styles.card}>
           <SettingRow label="Name">
             <TextField
               testID="geofence-name-input"
@@ -238,8 +238,8 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           </SettingRow>
         </Card>
 
-        <SectionTitle>GPS Pause Options</SectionTitle>
-        <Card style={styles.card}>
+        <SectionTitle>GPS pause options</SectionTitle>
+        <Card rows style={[styles.card, styles.cardTail]}>
           <SettingRow label="Don't record in zone" hint="Pause saving and syncing" style={styles.toggleRow}>
             <Toggle
               accessibilityLabel="Don't record in zone"
@@ -361,6 +361,9 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
 }
 
 const styles = StyleSheet.create({
+  // rows drops the card\'s vertical padding for the first row; the last child
+  // here is not a row, so it takes the bottom inset back.
+  cardTail: { paddingBottom: space.lg },
   content: { padding: 20, paddingBottom: 40 },
   card: { marginBottom: space.lg },
   nameInput: { flex: 1 },

--- a/apps/mobile/src/screens/LegalScreen.tsx
+++ b/apps/mobile/src/screens/LegalScreen.tsx
@@ -28,7 +28,7 @@ export function LegalScreen({}: ScreenProps) {
     <Container>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <SectionTitle>Colota</SectionTitle>
-        <Card flush>
+        <Card rows>
           <ListItem
             label="Privacy policy"
             sub="What the app stores, and what it never sends"
@@ -59,7 +59,7 @@ export function LegalScreen({}: ScreenProps) {
 
         <View style={styles.section}>
           <SectionTitle>Map data</SectionTitle>
-    <Card flush>
+    <Card rows>
             <ListItem
               label="OpenStreetMap"
               sub="Map data by OpenStreetMap contributors, ODbL"

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -184,7 +184,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
       >
         {/* Name & Priority */}
         <SectionTitle>Profile</SectionTitle>
-        <Card flush>
+        <Card rows style={styles.cardTop}>
           <View style={styles.inputGroup}>
             <TextField
               testID="profile-name-input"
@@ -212,7 +212,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
         {/* Condition */}
         <SectionTitle style={styles.sectionGap}>Activation condition</SectionTitle>
-        <Card>
+        <Card rows style={isSpeed && styles.cardTail}>
           {PROFILE_CONDITIONS.map((opt, i) => (
             <RadioRow
               key={opt.type}
@@ -245,7 +245,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
         {/* Tracking Settings */}
         <SectionTitle style={styles.sectionGap}>Tracking settings</SectionTitle>
-        <Card>
+        <Card rows style={styles.cardTail}>
           <SettingRow label="Tracking interval" hint={`Default: ${settings.interval}s`}>
             <View style={styles.inputWithUnit}>
               <TextField
@@ -357,7 +357,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         </Card>
 
         <SectionTitle style={styles.sectionGap}>Switching</SectionTitle>
-        <Card>
+        <Card rows>
           {profile.condition.type === "stationary" ? (
             <SettingRow
               label="Activation delay"
@@ -433,6 +433,12 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 }
 
 const styles = StyleSheet.create({
+  // rows drops the card's vertical padding for the row at its bottom; the first
+  // child here is not a row, so it takes the top inset back.
+  cardTop: { paddingTop: space.lg },
+  // rows drops the card\'s vertical padding for the first row; the last child
+  // here is not a row, so it takes the bottom inset back.
+  cardTail: { paddingBottom: space.lg },
   scrollContent: { paddingHorizontal: space.lg, paddingTop: space.lg, paddingBottom: 40 },
   inputGroup: { marginBottom: space.xs },
   numInput: {

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -124,7 +124,7 @@ export function SettingsScreen({ navigation }: Props) {
 
         <View style={styles.section}>
           <SectionTitle>Tracking</SectionTitle>
-          <Card flush>
+          <Card rows>
             <ListItem
               testID="nav-connection"
               icon={Cloud}
@@ -165,7 +165,7 @@ export function SettingsScreen({ navigation }: Props) {
 
         <View style={styles.section}>
           <SectionTitle>Display</SectionTitle>
-          <Card flush>
+          <Card rows>
             <ListItem
               testID="nav-appearance"
               icon={Palette}
@@ -178,7 +178,7 @@ export function SettingsScreen({ navigation }: Props) {
 
         <View style={styles.section}>
           <SectionTitle>Data</SectionTitle>
-          <Card flush>
+          <Card rows>
             <ListItem
               testID="nav-data-management"
               icon={Database}
@@ -247,7 +247,7 @@ export function SettingsScreen({ navigation }: Props) {
 
         <View style={styles.section}>
           <SectionTitle>Colota</SectionTitle>
-          <Card flush>
+          <Card rows>
             <ListItem
               testID="nav-whats-new"
               icon={Sparkles}

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { View, Text, ScrollView, StyleSheet, Share } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
-import { Button, Card, Container, SectionTitle, Toggle } from "../components"
+import { Button, Card, Container, Divider, SectionTitle, SettingRow, Toggle } from "../components"
 import { fontSizes, fonts } from "../styles/typography"
 import { Share2, TriangleAlert } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
@@ -136,31 +136,21 @@ export function ShareSetupScreen() {
         </Card>
 
         <View style={styles.section}>
-          <SectionTitle>INCLUDE</SectionTitle>
-          <Card>
+          <SectionTitle>Include</SectionTitle>
+          <Card rows>
             {rows.map((row, i) => (
-              <View
-                key={row.key}
-                style={[
-                  styles.row,
-                  i < rows.length - 1 && styles.rowBorder,
-                  i < rows.length - 1 && { borderBottomColor: colors.border }
-                ]}
-              >
-                <View style={styles.rowText}>
-                  <Text style={[styles.rowLabel, { color: row.disabled ? colors.textSecondary : colors.text }]}>
-                    {row.label}
-                  </Text>
-                  <Text style={[styles.rowSub, { color: colors.textSecondary }]}>{row.sub}</Text>
-                </View>
-                <Toggle
-                  accessibilityLabel={row.label}
-                  testID={`share-${row.key}`}
-                  value={selection[row.key] && !row.disabled}
-                  onValueChange={() => toggle(row.key)}
-                  disabled={row.disabled}
-                />
-              </View>
+              <React.Fragment key={row.key}>
+                {i > 0 && <Divider tight />}
+                <SettingRow label={row.label} hint={row.sub} disabled={row.disabled}>
+                  <Toggle
+                    accessibilityLabel={row.label}
+                    testID={`share-${row.key}`}
+                    value={selection[row.key] && !row.disabled}
+                    onValueChange={() => toggle(row.key)}
+                    disabled={row.disabled}
+                  />
+                </SettingRow>
+              </React.Fragment>
             ))}
           </Card>
         </View>
@@ -215,28 +205,6 @@ const styles = StyleSheet.create({
   },
   section: {
     marginTop: space.sm
-  },
-  row: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: space.md,
-    gap: space.md
-  },
-  rowBorder: {
-    borderBottomWidth: StyleSheet.hairlineWidth
-  },
-  rowText: {
-    flex: 1
-  },
-  rowLabel: {
-    fontSize: fontSizes.body,
-    ...fonts.semiBold
-  },
-  rowSub: {
-    fontSize: fontSizes.caption,
-    ...fonts.regular,
-    marginTop: 2
   },
   warningCard: {
     borderWidth: StyleSheet.hairlineWidth


### PR DESCRIPTION
Rows padded themselves so a press could reach the card edge, which left cards that also padded drawing rows twice as far in as their content. Rows cancel the card's inset and reapply it; a card bounded by rows takes a rows prop for the vertical axis. RadioRow, PresetOption and share setup's hand-built rows get the same treatment.