### PR TITLE
fix(ui): a button is a fill or text, never a stroke

### DIFF
--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -52,30 +52,22 @@ export function Button({
       case "primary":
         return {
           bg: disabled ? colors.textDisabled : colors.primary,
-          text: color ?? colors.textOnPrimary,
-          borderColor: "transparent",
-          borderWidth: 0
+          text: color ?? colors.textOnPrimary
         }
       case "secondary":
         return {
           bg: disabled ? colors.textDisabled : colors.primaryContainer,
-          text: color ?? colors.onPrimaryContainer,
-          borderColor: "transparent",
-          borderWidth: 0
+          text: color ?? colors.onPrimaryContainer
         }
       case "ghost":
         return {
           bg: "transparent",
-          text: color ?? colors.primaryDark,
-          borderColor: "transparent",
-          borderWidth: 0
+          text: disabled ? colors.textDisabled : (color ?? colors.primaryDark)
         }
       case "danger":
         return {
           bg: disabled ? colors.textDisabled : colors.error,
-          text: color ?? colors.textOnPrimary,
-          borderColor: "transparent",
-          borderWidth: 0
+          text: color ?? colors.textOnPrimary
         }
     }
   }
@@ -89,15 +81,7 @@ export function Button({
         accessibilityRole="button"
         accessibilityState={{ disabled: disabled || loading, expanded }}
         android_ripple={disabled || loading ? undefined : { color: v.text + STATE_LAYER_ALPHA }}
-        style={[
-          styles.button,
-          {
-            backgroundColor: v.bg,
-            borderColor: v.borderColor,
-            borderWidth: v.borderWidth,
-            borderRadius: colors.borderRadius
-          }
-        ]}
+        style={[styles.button, { backgroundColor: v.bg, borderRadius: colors.borderRadius }]}
         onPress={onPress}
         disabled={disabled || loading}
       >

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -79,7 +79,7 @@ export function DisclosureModal({ icon, title, paragraphs, confirmLabel, registe
           <View style={styles.buttons}>
             <Pressable
               android_ripple={{ color: colors.textSecondary + STATE_LAYER_ALPHA }}
-              style={[styles.button, styles.secondaryButton, { borderColor: colors.border }]}
+              style={styles.button}
               onPress={handleNotNow}
             >
               <Text style={[styles.buttonText, { color: colors.textSecondary }]}>Not now</Text>
@@ -87,7 +87,7 @@ export function DisclosureModal({ icon, title, paragraphs, confirmLabel, registe
 
             <Pressable
               android_ripple={{ color: colors.textOnPrimary + STATE_LAYER_ALPHA }}
-              style={[styles.button, styles.primaryButton, { backgroundColor: colors.primary }]}
+              style={[styles.button, { backgroundColor: colors.primary }]}
               onPress={handleConfirm}
             >
               <Text style={[styles.buttonText, { color: colors.textOnPrimary }]}>{confirmLabel}</Text>
@@ -146,8 +146,6 @@ const styles = StyleSheet.create({
     overflow: "hidden",
     alignItems: "center"
   },
-  primaryButton: {},
-  secondaryButton: {},
   buttonText: {
     fontSize: fontSizes.label,
     ...fonts.semiBold

--- a/apps/mobile/src/components/ui/__tests__/Button.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Button.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { render } from "@testing-library/react-native"
-import { StyleSheet } from "react-native"
+import { StyleSheet, Text } from "react-native"
 import { lightColors } from "@colota/shared"
 
 jest.mock("../../../hooks/useTheme", () => ({
@@ -21,7 +21,21 @@ describe("Button variants", () => {
 
     const style = flat(getByTestId("add-btn"))
     expect(style.backgroundColor).toBe(lightColors.primaryContainer)
-    expect(style.borderWidth).toBe(0)
+    expect(style.borderWidth).toBeUndefined()
+  })
+
+  it("greys a disabled ghost, which has no fill to grey instead", () => {
+    // Every other variant says disabled by swapping its fill for textDisabled. A ghost has no
+    // fill, so it read as pressable while refusing the press.
+    const { getByTestId, rerender } = render(
+      <Button title="Reset all" onPress={jest.fn()} variant="ghost" testID="reset-btn" />
+    )
+    const label = () => getByTestId("reset-btn").findByType(Text).props.style
+
+    expect(StyleSheet.flatten(label()).color).toBe(lightColors.primaryDark)
+
+    rerender(<Button title="Reset all" onPress={jest.fn()} variant="ghost" disabled testID="reset-btn" />)
+    expect(StyleSheet.flatten(label()).color).toBe(lightColors.textDisabled)
   })
 
   it("keeps the touch target at the Android minimum", () => {

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -220,7 +220,6 @@ export function DataManagementScreen({}: ScreenProps) {
     )
   }, [daysInput, handleDeleteAction, showFeedback])
 
-
   const handleVacuum = useCallback(async () => {
     setIsProcessing(true)
     try {
@@ -246,7 +245,9 @@ export function DataManagementScreen({}: ScreenProps) {
     <Container>
       <KeyboardAvoidingView style={styles.keyboardAvoid} behavior={Platform.OS === "ios" ? "padding" : undefined}>
         <ScrollView contentContainerStyle={styles.scrollContent}>
-        <Text style={[styles.intro, { color: colors.textSecondary }]}>What this device is storing, and how to clear it</Text>
+          <Text style={[styles.intro, { color: colors.textSecondary }]}>
+            What this device is storing, and how to clear it
+          </Text>
           {/* Stats */}
           <View style={styles.section}>
             <SectionTitle>Database statistics</SectionTitle>
@@ -352,12 +353,7 @@ export function DataManagementScreen({}: ScreenProps) {
                     placeholder="90"
                   />
                   <Text style={[styles.daysLabel, { color: colors.textSecondary }]}>days</Text>
-                  <Button
-                    style={[isProcessing && styles.buttonDisabled]}
-                    onPress={handleDeleteOlderThan}
-                    disabled={isProcessing}
-                    title="Delete"
-                  />
+                  <Button onPress={handleDeleteOlderThan} disabled={isProcessing} title="Delete" />
                 </View>
               </View>
               <Divider />
@@ -519,8 +515,5 @@ const styles = StyleSheet.create({
   daysLabel: {
     fontSize: fontSizes.input,
     ...fonts.medium
-  },
-  buttonDisabled: {
-    opacity: 0.5
   }
 })

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -153,22 +153,13 @@ const DownloadForm = memo(
                 <Pressable
                   testID="cancel-download-btn"
                   onPress={onCancelDownload}
-                  style={({ pressed }) => [
-                    styles.cancelBtn,
-                    { borderColor: colors.error + "40" },
-                    pressed && { opacity: colors.pressedOpacity }
-                  ]}
+                  style={({ pressed }) => [styles.cancelBtn, pressed && { opacity: colors.pressedOpacity }]}
                 >
                   <Text style={[styles.cancelBtnText, { color: colors.error }]}>Cancel download</Text>
                 </Pressable>
               </View>
             ) : (
-              <Button
-                testID="download-btn"
-                title="Download area"
-                disabled={!estimatedSizeLabel}
-                onPress={onDownload}
-              />
+              <Button testID="download-btn" title="Download area" disabled={!estimatedSizeLabel} onPress={onDownload} />
             )}
 
             {downloadError && <Text style={[styles.errorText, { color: colors.error }]}>{downloadError}</Text>}
@@ -720,11 +711,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
               <Pressable
                 onPress={() => handleCancelArea(item)}
                 disabled={isCanceling}
-                style={({ pressed }) => [
-                  styles.cancelAreaBtn,
-                  { backgroundColor: colors.error + "15", borderColor: colors.error + "40" },
-                  pressed && { opacity: colors.pressedOpacity }
-                ]}
+                style={({ pressed }) => [styles.cancelAreaBtn, pressed && { opacity: colors.pressedOpacity }]}
               >
                 {isCanceling ? (
                   <ActivityIndicator size="small" color={colors.error} />
@@ -859,7 +846,8 @@ export function OfflineMapsScreen({}: ScreenProps) {
         ListHeaderComponent={listHeader}
         ListEmptyComponent={
           areas.length === 0 && !downloading ? (
-            <EmptyState style={styles.emptyInset}
+            <EmptyState
+              style={styles.emptyInset}
               title="No saved areas yet"
               hint="Download map tiles to browse your tracks offline while hiking or camping"
             />
@@ -888,8 +876,7 @@ const styles = StyleSheet.create({
   progressSub: { fontSize: fontSizes.caption, ...fonts.regular },
   cancelBtn: {
     padding: space.md,
-    borderRadius: 10,
-    borderWidth: 1.5,
+    borderRadius: radius.sm,
     alignItems: "center",
     marginTop: space.xs
   },
@@ -920,8 +907,7 @@ const styles = StyleSheet.create({
   cancelAreaBtn: {
     paddingHorizontal: space.md,
     paddingVertical: 6,
-    borderRadius: radius.sm,
-    borderWidth: 1
+    borderRadius: radius.sm
   },
   cancelAreaLabel: { fontSize: fontSizes.description, ...fonts.semiBold },
   mapHint: {

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from "react"
+import { StyleSheet } from "react-native"
 import { render, fireEvent, waitFor, act } from "@testing-library/react-native"
 import { OfflineMapsScreen } from "../OfflineMapsScreen"
 import { logger } from "../../utils/logger"
@@ -327,6 +328,23 @@ describe("OfflineMapsScreen", () => {
       expect(mockDeleteOfflineArea).toHaveBeenCalledWith("my area")
       expect(mockRemoveOfflineAreaBounds).toHaveBeenCalledWith("my area")
     })
+  })
+
+  it("says a cancel is destructive in error text, with no shape around it", async () => {
+    // It and the per-area cancel were the only two buttons in the app drawing a border, at two
+    // different widths. The plan has two destructive shapes, a filled danger for a confirm step
+    // and a danger ghost for everything else; a cancel is the second.
+    mockShowConfirm.mockResolvedValue(true)
+    mockCreateOfflinePack.mockReturnValue(new Promise(() => {}))
+    const { findByText, getByTestId, getByPlaceholderText } = renderScreen()
+    await waitForMapReady(findByText)
+    fireEvent.changeText(getByPlaceholderText("Home area, Trail..."), "my area")
+    fireEvent.press(getByTestId("download-btn"))
+    await findByText("Cancel download")
+
+    const style = StyleSheet.flatten(getByTestId("cancel-download-btn").props.style)
+    expect(style.borderWidth).toBeUndefined()
+    expect(style.backgroundColor).toBeUndefined()
   })
 
   it("shows saved areas loaded on mount", async () => {


### PR DESCRIPTION
Button gave all four variants a transparent border at width 0 and threaded it to the Pressable, so the primitive carried a knob that existed only to be off. The two Offline maps cancels were the only buttons anywhere that turned one on, at 1.5 and 1, and one of them also painted a tonal error fill the palette has no token for. The plan has two destructive shapes, a filled danger for a confirm step and a danger ghost for everything else, so both cancels are error text now.

Three states were wrong while I was in there. A disabled ghost was indistinguishable from an enabled one, since every other variant says disabled by swapping a fill it does not have. DisclosureModal's Not now passed a borderColor with no borderWidth, so its intended outline has never painted, and both its variant styles were empty objects. Data management's Delete was the only Button stacking its own opacity on top of the primitive's disabled fill, the same shape PR 697 and PR 699 removed elsewhere.

Button.test's border assertion moves to toBeUndefined and the ghost gets its own test. Offline maps gains one for the cancel reading as destructive without a shape around it.