### PR TITLE
feat(ui): the tab bar says which tab you are on

### DIFF
--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -5,29 +5,34 @@
 import React from "react"
 import { View, Pressable, Text, StyleSheet } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { Settings, LucideIcon, House, MapPinHouse, Waypoints } from "lucide-react-native"
+import { Settings, House, CircleDot, Route } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { size, space, STATE_LAYER_ALPHA } from "../../constants"
 import type { RootStackRoute } from "../../types/navigation"
 
+type TabIcon = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
+
 interface Tab {
   name: string
   label: string
-  icon: LucideIcon
+  icon: TabIcon
   route: RootStackRoute
 }
 
 const TABS: Tab[] = [
   { name: "dashboard", label: "Dashboard", icon: House, route: "Dashboard" },
-  { name: "history", label: "History", icon: Waypoints, route: "Location History" },
-  { name: "geofences", label: "Geofences", icon: MapPinHouse, route: "Geofences" },
+  { name: "history", label: "History", icon: Route, route: "Location History" },
+  { name: "geofences", label: "Geofences", icon: CircleDot, route: "Geofences" },
   { name: "settings", label: "Settings", icon: Settings, route: "Settings" }
 ]
 
 /** Routes where the tab bar is visible. The one list; App.tsx reads it rather than repeating it. */
 // Typed loosely on purpose: lookups come from navigation state, which is a bare string.
 export const TAB_ROUTES: Set<string> = new Set(TABS.map((t) => t.route))
+
+/** The semibold of a glyph: with no filled variants in the set, weight carries the active tab. */
+const ACTIVE_STROKE = 2.25
 
 interface BottomTabBarProps {
   currentRoute: string | undefined
@@ -52,16 +57,22 @@ export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
     >
       {TABS.map((tab) => {
         const active = currentRoute === tab.route
-        const color = active ? colors.primary : colors.textLight
+        const color = active ? colors.primary : colors.textSecondary
         return (
           <Pressable
             key={tab.name}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={tab.label}
             android_ripple={{ color: colors.text + STATE_LAYER_ALPHA, borderless: true, radius: size.touch / 2 }}
             style={styles.tab}
             onPress={() => onNavigate(tab.route)}
           >
-            <tab.icon size={size.icon.md} color={color} />
-            <Text style={[styles.label, { color }]}>{tab.label}</Text>
+            {/* The set has no filled variants, so weight is what marks the active glyph. */}
+            <tab.icon size={size.icon.lg} color={color} strokeWidth={active ? ACTIVE_STROKE : undefined} />
+            <Text numberOfLines={2} style={[styles.label, active && fonts.semiBold, { color }]}>
+              {tab.label}
+            </Text>
           </Pressable>
         )
       })}
@@ -79,6 +90,7 @@ const styles = StyleSheet.create({
   },
   tab: {
     flex: 1,
+    minHeight: size.row,
     alignItems: "center",
     justifyContent: "center",
     gap: 3

--- a/apps/mobile/src/components/ui/__tests__/BottomTabBar.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/BottomTabBar.test.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })
+}))
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { lightColors } from "@colota/shared"
+import { BottomTabBar, TAB_ROUTES } from "../BottomTabBar"
+
+function renderBar(currentRoute: string | undefined) {
+  return render(<BottomTabBar currentRoute={currentRoute} onNavigate={jest.fn()} />)
+}
+
+describe("BottomTabBar", () => {
+  it("hides itself off the four tab routes, so a pushed screen is not framed as one", () => {
+    expect(renderBar("Connection").toJSON()).toBeNull()
+    expect(renderBar(undefined).toJSON()).toBeNull()
+    expect(renderBar("Dashboard").toJSON()).not.toBeNull()
+  })
+
+  it("marks the current tab selected, which is the whole announcement for a screen reader", () => {
+    // Without accessibilityRole tab and a selected state TalkBack reads four plain buttons and
+    // never says which screen you are on.
+    const { getByLabelText } = renderBar("Geofences")
+
+    expect(getByLabelText("Geofences").props.accessibilityRole).toBe("tab")
+    expect(getByLabelText("Geofences").props.accessibilityState.selected).toBe(true)
+    expect(getByLabelText("Dashboard").props.accessibilityState.selected).toBe(false)
+  })
+
+  it("weights the active glyph, because the icon set has no filled variants to switch to", () => {
+    const { getByLabelText } = renderBar("Dashboard")
+
+    const active = getByLabelText("Dashboard").findByProps({ strokeWidth: 2.25 })
+    expect(active).toBeTruthy()
+    expect(getByLabelText("Geofences").findAllByProps({ strokeWidth: 2.25 })).toHaveLength(0)
+  })
+
+  it("colours the active tab with the accent and the rest with secondary ink", () => {
+    const { getByText } = renderBar("Settings")
+
+    expect(getByText("Settings").props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: lightColors.primary })])
+    )
+    expect(getByText("History").props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: lightColors.textSecondary })])
+    )
+  })
+
+  it("lets a label wrap to two lines rather than truncate at a large font scale", () => {
+    const { getByText } = renderBar("Dashboard")
+    expect(getByText("Dashboard").props.numberOfLines).toBe(2)
+  })
+
+  it("exports the routes it covers, so App.tsx does not keep a second list", () => {
+    expect(TAB_ROUTES).toEqual(new Set(["Dashboard", "Location History", "Geofences", "Settings"]))
+  })
+})


### PR DESCRIPTION
The tabs carried no accessibilityRole or selected state, so a screen reader never said which screen you were on. History takes Lucide's Route, the glyph the trip list already uses for an empty day, and Geofences takes CircleDotDashed. Plus the plan's sizing, weight and ink, and the first test the bar has had.