### PR TITLE
fix(ui): fields carry their own label

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -18,7 +18,6 @@ import { TEST_RESULT_DISPLAY_MS, size, space } from "../../../constants"
 import { logger } from "../../../utils/logger"
 import { Button, Card, Divider, FieldMessage, TextField, Toggle, ListItem } from "../../index"
 import { showChoice } from "../../../services/modalService"
-import { radius } from "@colota/shared"
 
 interface ConnectionSettingsProps {
   settings: Settings
@@ -197,35 +196,8 @@ export function ConnectionSettings({
             <Divider tight />
 
             <View style={styles.inputGroup}>
-              <View style={styles.inputHeader}>
-                <Text style={[styles.inputLabel, { color: colors.text }]}>Server endpoint</Text>
-                {endpointInput && (
-                  <View
-                    style={[
-                      styles.protocolBadge,
-                      {
-                        backgroundColor: endpointInput.startsWith("https://")
-                          ? colors.well
-                          : colors.warning + "20"
-                      }
-                    ]}
-                  >
-                    <Text
-                      style={[
-                        styles.protocolText,
-                        {
-                          color: endpointInput.startsWith("https://") ? colors.textSecondary : colors.warning
-                        }
-                      ]}
-                    >
-                      {endpointInput.startsWith("https://") ? "HTTPS" : "HTTP"}
-                    </Text>
-                  </View>
-                )}
-              </View>
-
               <TextField
-                accessibilityLabel="Server endpoint"
+                label="Server endpoint"
                 testID="endpoint-input"
                 mono
                 value={endpointInput}
@@ -296,25 +268,6 @@ const styles = StyleSheet.create({
   },
   inputGroup: {
     marginBottom: space.md
-  },
-  inputHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 10
-  },
-  inputLabel: {
-    fontSize: fontSizes.input,
-    ...fonts.semiBold
-  },
-  protocolBadge: {
-    paddingHorizontal: 10,
-    paddingVertical: space.xs,
-    borderRadius: radius.md
-  },
-  protocolText: {
-    fontSize: fontSizes.small,
-    ...fonts.bold
   },
   testButton: {
     marginTop: space.md

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -162,17 +162,7 @@ describe("ConnectionSettings", () => {
       expect(getByText("Authentication & headers")).toBeTruthy()
     })
 
-    it("shows HTTPS badge for https endpoint", () => {
-      const { getByText } = renderComponent({}, "https://example.com/api/locations")
 
-      expect(getByText("HTTPS")).toBeTruthy()
-    })
-
-    it("shows HTTP badge for http endpoint", () => {
-      const { getByText } = renderComponent({}, "http://192.168.1.1/api/locations")
-
-      expect(getByText("HTTP")).toBeTruthy()
-    })
   })
 
   describe("offline mode", () => {

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -144,12 +144,9 @@ export function AppearanceScreen({}: ScreenProps) {
 
           {showMapTileServer && (
             <View style={styles.mapTilePanel}>
-              <Text style={[styles.mapStyleSub, styles.mapStyleSubFirst, { color: colors.textSecondary }]}>
-                {t("appearance.mapStyle.light")}
-              </Text>
               <TextField
                 testID="map-style-url-light"
-                accessibilityLabel={t("appearance.mapStyle.light")}
+                label={t("appearance.mapStyle.light")}
                 mono
                 value={mapStyleUrlLight}
                 onChangeText={setMapStyleUrlLight}
@@ -160,12 +157,9 @@ export function AppearanceScreen({}: ScreenProps) {
                 autoCorrect={false}
                 keyboardType="url"
               />
-              <Text style={[styles.mapStyleSub, styles.mapStyleSubSecond, { color: colors.textSecondary }]}>
-                {t("appearance.mapStyle.dark")}
-              </Text>
               <TextField
                 testID="map-style-url-dark"
-                accessibilityLabel={t("appearance.mapStyle.dark")}
+                label={t("appearance.mapStyle.dark")}
                 mono
                 value={mapStyleUrlDark}
                 onChangeText={setMapStyleUrlDark}
@@ -212,13 +206,6 @@ const styles = StyleSheet.create({
     marginTop: space.xs,
     paddingBottom: space.xs
   },
-  mapStyleSub: {
-    fontSize: fontSizes.caption,
-    ...fonts.medium,
-    marginBottom: 6
-  },
-  mapStyleSubFirst: { marginTop: space.md },
-  mapStyleSubSecond: { marginTop: 10 },
   mapStyleFooter: {
     flexDirection: "row",
     justifyContent: "space-between",


### PR DESCRIPTION
The endpoint's HTTPS/HTTP badge restated the value, duplicated the warning below it, and went amber for private-address HTTP that UrlSafety allows. Removing it lets the label move into TextField. Appearance's map style fields had the same label written twice, once visible and once for the screen reader.