### PR TITLE
chore(about): drop the two styles the debug removal left behind

### DIFF
--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -274,15 +274,6 @@ const styles = StyleSheet.create({
   section: {
     marginTop: space.xl
   },
-  debugHint: {
-    fontSize: fontSizes.small,
-    marginTop: space.sm,
-    fontStyle: "italic"
-  },
-  debugText: {
-    fontSize: fontSizes.caption,
-    ...fonts.semiBold
-  },
   debugActions: {
     gap: 10,
     marginTop: space.lg


### PR DESCRIPTION
`debugHint` and `debugText` stopped being referenced when the debug mode came out in #717. `debugActions` from the same group is still in use.

A scan of every StyleSheet block under apps/mobile/src found no other dead entry.