### PR TITLE
fix(ui): a chip's label matches the primitive, not its screen

### DIFF
--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -445,13 +445,14 @@ const styles = StyleSheet.create({
   },
   exportChip: {
     minHeight: size.chip,
+    justifyContent: "center",
     paddingHorizontal: space.md,
     paddingVertical: space.sm,
     borderRadius: radius.sm
   },
   exportChipText: {
-    fontSize: fontSizes.small,
-    ...fonts.bold
+    fontSize: fontSizes.caption,
+    ...fonts.medium
   },
   list: {
     paddingHorizontal: space.md,

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -240,7 +240,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
                   }
                 ]}
               >
-                <Text style={[styles.chipText, { color: active ? colors.textOnPrimary : colors.textLight }]}>
+                <Text style={[styles.chipText, active && styles.chipTextActive, { color: active ? colors.textOnPrimary : colors.textLight }]}>
                   {level}
                   {count > 0 ? ` ${count}` : ""}
                 </Text>
@@ -350,6 +350,7 @@ const styles = StyleSheet.create({
   },
   chip: {
     minHeight: size.chip,
+    justifyContent: "center",
     paddingHorizontal: space.md,
     paddingVertical: space.sm,
     borderRadius: radius.sm
@@ -360,8 +361,12 @@ const styles = StyleSheet.create({
     marginTop: space.xs
   },
   chipText: {
-    ...fonts.semiBold,
-    fontSize: fontSizes.small
+    ...fonts.medium,
+    fontSize: fontSizes.caption
+  },
+  // Selection is a weight step as well as the fill, matching ChipGroup, so it does not rest on colour alone.
+  chipTextActive: {
+    ...fonts.semiBold
   },
   logText: {
     ...fonts.regular,

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -395,7 +395,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [
                     styles.exportChip,
-                    { backgroundColor: colors.primary + "12", borderColor: colors.primary + "30" },
+                    { backgroundColor: colors.primary + "12" },
                     pressed && { opacity: colors.pressedOpacity }
                   ]}
                 >
@@ -529,13 +529,14 @@ const styles = StyleSheet.create({
   },
   exportChip: {
     minHeight: size.chip,
+    justifyContent: "center",
     paddingHorizontal: space.md,
     paddingVertical: space.sm,
     borderRadius: radius.sm
   },
   exportChipText: {
     fontSize: fontSizes.caption,
-    ...fonts.bold
+    ...fonts.medium
   },
   headerBtn: {
     padding: space.sm


### PR DESCRIPTION
PR 743 gave the four chips one box but left three labels behind: two sizes and three weights for the same control, which reads at normal font scale where the 1px height gap does not. The three hand-built ones take ChipGroup's caption and medium, and the log's filter gets the same weight step on selection so it does not rest on colour alone.

They also centre their label now. minHeight is a floor, so the slack it leaves was pooling under the text instead of splitting.

TripDetail passed a borderColor with no borderWidth to pair it with.