### PR TITLE
fix(ui): a single-line field's hint cannot wrap

### DIFF
--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -202,7 +202,7 @@ export function ConnectionSettings({
                 mono
                 value={endpointInput}
                 onChangeText={onEndpointInputChange}
-                placeholder="https://your-server.com/api/locations"
+                placeholder="https://your-server.com/api"
                 autoCapitalize="none"
                 autoCorrect={false}
                 keyboardType="url"

--- a/apps/mobile/src/components/ui/TextField.tsx
+++ b/apps/mobile/src/components/ui/TextField.tsx
@@ -97,6 +97,7 @@ export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function 
             onBlur?.(e)
           }}
           multiline={multiline}
+          numberOfLines={multiline ? undefined : 1}
           style={[
             styles.input,
             mono && styles.mono,


### PR DESCRIPTION
The endpoint placeholder was wider than the field in monospace, so Android wrapped the hint onto a second line and TextField's 48 minimum clipped it. It read as a line hidden behind the box. Every non-multiline field passes numberOfLines 1 now, and that placeholder drops its path segment.
