### PR TITLE
fix(navigation): the navigator paints the app's background

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 import React, { useMemo, useState, useCallback } from "react"
-import { NavigationContainer, NavigationContainerRef } from "@react-navigation/native"
+import { NavigationContainer, NavigationContainerRef, DefaultTheme, DarkTheme } from "@react-navigation/native"
 import { LucideProvider } from "lucide-react-native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { SafeAreaProvider } from "react-native-safe-area-context"
@@ -207,6 +207,7 @@ function AppNavigator() {
         color: colors.text
       },
       headerTitleAlign: "left" as const,
+      contentStyle: { backgroundColor: colors.background },
       headerBackTitleVisible: false,
       ...(Platform.OS === "android" && {
         animation: "slide_from_right" as const
@@ -214,6 +215,20 @@ function AppNavigator() {
     }),
     [colors]
   )
+  const navigationTheme = useMemo(() => {
+    const base = isDark ? DarkTheme : DefaultTheme
+    return {
+      ...base,
+      colors: {
+        ...base.colors,
+        background: colors.background,
+        card: colors.background,
+        text: colors.text,
+        border: colors.border,
+        primary: colors.primary
+      }
+    }
+  }, [colors, isDark])
   const statusBarConfig = useMemo(
     () => ({
       barStyle: isDark ? ("light-content" as const) : ("dark-content" as const),
@@ -255,7 +270,7 @@ function AppNavigator() {
       {/* One provider so a 16 badge and a 24 tab glyph carry the same painted weight. */}
       <LucideProvider strokeWidth={1.5} absoluteStrokeWidth>
         <StatusBar {...statusBarConfig} />
-        <NavigationContainer linking={linking} ref={navigationRef} onStateChange={handleStateChange}>
+        <NavigationContainer theme={navigationTheme} linking={linking} ref={navigationRef} onStateChange={handleStateChange}>
           <View style={styles.flex}>
             <Stack.Navigator initialRouteName="Dashboard" screenOptions={screenOptions}>
               {SCREEN_CONFIG.map((screen) => (


### PR DESCRIPTION
Sliding between screens showed a grey block at the edge. That is React Navigation's own DefaultTheme background, rgb(242, 242, 242), which nothing had overridden: the stack had no theme and screenOptions had no contentStyle.

Both were needed. contentStyle alone leaves the container grey behind a screen that does not fill, and the theme alone does not cover a screen whose own root is transparent. The theme is built from DarkTheme or DefaultTheme with the app's own background, card, text, border and primary, so it follows the mode.

It only showed in dark, because the default is close enough to the light ground to pass.
