### PR TITLE
fix(api): the two text actions are controls, not captions

### DIFF
--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -22,7 +22,16 @@ import { useTimeout } from "../hooks/useTimeout"
 import { useTracking } from "../contexts/TrackingProvider"
 import NativeLocationService from "../services/NativeLocationService"
 import { fontSizes, fonts } from "../styles/typography"
-import { SectionTitle, FloatingSaveIndicator, Container, Divider, ChipGroup, Button, TextField, IconButton } from "../components"
+import {
+  SectionTitle,
+  FloatingSaveIndicator,
+  Container,
+  Divider,
+  ChipGroup,
+  Button,
+  TextField,
+  IconButton
+} from "../components"
 import { findDuplicates } from "../utils/settingsValidation"
 import {
   buildTraccarJsonPayload,
@@ -30,7 +39,7 @@ import {
   isTraccarJsonFormat,
   isOverlandFormat
 } from "../utils/apiPayload"
-import { space } from "../constants"
+import { HIT_SLOP_LG, space } from "../constants"
 import { radius } from "@colota/shared"
 
 type LocalCustomField = CustomField & { id: number }
@@ -542,6 +551,8 @@ export function ApiSettingsScreen({}: ScreenProps) {
             {hasModifications && (
               <Pressable
                 onPress={handleResetAll}
+                hitSlop={HIT_SLOP_LG}
+                accessibilityRole="button"
                 style={({ pressed }) => [styles.resetAllButton, pressed && { opacity: colors.pressedOpacity }]}
               >
                 <Text style={[styles.resetAllText, { color: colors.primaryDark }]}>Reset all</Text>
@@ -691,10 +702,12 @@ export function ApiSettingsScreen({}: ScreenProps) {
             <Text style={[styles.exampleCode, { color: colors.textSecondary }]}>{examplePayload}</Text>
             <Pressable
               onPress={handleCopyPayload}
+              hitSlop={HIT_SLOP_LG}
+              accessibilityRole="button"
               style={({ pressed }) => [styles.copyButton, pressed && { opacity: colors.pressedOpacity }]}
             >
               <Text style={[styles.copyButtonText, { color: copied ? colors.success : colors.primaryDark }]}>
-                {copied ? "COPIED!" : "COPY"}
+                {copied ? "Copied!" : "Copy"}
               </Text>
             </Pressable>
           </View>
@@ -747,9 +760,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: space.sm
   },
   resetAllText: {
-    fontSize: fontSizes.small,
-    ...fonts.bold,
-    letterSpacing: 0.5
+    fontSize: fontSizes.label,
+    ...fonts.semiBold
   },
   fieldsCard: {
     padding: space.md,
@@ -831,13 +843,12 @@ const styles = StyleSheet.create({
   copyButton: {
     alignSelf: "flex-end",
     paddingVertical: space.xs,
-    paddingHorizontal: 2,
+    paddingHorizontal: space.sm,
     marginTop: space.sm
   },
   copyButtonText: {
-    fontSize: fontSizes.small,
-    ...fonts.bold,
-    letterSpacing: 0.5
+    fontSize: fontSizes.label,
+    ...fonts.semiBold
   },
   exampleCard: {
     padding: 14,

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -253,13 +253,15 @@ describe("ApiSettingsScreen", () => {
       expect(getByText("Modified")).toBeTruthy()
     })
 
-    it("shows RESET ALL button when any field is modified", () => {
-      const { getByText, getByDisplayValue } = renderScreen()
+    it("offers Reset all as a button once a field is modified", () => {
+      // The heading's action was a bare Pressable, so a screen reader announced the words with
+      // no role and nothing said it was pressable.
+      const { getByRole, getByDisplayValue } = renderScreen()
 
       const latInput = getByDisplayValue("lat")
       fireEvent.changeText(latInput, "latitude")
 
-      expect(getByText("Reset all")).toBeTruthy()
+      expect(getByRole("button", { name: "Reset all" })).toBeTruthy()
     })
   })
 
@@ -282,10 +284,12 @@ describe("ApiSettingsScreen", () => {
   })
 
   describe("copy payload", () => {
-    it("renders the COPY button", () => {
-      const { getByText } = renderScreen()
+    it("offers the payload copy as a button, in sentence case", () => {
+      // A bare Pressable with no role: TalkBack announced the word and nothing else. COPY was
+      // also the last caps label left after the sentence-case sweep.
+      const { getByRole } = renderScreen()
 
-      expect(getByText("COPY")).toBeTruthy()
+      expect(getByRole("button", { name: "Copy" })).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
Reset all and Copy were bare Pressables at 24 and 22 high with no hitSlop and no role, so they sat at half the touch minimum and TalkBack announced the words with nothing saying they were pressable. COPY and COPIED! were also the last caps labels after the sentence-case sweep, out of step with the screen they sit on.

Both take the ghost button's label metrics and a slop that clears 48, and copyButton's 2px side padding goes to the scale. They stay hand-built: a ghost Button is 48 tall with 24px side padding and its own margins, which does not go inside a heading row, and the plan models a heading action as text. Same call PR 743 made for the three hand-built chips.

Both tests now assert the role rather than the words.