### PR TITLE
fix(ui): a border means state, never grouping

### DIFF
--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -89,7 +89,7 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
       onPress={() => navigation.navigate("Connection")}
       style={({ pressed }) => [
         styles.container,
-        { backgroundColor: colors.card, borderColor: colors.border },
+        { backgroundColor: colors.card },
         pressed && { opacity: colors.pressedOpacity }
       ]}
     >
@@ -109,7 +109,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     padding: 14,
     borderRadius: radius.md,
-    borderWidth: 1,
     marginBottom: 22
   },
   dot: {

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -116,7 +116,6 @@ export function WelcomeCard({
         <Pressable
           style={({ pressed }) => [
             styles.dismissButton,
-            { borderColor: colors.border },
             pressed && { opacity: colors.pressedOpacity }
           ]}
           onPress={onDismiss}
@@ -179,8 +178,7 @@ const styles = StyleSheet.create({
   dismissButton: {
     paddingVertical: 10,
     alignItems: "center",
-    borderRadius: 10,
-    borderWidth: 1.5
+    borderRadius: 10
   },
   dismissText: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -306,7 +306,7 @@ export function TrackMap({
       )}
 
       {!isEmpty && popup && (
-        <View style={[styles.popupCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <View style={[styles.popupCard, { backgroundColor: colors.card }]}>
           <View style={styles.popupHeader}>
             <Text style={[styles.popupTime, { color: colors.text }]}>
               {popup.timestamp ? new Date(popup.timestamp * 1000).toLocaleTimeString() : "-"}
@@ -401,7 +401,7 @@ export function TrackMap({
       {!isEmpty && <MapCenterButton visible={!isCentered} onPress={handleFitTrack} />}
 
       {!isEmpty && trips && trips.length > 1 && (
-        <View style={[styles.legend, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <View style={[styles.legend, { backgroundColor: colors.card }]}>
           {trips.map((trip) => (
             <View key={trip.index} style={styles.legendItem}>
               <View style={[styles.legendDot, { backgroundColor: getTripColor(trip.index) }]} />
@@ -456,7 +456,6 @@ const styles = StyleSheet.create({
     right: 10,
     padding: space.md,
     borderRadius: radius.md,
-    borderWidth: 1,
     elevation: 6,
     zIndex: 10
   },
@@ -517,7 +516,6 @@ const styles = StyleSheet.create({
     bottom: 30,
     left: 10,
     borderRadius: radius.md,
-    borderWidth: 1,
     padding: space.sm,
     gap: space.xs,
     elevation: 4,

--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -353,7 +353,7 @@ export function TripList({
               }}
               style={({ pressed }) => [
                 styles.exportChip,
-                { backgroundColor: colors.primary + "12", borderColor: colors.primary + "30" },
+                { backgroundColor: colors.primary + "12" },
                 pressed && { opacity: colors.pressedOpacity }
               ]}
               accessibilityRole="button"
@@ -448,8 +448,7 @@ const styles = StyleSheet.create({
   exportChip: {
     paddingHorizontal: 10,
     paddingVertical: 5,
-    borderRadius: radius.sm,
-    borderWidth: 1
+    borderRadius: radius.sm
   },
   exportChipText: {
     fontSize: fontSizes.small,

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -223,7 +223,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
             <Pressable style={styles.attributionBackdrop} onPress={() => setAttributionOpen(false)}>
               <Pressable
                 onPress={() => {}}
-                style={[styles.attributionPopup, { backgroundColor: colors.card, borderColor: colors.border }]}
+                style={[styles.attributionPopup, { backgroundColor: colors.card }]}
               >
                 <Pressable
                   onPress={() => setAttributionOpen(false)}
@@ -272,7 +272,6 @@ const styles = StyleSheet.create({
     paddingEnd: 36,
     paddingVertical: 14,
     borderRadius: 10,
-    borderWidth: 1,
     gap: space.sm,
     elevation: 8
   },

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -363,7 +363,7 @@ export function SyncStrategySettings({
                           <Pressable
                             style={({ pressed }) => [
                               styles.ssidFillButton,
-                              { borderColor: colors.primary, backgroundColor: colors.primary + "15" },
+                              { backgroundColor: colors.primary + "15" },
                               pressed && { opacity: colors.pressedOpacity }
                             ]}
                             onPress={() => {
@@ -502,8 +502,7 @@ const styles = StyleSheet.create({
     alignSelf: "flex-start",
     paddingHorizontal: 10,
     paddingVertical: 6,
-    borderRadius: radius.sm,
-    borderWidth: 1
+    borderRadius: radius.sm
   },
   ssidFillText: {
     ...fonts.medium,

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -122,7 +122,7 @@ function getButtonStyles(
       }
     case "secondary":
       return {
-        container: { borderWidth: 1.5, borderColor: colors.border } as const,
+        container: {} as const,
         text: { color: colors.textSecondary } as const
       }
     default:

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -147,9 +147,7 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   primaryButton: {},
-  secondaryButton: {
-    borderWidth: 1.5
-  },
+  secondaryButton: {},
   buttonText: {
     fontSize: fontSizes.label,
     ...fonts.semiBold

--- a/apps/mobile/src/components/ui/FormatOption.tsx
+++ b/apps/mobile/src/components/ui/FormatOption.tsx
@@ -56,8 +56,7 @@ export const FormatOption = ({
                 style={[
                   styles.extensionBadge,
                   {
-                    backgroundColor: selected ? colors.primary + "20" : colors.primary + "15",
-                    borderColor: selected ? colors.primary + "40" : colors.primary + "30"
+                    backgroundColor: selected ? colors.primary + "20" : colors.primary + "15"
                   }
                 ]}
               >
@@ -108,8 +107,7 @@ const styles = StyleSheet.create({
   extensionBadge: {
     paddingHorizontal: space.sm,
     paddingVertical: 3,
-    borderRadius: 6,
-    borderWidth: 1
+    borderRadius: 6
   },
   extensionText: {
     fontSize: fontSizes.micro,

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -549,7 +549,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
             )}
           </View>
 
-          <View style={[styles.fieldsCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <View style={[styles.fieldsCard, { backgroundColor: colors.card }]}>
             {(Object.keys(DEFAULT_FIELD_MAP) as Array<keyof FieldMap>).map((key, index) => {
               const isFieldModified = modifiedFields.has(key)
               const fieldValue = localFieldMap[key]?.trim()
@@ -613,7 +613,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
             <SectionTitle>Custom fields</SectionTitle>
           </View>
 
-          <View style={[styles.fieldsCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <View style={[styles.fieldsCard, { backgroundColor: colors.card }]}>
             {localCustomFields.length === 0 ? (
               <Text style={[styles.emptyHint, { color: colors.textSecondary }]}>
                 No custom fields. Add static key-value pairs to include in every payload.
@@ -753,8 +753,7 @@ const styles = StyleSheet.create({
   },
   fieldsCard: {
     padding: space.md,
-    borderRadius: 10,
-    borderWidth: 1
+    borderRadius: 10
   },
   fieldRow: {
     flexDirection: "row",
@@ -842,8 +841,7 @@ const styles = StyleSheet.create({
   },
   exampleCard: {
     padding: 14,
-    borderRadius: radius.sm,
-    borderWidth: 1
+    borderRadius: radius.sm
   },
   exampleCode: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -115,7 +115,7 @@ function PasswordPromptModal({
       onRequestClose={busy ? undefined : onCancel}
     >
       <View style={[styles.modalOverlay, { backgroundColor: colors.overlay }]}>
-        <View style={[styles.modalCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <View style={[styles.modalCard, { backgroundColor: colors.card }]}>
           <Text style={[styles.modalTitle, { color: colors.text }]}>Enter password</Text>
           <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]} numberOfLines={1}>
             For {filename}
@@ -398,8 +398,7 @@ const styles = StyleSheet.create({
   },
   modalCard: {
     padding: space.lg,
-    borderRadius: radius.md,
-    borderWidth: 1
+    borderRadius: radius.md
   },
   modalTitle: {
     fontSize: fontSizes.label,

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -423,7 +423,7 @@ const ActionRow = ({
         <Text style={[styles.actionLabel, { color }]}>{label}</Text>
         <Text style={[styles.actionHint, { color: textColor }]}>{hint}</Text>
       </View>
-      <View style={[styles.actionBadge, { backgroundColor: color + "20", borderColor: color }]}>
+      <View style={[styles.actionBadge, { backgroundColor: color + "20" }]}>
         <Text style={[styles.actionBadgeText, { color }]}>{value}</Text>
       </View>
     </Pressable>
@@ -495,8 +495,7 @@ const styles = StyleSheet.create({
   actionBadge: {
     paddingHorizontal: space.md,
     paddingVertical: 6,
-    borderRadius: radius.lg,
-    borderWidth: 1
+    borderRadius: radius.lg
   },
   actionBadgeText: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -91,7 +91,7 @@ const FormatRow = ({ entry, colors }: { entry: (typeof SUPPORTED_FORMATS)[number
           <View
             style={[
               styles.extensionBadge,
-              { backgroundColor: colors.primary + "15", borderColor: colors.primary + "30" }
+              { backgroundColor: colors.primary + "15" }
             ]}
           >
             <Text style={[styles.extensionText, { color: colors.primaryDark }]}>{entry.extension}</Text>
@@ -289,8 +289,7 @@ const styles = StyleSheet.create({
   extensionBadge: {
     paddingHorizontal: space.sm,
     paddingVertical: 3,
-    borderRadius: 6,
-    borderWidth: 1
+    borderRadius: 6
   },
   extensionText: {
     fontSize: fontSizes.micro,

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -529,8 +529,7 @@ const styles = StyleSheet.create({
   exportChip: {
     paddingHorizontal: 14,
     paddingVertical: space.sm,
-    borderRadius: radius.sm,
-    borderWidth: 1
+    borderRadius: radius.sm
   },
   exportChipText: {
     fontSize: fontSizes.caption,


### PR DESCRIPTION
An outline meant both 'selected' and 'here is a box', so it signalled neither. Twelve grouping borders go; selection, error and control-shape ones stay. After this an outline means the thing is selected or wrong, which is learnable on one screen.