### PR TITLE
fix(ui): headings line up with what they title

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -192,7 +192,7 @@ export function SyncStrategySettings({
 
             {/* Tracking Parameters Group */}
             <View style={styles.paramGroup}>
-              <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Tracking parameters</Text>
+              <SectionTitle color={colors.textSecondary}>Tracking parameters</SectionTitle>
 
               <NumericInput
                 label="Tracking interval"
@@ -221,7 +221,7 @@ export function SyncStrategySettings({
 
                 {/* Network Parameters Group */}
                 <View style={styles.paramGroup}>
-                  <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Network settings</Text>
+                  <SectionTitle color={colors.textSecondary}>Network settings</SectionTitle>
 
                   {/* Sync Interval */}
                   <View style={styles.settingBlock}>
@@ -316,7 +316,7 @@ export function SyncStrategySettings({
                   )}
 
                   {/* Sync Condition */}
-                  <View style={styles.settingRowSpaced}>
+                  <View style={styles.settingBlock}>
                     <Text style={[styles.blockLabel, { color: colors.text }]}>Sync only on</Text>
                     <Text style={[styles.blockHint, { color: colors.textSecondary }]}>
                       {settings.syncCondition === "any" && "Upload on any network connection"}
@@ -386,9 +386,13 @@ export function SyncStrategySettings({
 
             {/* Quality Parameters Group */}
             <View style={styles.paramGroup}>
-              <Text style={[styles.paramGroupTitle, { color: colors.text }]}>Quality filters</Text>
+              <SectionTitle color={colors.textSecondary}>Quality filters</SectionTitle>
 
-              <SettingRow label="Filter inaccurate locations" hint="Reject fixes the GPS chip reports as imprecise">
+              <SettingRow
+                style={styles.firstInGroup}
+                label="Filter inaccurate locations"
+                hint="Reject fixes the GPS chip reports as imprecise"
+              >
                 <Toggle
                   accessibilityLabel="Filter inaccurate locations"
                   value={settings.filterInaccurateLocations}
@@ -402,7 +406,7 @@ export function SyncStrategySettings({
               </SettingRow>
 
               {settings.filterInaccurateLocations && (
-                <View style={[styles.nestedSetting, { borderLeftColor: colors.border }]}>
+                <View style={styles.nestedSetting}>
                   <NumericInput
                     label="Accuracy threshold"
                     value={accuracyThresholdInput}
@@ -455,14 +459,15 @@ const styles = StyleSheet.create({
   paramGroup: {
     marginBottom: space.xs
   },
-  paramGroupTitle: {
-    fontSize: fontSizes.description,
-    ...fonts.bold,
-    marginBottom: space.lg,
-    opacity: 0.6
-  },
+  // A block is a row whose control wraps below the label rather than sitting beside it. It
+  // pays nothing on top: the heading's own margin is the whole gap, so every group under a
+  // heading starts at the same distance whatever its first element is.
   settingBlock: {
-    marginBottom: 20
+    paddingBottom: space.lg
+  },
+  // SettingRow pads itself, which would double the gap when it is the first thing in a group.
+  firstInGroup: {
+    paddingTop: 0
   },
   blockLabel: {
     fontSize: fontSizes.label,
@@ -475,13 +480,11 @@ const styles = StyleSheet.create({
     marginBottom: space.md,
     lineHeight: 18
   },
-  settingRowSpaced: {
-    marginTop: space.lg
-  },
+  // A dependent control lines up with its parent's text; position carries the relationship,
+  // so there is no rule to draw.
   nestedSetting: {
     marginTop: space.md,
-    paddingStart: space.lg,
-    borderLeftWidth: 3
+    marginStart: space.lg
   },
   customSyncInput: {
     marginTop: space.md

--- a/apps/mobile/src/components/ui/SectionTitle.tsx
+++ b/apps/mobile/src/components/ui/SectionTitle.tsx
@@ -29,7 +29,6 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: fontSizes.label,
     ...fonts.semiBold,
-    marginBottom: space.md,
-    paddingHorizontal: space.xs
+    marginBottom: space.md
   }
 })

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -280,7 +280,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           </SettingRow>
 
           {pauseTracking && pauseOnMotionless && (
-            <View style={[styles.nestedSetting, { borderLeftColor: colors.border }]}>
+            <View style={styles.nestedSetting}>
               <SettingRow label="Timeout (min)" hint="Minutes without motion before GPS stops">
                 <TextField
                   testID="motionless-timeout-input"
@@ -315,7 +315,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           </SettingRow>
 
           {pauseTracking && heartbeatEnabled && (
-            <View style={[styles.nestedSetting, { borderLeftColor: colors.border }]}>
+            <View style={styles.nestedSetting}>
               <SettingRow label="Interval (min)" hint="How often to record a point">
                 <TextField
                   testID="heartbeat-interval-input"
@@ -369,12 +369,10 @@ const styles = StyleSheet.create({
   nameInput: { flex: 1 },
   numInput: { width: 80 },
   toggleRow: { paddingVertical: 10 },
+  // See SyncStrategySettings: a dependent control indents, it does not get a rule.
   nestedSetting: {
-    marginStart: space.lg,
-    paddingStart: space.md,
-    borderLeftWidth: 3,
-    marginTop: space.xs,
-    marginBottom: space.xs
+    marginTop: space.md,
+    marginStart: space.lg
   },
   combinedNote: {
     marginTop: space.sm,


### PR DESCRIPTION
SectionTitle sat 4dp inside whatever it titled, on all 57 call sites. The advanced panel's headings become SectionTitle instead of a hand-rolled Text at 0.6 opacity, and every heading now sits the same 12 from its first line. The 3px rule marking a dependent control goes; the indent stays.