### PR TITLE
fix(screens): data management and export say what they are for

### DIFF
--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -246,6 +246,7 @@ export function DataManagementScreen({}: ScreenProps) {
     <Container>
       <KeyboardAvoidingView style={styles.keyboardAvoid} behavior={Platform.OS === "ios" ? "padding" : undefined}>
         <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>What this device is storing, and how to clear it</Text>
           {/* Stats */}
           <View style={styles.section}>
             <SectionTitle>Database statistics</SectionTitle>
@@ -430,6 +431,12 @@ const ActionRow = ({
 }
 
 const styles = StyleSheet.create({
+  intro: {
+    fontSize: fontSizes.body,
+    ...fonts.regular,
+    lineHeight: 20,
+    marginBottom: space.lg
+  },
   keyboardAvoid: {
     flex: 1
   },

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -15,7 +15,6 @@ import { logger } from "../utils/logger"
 import { showAlert } from "../services/modalService"
 import { ScreenProps } from "../types/global"
 import { space } from "../constants"
-import { radius } from "@colota/shared"
 
 export function ExportLocationsScreen({}: ScreenProps) {
   const { colors } = useTheme()
@@ -81,6 +80,9 @@ export function ExportLocationsScreen({}: ScreenProps) {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>
+          {totalLocations.toLocaleString()} locations. Save them to a file, once
+        </Text>
         {totalLocations === 0 ? (
           <Card style={styles.emptyCard}>
             <View style={styles.emptyState}>
@@ -93,17 +95,6 @@ export function ExportLocationsScreen({}: ScreenProps) {
           </Card>
         ) : (
           <>
-            {/* Stats Card */}
-            <View style={[styles.statsContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
-              <View style={styles.statsGrid}>
-                <View style={styles.statItem}>
-                  <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Total locations</Text>
-                  <Text style={[styles.statValue, { color: colors.primaryDark }]}>
-                    {totalLocations.toLocaleString()}
-                  </Text>
-                </View>
-              </View>
-            </View>
 
             {/* Format Selection */}
             <View style={styles.section}>
@@ -134,6 +125,12 @@ export function ExportLocationsScreen({}: ScreenProps) {
 }
 
 const styles = StyleSheet.create({
+  intro: {
+    fontSize: fontSizes.body,
+    ...fonts.regular,
+    lineHeight: 20,
+    marginBottom: space.lg
+  },
   scrollContent: {
     paddingHorizontal: space.lg,
     paddingTop: 20,
@@ -156,31 +153,6 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.description,
     textAlign: "center",
     lineHeight: 18
-  },
-  statsContainer: {
-    borderRadius: radius.lg,
-    borderWidth: 2,
-    marginBottom: space.xl,
-    overflow: "hidden"
-  },
-  statsGrid: {
-    flexDirection: "row",
-    padding: 20
-  },
-  statItem: {
-    flex: 1,
-    alignItems: "center"
-  },
-  statLabel: {
-    fontSize: fontSizes.caption,
-    ...fonts.semiBold,
-    marginBottom: space.sm
-  },
-  statValue: {
-    fontSize: fontSizes.cardTitle,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    textAlign: "center"
   },
   section: {
     marginBottom: space.xl

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -17,7 +17,6 @@ import { FILE_FORMATS, IMPORT_FORMAT_ORDER, importDescription } from "../utils/f
 import { ScreenProps } from "../types/global"
 import type { ThemeColors } from "../types/global"
 import { size, space } from "../constants"
-import { radius } from "@colota/shared"
 
 const IMPORT_FORMAT_LABELS = Object.fromEntries(
   (Object.keys(FILE_FORMATS) as ImportFormat[]).map((k) => [k, FILE_FORMATS[k].label])
@@ -213,14 +212,9 @@ export function ImportLocationsScreen({}: ScreenProps) {
     <Container>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Stats Card */}
-        <View style={[styles.statsContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
-          <View style={styles.statsGrid}>
-            <View style={styles.statItem}>
-              <Text style={[styles.statLabel, { color: colors.textSecondary }]}>Total locations</Text>
-              <Text style={[styles.statValue, { color: colors.primaryDark }]}>{totalLocations.toLocaleString()}</Text>
-            </View>
-          </View>
-        </View>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>
+          {totalLocations.toLocaleString()} locations recorded so far
+        </Text>
 
         {/* Supported formats */}
         <View style={styles.section}>
@@ -262,31 +256,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: space.lg,
     paddingTop: 20,
     paddingBottom: 40
-  },
-  statsContainer: {
-    borderRadius: radius.lg,
-    borderWidth: 2,
-    marginBottom: space.xl,
-    overflow: "hidden"
-  },
-  statsGrid: {
-    flexDirection: "row",
-    padding: 20
-  },
-  statItem: {
-    flex: 1,
-    alignItems: "center"
-  },
-  statLabel: {
-    fontSize: fontSizes.caption,
-    ...fonts.semiBold,
-    marginBottom: space.sm
-  },
-  statValue: {
-    fontSize: fontSizes.cardTitle,
-    ...fonts.bold,
-    letterSpacing: -0.5,
-    textAlign: "center"
   },
   section: {
     marginBottom: space.xl

--- a/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ExportLocationsScreen.test.tsx
@@ -244,12 +244,13 @@ describe("ExportLocationsScreen", () => {
     })
   })
 
-  it("shows total location count", async () => {
+  it("says how many locations are about to be exported", async () => {
+    // The count used to be a card of its own for one number. It reads out of the caption now,
+    // so the assertion is on the sentence rather than on a label beside a figure.
     const { getByText } = renderScreen()
 
     await waitFor(() => {
-      expect(getByText("Total locations")).toBeTruthy()
-      expect(getByText("100")).toBeTruthy()
+      expect(getByText(/100 locations/)).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
Two screens get the caption Connection and Tracking & sync have. Import and export drop a bordered card that held a single number, a leftover copy of the old StatsCard styling; the count moves into the caption.