### PR TITLE
fix(ui): cards drop their border

### DIFF
--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -54,9 +54,7 @@ export function Card({
     switch (variant) {
       case "default":
         return {
-          backgroundColor: colors.card,
-          borderColor: colors.border,
-          borderWidth: 1
+          backgroundColor: colors.card
         }
       case "elevated":
         return {
@@ -73,9 +71,7 @@ export function Card({
         }
       case "interactive":
         return {
-          backgroundColor: colors.card,
-          borderColor: colors.border,
-          borderWidth: 1
+          backgroundColor: colors.card
         }
     }
   }

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -68,7 +68,7 @@ export const lightColors: ThemeColors = {
   info: "#1976D2",
 
   // UI
-  background: "#f8fafb",
+  background: "#F1F4F6",
   backgroundElevated: "#FFFFFF",
   card: "#FFFFFF",
   cardElevated: "#FFFFFF",


### PR DESCRIPTION
default and interactive paint a fill only. The light ground moves to #F1F4F6 because a white card on the old one was a 1.05 step and would have vanished. Dark is unchanged. Note this also moves the docs site background, which reads from the same token.