### PR TITLE
test: five tests that could not fail

### DIFF
--- a/apps/mobile/android/app/src/test/java/com/Colota/service/ConditionMonitorTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/service/ConditionMonitorTest.kt
@@ -284,8 +284,8 @@ class ConditionMonitorTest {
 
         monitor.stop()
 
-        // Should complete without crash — observer null check returns early
-        // (observer is non-null but connection is null → returns early after observer check)
+        // Nothing was posted to the main looper, because there is no LiveData to remove from.
+        verify(exactly = 0) { mockHandler.post(any()) }
     }
 
     // ========================================================================

--- a/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DashboardScreen.test.tsx
@@ -193,12 +193,6 @@ describe("DashboardScreen", () => {
     expect(queryByTestId("WelcomeCard")).toBeNull()
   })
 
-  it("renders DatabaseStatistics component", () => {
-    const { getByTestId } = render(<DashboardScreen navigation={mockNavigation} />)
-
-    expect(getByTestId("DatabaseStatistics")).toBeTruthy()
-  })
-
   it("renders ConnectionStatus component", () => {
     const { getByTestId } = render(<DashboardScreen navigation={mockNavigation} />)
 

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -429,19 +429,6 @@ describe("LocationHistoryScreen", () => {
     fireEvent.press(getByText("Data"))
     expect(getByTestId("CalendarPicker")).toBeTruthy()
   })
-
-  it("shows LocationTable in Data tab", () => {
-    const props = createProps()
-    const { getByText, getByTestId } = render(<LocationHistoryScreen {...props} />)
-
-    // Initially not visible
-    expect(() => getByTestId("LocationTable")).toThrow()
-
-    // Switch to Data tab
-    fireEvent.press(getByText("Data"))
-
-    expect(getByTestId("LocationTable")).toBeTruthy()
-  })
 })
 
 describe("LocationHistoryScreen - notes saved on the map", () => {

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -94,10 +94,6 @@ const mockEstimateSizeLabel = jest.fn()
 const mockEstimateSizeBytes = jest.fn()
 const mockWillExceedTileLimit = jest.fn()
 
-jest.mock("../../utils/format", () => ({
-  formatBytes: jest.fn().mockReturnValue("5.0 MB")
-}))
-
 jest.mock("../../components/features/map/OfflinePackManager", () => ({
   DOWNLOAD_STATE: { INACTIVE: "inactive", ACTIVE: "active", COMPLETE: "complete" },
   loadOfflineAreas: (...args: any[]) => mockLoadOfflineAreas(...args),
@@ -341,12 +337,12 @@ describe("OfflineMapsScreen", () => {
     await findByText("forest trail")
   })
 
-  it("shows size for a saved area", async () => {
+  it("shows the size the pack actually takes on disk", async () => {
     mockLoadOfflineAreas.mockResolvedValue([
-      { name: "my park", sizeBytes: 2_000_000, isComplete: true, isActive: false }
+      { name: "my park", sizeBytes: 2 * 1024 * 1024, isComplete: true, isActive: false }
     ])
     const { findByText } = renderScreen()
-    await findByText("5.0 MB")
+    await findByText("2.0 MB")
   })
 
   it("shows stale indicator when style URL has changed", async () => {

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -88,8 +88,8 @@ jest.mock("../../components", () => {
       R.createElement(
         View,
         { testID: "StatsCard" },
-        R.createElement(Text, null, `${queueCount}`),
-        R.createElement(Text, null, `${sentCount}`)
+        R.createElement(Text, null, `queued ${queueCount}`),
+        R.createElement(Text, null, `sent ${sentCount}`)
       ),
     ListItem: ({ testID, label, sub, onPress }: any) =>
       R.createElement(
@@ -122,10 +122,12 @@ describe("SettingsScreen", () => {
     expect(getByText("Colota")).toBeTruthy()
   })
 
-  it("renders StatsCard with stats", () => {
-    const { getByTestId } = render(<SettingsScreen {...mockProps} />)
+  it("hands the card the counts it read from the bridge", async () => {
+    const { findByText } = render(<SettingsScreen {...mockProps} />)
 
-    expect(getByTestId("StatsCard")).toBeTruthy()
+    // The stub labels each slot, so wiring sent into queueCount fails here.
+    expect(await findByText("queued 5")).toBeTruthy()
+    expect(await findByText("sent 42")).toBeTruthy()
   })
 
   // --- Summary rows ---


### PR DESCRIPTION
A scan of the 73 jest suites and 46 Kotlin suites for tests that cannot fail. Nothing is skipped anywhere and no test file is orphaned, so this is the whole of it.

The offline maps size test mocked `formatBytes` to a fixed `"5.0 MB"` and then asserted that string against a 2 MB fixture; the mock is gone and the assertion is now the real formatter's output. The settings stats test asserted a stubbed `StatsCard` exists and checked no stats; the stub labels its slots and the test reads them. Two tests repeated a sibling verbatim and are deleted. The Kotlin `skips when connection is null` case had a comment where its assertion should be.

Each rewrite was checked by breaking the code it covers first.