### PR TITLE
fix(ui): every input is one fill, and a ring means state

### DIFF
--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -373,7 +373,7 @@ export function TrackMap({
                     onChangeText={setNoteDraft}
                     placeholder="Add a note"
                     placeholderTextColor={colors.textSecondary}
-                    style={[styles.noteInput, { color: colors.text, borderColor: colors.border }]}
+                    style={[styles.noteInput, { color: colors.text, backgroundColor: colors.well }]}
                     multiline
                   />
                   {noteDraft.trim() !== popup.note && (
@@ -481,7 +481,6 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.description,
     paddingVertical: 2,
     paddingHorizontal: 6,
-    borderWidth: 1,
     borderRadius: 6,
     minHeight: 32,
     maxHeight: 80

--- a/apps/mobile/src/components/ui/TextField.tsx
+++ b/apps/mobile/src/components/ui/TextField.tsx
@@ -14,8 +14,9 @@ import { radius } from "@colota/shared"
 import { FieldMessage } from "./FieldMessage"
 
 /**
- * Distance from the outer edge to the text. The border grows from 1 to 2 on focus and on
- * error, so the padding shrinks by the same amount or the text jumps sideways as you tap in.
+ * Distance from the outer edge to the text. The resting field has no border, only a fill; the
+ * ring appears on focus and on error, so the padding shrinks by the same amount it grows or
+ * the text jumps sideways as you tap in.
  */
 const FIELD_INSET = 15
 
@@ -23,12 +24,11 @@ const FIELD_INSET = 15
 const MULTILINE_MIN_HEIGHT = 80
 
 type BaseProps = Omit<TextInputProps, "style" | "editable" | "secureTextEntry"> & {
-  /** A string shows the ring and the message; true shows the ring alone, when a caller says it elsewhere. */
   error?: string | boolean
   disabled?: boolean
   secure?: boolean
   mono?: boolean
-  /** A number the user reads back: centred and weighted, so the value is the thing you see. */
+  border?: boolean
   figure?: boolean
   style?: StyleProp<ViewStyle>
   testID?: string
@@ -45,6 +45,7 @@ export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function 
   disabled = false,
   secure = false,
   mono = false,
+  border = false,
   figure = false,
   style,
   testID,
@@ -60,8 +61,8 @@ export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function 
   const [revealed, setRevealed] = useState(false)
 
   const name = label ?? accessibilityLabel ?? ""
-  const borderWidth = error || (focused && !disabled) ? 2 : 1
-  const borderColor = disabled ? colors.border : error ? colors.error : focused ? colors.primary : colors.border
+  const borderWidth = error || (focused && !disabled) ? 2 : border ? 1 : 0
+  const borderColor = error ? colors.error : focused && !disabled ? colors.primary : colors.border
   const RevealIcon = revealed ? EyeOff : Eye
   const labelColor = disabled ? colors.textDisabled : focused ? colors.primary : colors.textSecondary
 

--- a/apps/mobile/src/components/ui/__tests__/TextField.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/TextField.test.tsx
@@ -26,15 +26,26 @@ describe("TextField", () => {
     expect(focused.borderWidth + focused.paddingHorizontal).toBe(15)
   })
 
-  it("paints the focus ring in primary and the error ring in error", () => {
+  it("rests without a ring and grows one on focus and on error", () => {
+    // A border marks state, so the resting field is a fill. The ring's width is what the box
+    // gives back in padding, or the text would jump sideways as you tap in.
     const { getByTestId, rerender } = render(<TextField label="Server address" testID="server-input" />)
-    expect(flat(getByTestId("server-input-box")).borderColor).toBe(lightColors.border)
+    expect(flat(getByTestId("server-input-box")).borderWidth).toBe(0)
 
     fireEvent(getByTestId("server-input"), "focus")
+    expect(flat(getByTestId("server-input-box")).borderWidth).toBe(2)
     expect(flat(getByTestId("server-input-box")).borderColor).toBe(lightColors.primary)
 
     rerender(<TextField label="Server address" testID="server-input" error="Public hosts need https" />)
     expect(flat(getByTestId("server-input-box")).borderColor).toBe(lightColors.error)
+  })
+
+  it("can be asked for a resting outline, which it does not draw otherwise", () => {
+    const { getByTestId } = render(<TextField label="Server address" testID="server-input" border />)
+    const style = flat(getByTestId("server-input-box"))
+
+    expect(style.borderWidth).toBe(1)
+    expect(style.borderColor).toBe(lightColors.border)
   })
 
   it("reads the error out with the field name, because the ring alone is colour", () => {
@@ -52,7 +63,7 @@ describe("TextField", () => {
     const input = getByTestId("server-input")
     expect(input.props.editable).toBe(false)
     expect(flat(input).color).toBe(lightColors.textDisabled)
-    expect(flat(getByTestId("server-input-box")).borderColor).toBe(lightColors.border)
+    expect(flat(getByTestId("server-input-box")).borderWidth).toBe(0)
   })
 
   it("passes keyboard and autofill props through to the input", () => {

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -205,7 +205,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
     <Container>
       {tabBar}
       <View style={styles.filterBar}>
-        <View style={[styles.searchContainer, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <View style={[styles.searchContainer, { backgroundColor: colors.well }]}>
           <Search size={size.icon.sm} color={colors.textLight} />
           <TextInput
             style={[styles.searchInput, { color: colors.text }]}
@@ -332,7 +332,6 @@ const styles = StyleSheet.create({
   searchContainer: {
     flexDirection: "row",
     alignItems: "center",
-    borderWidth: 1,
     borderRadius: radius.sm,
     paddingHorizontal: 10,
     height: 40,


### PR DESCRIPTION
A field's resting border is gone, so an outline on an input means focus or error like it does everywhere else. border is an opt-in prop nothing uses. The two hand-built fields take the same well fill, which they did not before.