### PR TITLE
fix(logging): the log opens on warnings and errors

### DIFF
--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -22,7 +22,7 @@ import { Container, EmptyState, SectionTitle } from "../components"
 import { Tab } from "../components/ui/Tab"
 import { FileLoggingPanel } from "../components/features/log/FileLoggingPanel"
 import { useTheme } from "../hooks/useTheme"
-import { logger, LOG_LEVELS, type LogLevel } from "../utils/logger"
+import { logger, LOG_LEVELS, DEFAULT_LOG_LEVELS, type LogLevel } from "../utils/logger"
 import { getMergedLogs, exportLogs, MergedLogEntry } from "../utils/logExport"
 import NativeLocationService from "../services/NativeLocationService"
 import { ScreenProps } from "../types/global"
@@ -41,7 +41,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
   const [loading, setLoading] = useState(true)
   const [exporting, setExporting] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
-  const [activeLevels, setActiveLevels] = useState<Set<FilterLevel>>(new Set(LOG_LEVELS))
+  const [activeLevels, setActiveLevels] = useState<Set<FilterLevel>>(new Set(DEFAULT_LOG_LEVELS))
   const [showScrollEnd, setShowScrollEnd] = useState(false)
   const isNearEnd = useRef(true)
   const scrollRef = useRef<ScrollViewInstance>(null)

--- a/apps/mobile/src/utils/__tests__/logger.test.ts
+++ b/apps/mobile/src/utils/__tests__/logger.test.ts
@@ -148,3 +148,22 @@ describe("logger", () => {
     })
   })
 })
+
+describe("the level the log opens on", () => {
+  it("is problems only, not the debug traffic that drowns them", () => {
+    const { DEFAULT_LOG_LEVELS } = require("../logger")
+
+    expect([...DEFAULT_LOG_LEVELS]).toEqual(["WARN", "ERROR"])
+  })
+
+  it("does not change what is captured: the filter is a view, the export is not", () => {
+    // Dropping DEBUG at the source would empty the one diagnostic this project runs on.
+    const mod = require("../logger")
+    mod.logger.debug("zone lookup")
+    mod.logger.info("sync tick")
+
+    const levels = mod.getLogEntries().map((e: { level: string }) => e.level)
+    expect(levels).toContain("DEBUG")
+    expect(levels).toContain("INFO")
+  })
+})

--- a/apps/mobile/src/utils/logger.ts
+++ b/apps/mobile/src/utils/logger.ts
@@ -13,6 +13,8 @@ export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR"
 
 export const LOG_LEVELS: readonly LogLevel[] = ["DEBUG", "INFO", "WARN", "ERROR"]
 
+export const DEFAULT_LOG_LEVELS: readonly LogLevel[] = ["WARN", "ERROR"]
+
 export interface LogEntry {
   timestamp: string
   level: LogLevel


### PR DESCRIPTION
The screen showed every DEBUG line by default, which on a device is mostly zone lookups. It opens on WARN and ERROR now; the buffer still captures everything for export.