### PR TITLE
fix(legal): the copyright credits contributors, and stops restating the licence

### DIFF
--- a/apps/mobile/src/components/ui/Footer.tsx
+++ b/apps/mobile/src/components/ui/Footer.tsx
@@ -14,7 +14,7 @@ export function Footer() {
 
   return (
     <View style={styles.footer}>
-      <Text style={[styles.copyright, { color: colors.textLight }]}>© 2026 Max Dietrich</Text>
+      <Text style={[styles.copyright, { color: colors.textLight }]}>© 2026 Max Dietrich and contributors</Text>
     </View>
   )
 }

--- a/apps/mobile/src/screens/LegalScreen.tsx
+++ b/apps/mobile/src/screens/LegalScreen.tsx
@@ -12,7 +12,7 @@ import { Card, Container, Divider, ListItem, SectionTitle } from "../components"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
 import { fontSizes, fonts } from "../styles/typography"
-import { space, ISSUES_URL, OSM_COPYRIGHT_URL, PRIVACY_POLICY_URL, REPO_URL, TILE_SERVER_DOCS_URL } from "../constants"
+import { space, OSM_COPYRIGHT_URL, PRIVACY_POLICY_URL, REPO_URL, TILE_SERVER_DOCS_URL } from "../constants"
 
 export function LegalScreen({}: ScreenProps) {
   const { colors } = useTheme()
@@ -81,9 +81,8 @@ export function LegalScreen({}: ScreenProps) {
         </View>
 
         <Text style={[styles.copyright, { color: colors.textLight }]}>
-          Copyright &copy; 2026 Max Dietrich. Colota is free software: you may redistribute and modify it under the
-          terms of the GNU Affero General Public License. It comes with no warranty. Report a problem at{" "}
-          {ISSUES_URL.replace("https://", "")}.
+          Copyright &copy; 2026 Max Dietrich and contributors. Colota is free software, with no warranty; the License
+          row above has the terms.
         </Text>
       </ScrollView>
     </Container>


### PR DESCRIPTION
Both visible notices, the footer About renders and the paragraph on Legal, said Max Dietrich alone. They say Max Dietrich and contributors now.

Legal's paragraph also restated the AGPL in prose - redistribute, modify, no warranty - directly under a License row linking to the LICENSE file itself. Paraphrased terms drift from the file they paraphrase, so it points at the row instead and keeps only what a notice has to carry: the holder and the disclaimer. That orphaned a repeated issues URL, which Settings already links from Feedback and help.

The AGPL header on every source file is untouched; that is a separate sweep.
