### PR TITLE
fix(ui): a dialog is a card, not an elevated one

### DIFF
--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -64,7 +64,7 @@ export function AppModal() {
   return (
     <Modal visible transparent animationType="fade" statusBarTranslucent>
       <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
-        <View style={[styles.card, { backgroundColor: colors.cardElevated, borderRadius: colors.borderRadius + 4 }]}>
+        <View style={[styles.card, { backgroundColor: colors.card, borderRadius: radius.lg }]}>
           <View style={[styles.iconContainer, { backgroundColor: iconColor + "15" }]}>
             <Icon size={28} color={iconColor} />
           </View>

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -61,7 +61,7 @@ export function DisclosureModal({ icon, title, paragraphs, confirmLabel, registe
   return (
     <Modal visible={visible} transparent animationType="fade" statusBarTranslucent>
       <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
-        <View style={[styles.card, { backgroundColor: colors.cardElevated, borderRadius: colors.borderRadius + 4 }]}>
+        <View style={[styles.card, { backgroundColor: colors.card, borderRadius: radius.lg }]}>
           {/* Icon */}
           <View style={[styles.iconContainer, { backgroundColor: colors.primary + "15" }]}>{icon}</View>
 


### PR DESCRIPTION
AppModal and DisclosureModal painted cardElevated while LoadingOverlay and the backup restore modal painted card, so two of the four dialogs were a step lighter in dark. The plan gives cardElevated to things floating over map tiles, where a tonal step earns its keep against imagery, and gives the modal body card. A dialog sits on a scrim, which already separates it.

Their radius was colors.borderRadius + 4, arithmetic on a legacy alias landing on no scale. It is radius.lg.
