### PR TITLE
fix(dashboard): Got it is a button again

### DIFF
--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -9,6 +9,7 @@ import { Check, ChevronRight } from "lucide-react-native"
 import { Settings, ThemeColors } from "../../../types/global"
 import { useTracking } from "../../../contexts/TrackingProvider"
 import { fontSizes, fonts } from "../../../styles/typography"
+import { Button } from "../../ui/Button"
 import { Card } from "../../ui/Card"
 import { size, space } from "../../../constants"
 import { radius } from "@colota/shared"
@@ -113,15 +114,7 @@ export function WelcomeCard({
           </Pressable>
         </View>
 
-        <Pressable
-          style={({ pressed }) => [
-            styles.dismissButton,
-            pressed && { opacity: colors.pressedOpacity }
-          ]}
-          onPress={onDismiss}
-        >
-          <Text style={[styles.dismissText, { color: colors.textSecondary }]}>Got it</Text>
-        </Pressable>
+        <Button title="Got it" variant="secondary" onPress={onDismiss} />
       </Card>
     </View>
   )
@@ -175,13 +168,4 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.body,
     ...fonts.semiBold
   },
-  dismissButton: {
-    paddingVertical: 10,
-    alignItems: "center",
-    borderRadius: 10
-  },
-  dismissText: {
-    fontSize: fontSizes.body,
-    ...fonts.semiBold
-  }
 })

--- a/apps/mobile/src/components/features/dashboard/__tests__/WelcomeCard.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/WelcomeCard.test.tsx
@@ -10,6 +10,11 @@ jest.mock("../../../../contexts/TrackingProvider", () => ({
   })
 }))
 
+// Button reads the theme itself, unlike WelcomeCard, which takes colors as a prop.
+jest.mock("../../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
 jest.mock("../../../ui/Card", () => {
   const R = require("react")
   const { View } = require("react-native")


### PR DESCRIPTION
The border sweep took its outline, and it had no fill, so it became centred grey text with nothing marking it as tappable. That was my error: the outline was the button's only affordance, not a box around content. It is a secondary Button now, which also gives it the ripple and the 48 target the hand-rolled Pressable never had.

WelcomeCard takes colors as a prop while Button reads useTheme, so its test had never mocked the hook and every case in it failed at once.
