### PR TITLE
fix(ui): rows in one card sit a row apart

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -194,7 +194,7 @@ export function ConnectionSettings({
 
         {!settings.isOfflineMode && (
           <>
-            <Divider />
+            <Divider tight />
 
             <View style={styles.inputGroup}>
               <View style={styles.inputHeader}>
@@ -269,7 +269,7 @@ export function ConnectionSettings({
               </View>
             )}
 
-            <Divider />
+            <Divider tight />
 
             <ListItem
               testID="nav-auth-settings"

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -169,7 +169,7 @@ export function SyncStrategySettings({
           ))}
         </View>
 
-        <Divider />
+        <Divider tight />
 
         <ListItem
           testID="advanced-settings-toggle"
@@ -217,7 +217,7 @@ export function SyncStrategySettings({
 
             {!settings.isOfflineMode && (
               <>
-                <Divider />
+                <Divider tight />
 
                 {/* Network Parameters Group */}
                 <View style={styles.paramGroup}>
@@ -380,7 +380,7 @@ export function SyncStrategySettings({
                   </View>
                 </View>
 
-                <Divider />
+                <Divider tight />
               </>
             )}
 

--- a/apps/mobile/src/components/ui/RadioRow.tsx
+++ b/apps/mobile/src/components/ui/RadioRow.tsx
@@ -17,8 +17,6 @@ type RadioRowProps = {
   onPress: () => void
   sub?: string
   icon?: LucideIcon
-  /** A hairline below the row, from the text column. Omit on the last row of a group. */
-  divider?: boolean
   testID?: string
 }
 
@@ -26,29 +24,26 @@ type RadioRowProps = {
  * The whole row is the radio; RadioDot is decoration, which is why it is hidden from
  * accessibility and the state lives here.
  */
-export function RadioRow({ label, selected, onPress, sub, icon: Icon, divider = false, testID }: RadioRowProps) {
+export function RadioRow({ label, selected, onPress, sub, icon: Icon, testID }: RadioRowProps) {
   const { colors } = useTheme()
 
   return (
-    <View>
-      <Pressable
-        testID={testID}
-        onPress={onPress}
-        accessibilityRole="radio"
-        accessibilityState={{ checked: selected }}
-        accessibilityLabel={sub ? `${label}, ${sub}` : label}
-        android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
-        style={styles.row}
-      >
-        <RadioDot selected={selected} />
-        {Icon ? <Icon size={size.icon.md} color={colors.textSecondary} /> : null}
-        <View style={styles.text}>
-          <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
-          {sub ? <Text style={[styles.sub, { color: colors.textSecondary }]}>{sub}</Text> : null}
-        </View>
-      </Pressable>
-      {divider ? <View style={[styles.divider, { backgroundColor: colors.border }]} /> : null}
-    </View>
+    <Pressable
+      testID={testID}
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected }}
+      accessibilityLabel={sub ? `${label}, ${sub}` : label}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+      style={styles.row}
+    >
+      <RadioDot selected={selected} />
+      {Icon ? <Icon size={size.icon.md} color={colors.textSecondary} /> : null}
+      <View style={styles.text}>
+        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+        {sub ? <Text style={[styles.sub, { color: colors.textSecondary }]}>{sub}</Text> : null}
+      </View>
+    </Pressable>
   )
 }
 
@@ -74,9 +69,5 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.description,
     ...fonts.regular,
     marginTop: 2
-  },
-  divider: {
-    height: 1,
-    marginStart: size.iconColumn
   }
 })

--- a/apps/mobile/src/components/ui/TextField.tsx
+++ b/apps/mobile/src/components/ui/TextField.tsx
@@ -77,7 +77,7 @@ export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function 
             borderWidth,
             borderColor,
             paddingHorizontal: FIELD_INSET - borderWidth,
-            backgroundColor: colors.background
+            backgroundColor: colors.well
           }
         ]}
       >

--- a/apps/mobile/src/components/ui/__tests__/TextField.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/TextField.test.tsx
@@ -91,8 +91,12 @@ describe("TextField", () => {
     expect(flat(getByTestId("server-input")).fontFamily).toBe("monospace")
   })
 
-  it("keeps the recessed fill, so a field on a card still reads as a field", () => {
+  it("recesses into its card rather than punching through to the ground behind it", () => {
+    // The fill was colors.background, so a field cut a hole the colour of the screen behind
+    // its card and a card holding fields read as a different tone from one that did not.
     const { getByTestId } = render(<TextField label="Server address" testID="server-input" />)
-    expect(flat(getByTestId("server-input-box")).backgroundColor).toBe(lightColors.background)
+
+    expect(flat(getByTestId("server-input-box")).backgroundColor).toBe(lightColors.well)
+    expect(flat(getByTestId("server-input-box")).backgroundColor).not.toBe(lightColors.background)
   })
 })

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -29,6 +29,7 @@ export const size = {
   chip: 36,
   iconButton: 32,
   iconColumn: 40,
+  numericField: 88,
   icon: { sm: 16, md: 20, lg: 24 }
 } as const
 

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import { useState, useCallback, useEffect } from "react"
+import React, { useState, useCallback, useEffect } from "react"
 import { useFocusEffect } from "@react-navigation/native"
 import { Text, StyleSheet, View, ScrollView, Pressable, DeviceEventEmitter } from "react-native"
 import { FolderOpen, CircleCheckBig, Share2, TriangleAlert } from "lucide-react-native"
@@ -503,14 +503,15 @@ export function AutoExportScreen(_props: ScreenProps) {
           <SectionTitle>Export range</SectionTitle>
           <Card rows>
             {MODE_OPTIONS.map((option, i) => (
-              <RadioRow
-                key={option.key}
-                label={option.label}
-                sub={option.description}
-                selected={mode === option.key}
-                onPress={() => handleModeChange(option.key)}
-                divider={i < MODE_OPTIONS.length - 1}
-              />
+              <React.Fragment key={option.key}>
+                {i > 0 && <Divider tight />}
+                <RadioRow
+                  label={option.label}
+                  sub={option.description}
+                  selected={mode === option.key}
+                  onPress={() => handleModeChange(option.key)}
+                />
+              </React.Fragment>
             ))}
           </Card>
         </View>

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -15,7 +15,7 @@ import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
 import { parsePositiveInt, isPositiveInt } from "../utils/settingsValidation"
 import type { RootScreenProps } from "../types/navigation"
-import { space } from "../constants"
+import { size, space } from "../constants"
 
 declare function requestIdleCallback(callback: () => void): number
 declare function cancelIdleCallback(handle: number): void
@@ -344,7 +344,8 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
         </Card>
 
         <Button
-          title={saving ? "Saving..." : "Save geofence"}
+          title="Save geofence"
+          loading={saving}
           onPress={handleSave}
           disabled={
             saving ||
@@ -367,7 +368,7 @@ const styles = StyleSheet.create({
   content: { padding: 20, paddingBottom: 40 },
   card: { marginBottom: space.lg },
   nameInput: { flex: 1 },
-  numInput: { width: 80 },
+  numInput: { width: size.numericField },
   toggleRow: { paddingVertical: 10 },
   // See SyncStrategySettings: a dependent control indents, it does not get a rule.
   nestedSetting: {

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -15,9 +15,8 @@ import { Button, Card, ChipGroup, Container, Divider, FieldMessage, NumericInput
 import { Check } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
-import { MS_TO_KMH, PROFILE_CONDITIONS, STATIONARY_MAX_INTERVAL_SECONDS, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, defaultProfileDelays, space } from "../constants"
+import { MS_TO_KMH, PROFILE_CONDITIONS, STATIONARY_MAX_INTERVAL_SECONDS, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, defaultProfileDelays, size, space } from "../constants"
 import type { RootScreenProps } from "../types/navigation"
-import { radius } from "@colota/shared"
 
 function formatSyncDefault(seconds: number): string {
   if (SYNC_INTERVAL_LABELS[seconds]) return SYNC_INTERVAL_LABELS[seconds]
@@ -195,7 +194,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
             />
           </View>
 
-          <Divider />
+          <Divider tight />
 
           <SettingRow label="Priority" hint="Higher number wins when multiple profiles match">
             <TextField
@@ -214,20 +213,21 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         <SectionTitle style={styles.sectionGap}>Activation condition</SectionTitle>
         <Card rows style={isSpeed && styles.cardTail}>
           {PROFILE_CONDITIONS.map((opt, i) => (
-            <RadioRow
-              key={opt.type}
-              icon={opt.icon}
-              label={opt.label}
-              sub={opt.description}
-              selected={profile.condition.type === opt.type}
-              onPress={() => setConditionType(opt.type)}
-              divider={i < PROFILE_CONDITIONS.length - 1}
-            />
+            <React.Fragment key={opt.type}>
+              {i > 0 && <Divider tight />}
+              <RadioRow
+                icon={opt.icon}
+                label={opt.label}
+                sub={opt.description}
+                selected={profile.condition.type === opt.type}
+                onPress={() => setConditionType(opt.type)}
+              />
+            </React.Fragment>
           ))}
 
           {isSpeed && (
             <>
-              <Divider />
+              <Divider tight />
               <View style={styles.inputGroup}>
                 <TextField
                   testID="speed-threshold-input"
@@ -268,7 +268,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
             </FieldMessage>
           )}
 
-          <Divider />
+          <Divider tight />
 
           {profile.condition.type === "stationary" ? (
             <FieldMessage>
@@ -296,7 +296,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
           {!settings.isOfflineMode && (
             <>
-              <Divider />
+              <Divider tight />
 
               <View style={styles.syncLabelRow}>
                 <Text style={[styles.settingLabel, { color: colors.text }]}>Sync interval</Text>
@@ -421,10 +421,9 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
         {/* Save Button */}
         <Button
-          title={saving ? "Saving…" : isEditing ? "Save changes" : "Create profile"}
+          title={isEditing ? "Save changes" : "Create profile"}
           icon={Check}
           loading={saving}
-          style={styles.saveBtn}
           onPress={handleSave}
         />
       </ScrollView>
@@ -441,23 +440,12 @@ const styles = StyleSheet.create({
   cardTail: { paddingBottom: space.lg },
   scrollContent: { paddingHorizontal: space.lg, paddingTop: space.lg, paddingBottom: 40 },
   inputGroup: { marginBottom: space.xs },
-  numInput: {
-    width: 64
-  },
+  numInput: { width: size.numericField },
   inputWithUnit: { flexDirection: "row", alignItems: "center", gap: 6 },
   unit: { fontSize: fontSizes.body, ...fonts.medium, minWidth: 28 },
   syncLabelRow: { marginBottom: space.sm },
   settingLabel: { fontSize: fontSizes.label, ...fonts.semiBold, marginBottom: 2 },
   settingHint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18 }, // ~3 per row with gap
   customSyncInput: { marginTop: space.md },
-  saveBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: space.sm,
-    padding: space.lg,
-    borderRadius: radius.md,
-    marginTop: space.lg
-  },
   sectionGap: { marginTop: space.xl }
 })

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -182,7 +182,6 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
             <Button
               title="Create profile"
               icon={Plus}
-              style={styles.createBtn}
               onPress={() => navigation.navigate("Profile Editor", {})}
             />
 
@@ -220,15 +219,6 @@ const styles = StyleSheet.create({
   list: { padding: space.lg, paddingBottom: 40 },
   header: { marginBottom: 20 },
   subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: 20 },
-  createBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: space.sm,
-    padding: space.lg,
-    borderRadius: radius.md,
-    marginBottom: space.xl
-  },
   card: { marginBottom: space.md },
   activeCard: { borderWidth: 2 },
   row: { flexDirection: "row", alignItems: "center" },


### PR DESCRIPTION
Nine dividers inside row cards used the block margin instead of tight. TextField filled with the ground colour, so a field cut a hole through its card. RadioRow drew its own heavier hairline instead of using Divider. Both editors' save buttons behaved differently from each other and from the guide. The numeric field had two widths, the smaller of which clipped four digits.