### PR TITLE
fix(ui): a disabled button recedes instead of repainting its fill

### DIFF
--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -48,27 +48,20 @@ export function Button({
 }: Props) {
   const { colors } = useTheme()
   const getVariantStyles = () => {
+    // Disabled recedes: the container drops to the recessed fill and the content to the disabled
+    // token. Painting the fill itself disabled left a filled button wearing its enabled label.
+    if (disabled) {
+      return { bg: variant === "ghost" ? "transparent" : colors.well, text: colors.textDisabled }
+    }
     switch (variant) {
       case "primary":
-        return {
-          bg: disabled ? colors.textDisabled : colors.primary,
-          text: color ?? colors.textOnPrimary
-        }
+        return { bg: colors.primary, text: color ?? colors.textOnPrimary }
       case "secondary":
-        return {
-          bg: disabled ? colors.textDisabled : colors.primaryContainer,
-          text: color ?? colors.onPrimaryContainer
-        }
+        return { bg: colors.primaryContainer, text: color ?? colors.onPrimaryContainer }
       case "ghost":
-        return {
-          bg: "transparent",
-          text: disabled ? colors.textDisabled : (color ?? colors.primaryDark)
-        }
+        return { bg: "transparent", text: color ?? colors.primaryDark }
       case "danger":
-        return {
-          bg: disabled ? colors.textDisabled : colors.error,
-          text: color ?? colors.textOnPrimary
-        }
+        return { bg: colors.error, text: color ?? colors.textOnPrimary }
     }
   }
 

--- a/apps/mobile/src/components/ui/__tests__/Button.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Button.test.tsx
@@ -24,9 +24,21 @@ describe("Button variants", () => {
     expect(style.borderWidth).toBeUndefined()
   })
 
-  it("greys a disabled ghost, which has no fill to grey instead", () => {
-    // Every other variant says disabled by swapping its fill for textDisabled. A ghost has no
-    // fill, so it read as pressable while refusing the press.
+  it("recedes when disabled instead of wearing an enabled label", () => {
+    // The fill itself went to textDisabled while the label stayed textOnPrimary, so Offline maps'
+    // disabled download button was white on grey and still read as a filled button you could press.
+    const { getByTestId } = render(
+      <Button title="Download area" onPress={jest.fn()} disabled testID="download-btn" />
+    )
+
+    expect(flat(getByTestId("download-btn")).backgroundColor).toBe(lightColors.well)
+    expect(StyleSheet.flatten(getByTestId("download-btn").findByType(Text).props.style).color).toBe(
+      lightColors.textDisabled
+    )
+  })
+
+  it("greys a disabled ghost without giving it a fill to recede into", () => {
+    // A ghost is transparent by role, so the recessed fill would draw it a box it never had.
     const { getByTestId, rerender } = render(
       <Button title="Reset all" onPress={jest.fn()} variant="ghost" testID="reset-btn" />
     )
@@ -36,6 +48,7 @@ describe("Button variants", () => {
 
     rerender(<Button title="Reset all" onPress={jest.fn()} variant="ghost" disabled testID="reset-btn" />)
     expect(StyleSheet.flatten(label()).color).toBe(lightColors.textDisabled)
+    expect(flat(getByTestId("reset-btn")).backgroundColor).toBe("transparent")
   })
 
   it("keeps the touch target at the Android minimum", () => {


### PR DESCRIPTION
Disabled swapped the container for textDisabled and left the label on textOnPrimary, so a disabled button was a grey slab with a white label: 2.64:1 in light, 3.29:1 in dark, and still shaped like something you could press. Offline maps' download button is the one section 12 lists as unreadable.

The container drops to well and the content to textDisabled instead, which is the direction ListItem and SettingRow already take and what the plan's disabled state specifies. A ghost keeps its transparent ground, since the recessed fill would draw it a box it does not have when enabled.

The ratio itself is marginally lower and stays deferred to the palette work; what changes is that a disabled control no longer reads as an enabled one.