### PR TITLE
fix(a11y): the dialog buttons and the tabs say what they are

### DIFF
--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -78,12 +78,9 @@ export function AppModal() {
               return (
                 <Pressable
                   key={i}
+                  accessibilityRole="button"
                   android_ripple={{ color: btnStyles.text.color + STATE_LAYER_ALPHA }}
-                  style={[
-                    styles.button,
-                    current.buttons.length > 2 && styles.buttonFullWidth,
-                    btnStyles.container
-                  ]}
+                  style={[styles.button, current.buttons.length > 2 && styles.buttonFullWidth, btnStyles.container]}
                   onPress={() => handlePress(i)}
                 >
                   <Text style={[styles.buttonText, btnStyles.text]}>{btn.text}</Text>

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -78,6 +78,7 @@ export function DisclosureModal({ icon, title, paragraphs, confirmLabel, registe
           {/* Buttons */}
           <View style={styles.buttons}>
             <Pressable
+              accessibilityRole="button"
               android_ripple={{ color: colors.textSecondary + STATE_LAYER_ALPHA }}
               style={styles.button}
               onPress={handleNotNow}
@@ -86,6 +87,7 @@ export function DisclosureModal({ icon, title, paragraphs, confirmLabel, registe
             </Pressable>
 
             <Pressable
+              accessibilityRole="button"
               android_ripple={{ color: colors.textOnPrimary + STATE_LAYER_ALPHA }}
               style={[styles.button, { backgroundColor: colors.primary }]}
               onPress={handleConfirm}

--- a/apps/mobile/src/components/ui/Tab.tsx
+++ b/apps/mobile/src/components/ui/Tab.tsx
@@ -23,6 +23,8 @@ export function Tab({ label, active, onPress, colors }: TabProps) {
   return (
     <Pressable
       onPress={onPress}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
       android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
       style={[styles.tab, { borderBottomColor }]}
     >

--- a/apps/mobile/src/components/ui/__tests__/AppModal.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/AppModal.test.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { render, act } from "@testing-library/react-native"
+import { StyleSheet } from "react-native"
+import { lightColors } from "@colota/shared"
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })
+}))
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { AppModal } from "../AppModal"
+import { showConfirm } from "../../../services/modalService"
+
+describe("AppModal", () => {
+  it("announces every choice as a button", async () => {
+    // The buttons were bare Pressables, so TalkBack read the words and said nothing about them
+    // being pressable. AppModal is every alert and confirm in the app, destructive ones included.
+    const { getByRole } = render(<AppModal />)
+
+    await act(async () => {
+      showConfirm({ title: "Delete all data", message: "This cannot be undone.", confirmText: "Delete" })
+    })
+
+    expect(getByRole("button", { name: "Delete" })).toBeTruthy()
+    expect(getByRole("button", { name: "Cancel" })).toBeTruthy()
+  })
+
+  it("paints a destructive confirm in the error colour", async () => {
+    // showConfirm puts the confirming button first and marks it destructive, so the colour is
+    // what separates it from the dismissal beside it.
+    const { getByRole } = render(<AppModal />)
+
+    await act(async () => {
+      showConfirm({ title: "Delete zone", message: "This cannot be undone.", confirmText: "Delete", destructive: true })
+    })
+
+    const style = StyleSheet.flatten(getByRole("button", { name: "Delete" }).props.style)
+    expect(style.backgroundColor).toBe(lightColors.error)
+  })
+})

--- a/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
@@ -60,6 +60,19 @@ describe("DisclosureModal", () => {
     expect(await resultPromise!).toBe(false)
   })
 
+  it("announces both choices as buttons", async () => {
+    // Both were bare Pressables, so TalkBack read "Not now" and the confirm label as text and
+    // said nothing about them being pressable. This is the disclosure a location grant depends on.
+    const { getByRole } = render(<DisclosureModal {...defaultProps} />)
+
+    await act(async () => {
+      triggerModal()
+    })
+
+    expect(getByRole("button", { name: "Not now" })).toBeTruthy()
+    expect(getByRole("button", { name: "Confirm" })).toBeTruthy()
+  })
+
   it("resolves true when confirm is pressed", async () => {
     const { getByText } = render(<DisclosureModal {...defaultProps} />)
 

--- a/apps/mobile/src/components/ui/__tests__/Tab.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Tab.test.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { lightColors } from "@colota/shared"
+
+import { Tab } from "../Tab"
+
+const props = { label: "Trips", onPress: jest.fn(), colors: lightColors as never }
+
+describe("Tab", () => {
+  it("says it is a tab and which one is selected", () => {
+    // It was a bare Pressable: the History tabs and the log's Live and File announced as three
+    // words with no role, and nothing said which of them was showing.
+    const { getByRole, rerender } = render(<Tab {...props} active />)
+
+    expect(getByRole("tab", { name: "Trips" }).props.accessibilityState.selected).toBe(true)
+
+    rerender(<Tab {...props} active={false} />)
+    expect(getByRole("tab", { name: "Trips" }).props.accessibilityState.selected).toBe(false)
+  })
+})


### PR DESCRIPTION
AppModal's buttons, DisclosureModal's pair and Tab were bare Pressables with a Text inside, so TalkBack read the words and said nothing about them being activatable. That covers every alert and confirm in the app, the disclosure a location grant depends on, and the History and Logging tab rows, where nothing said which tab was showing either. Android's accessibility guidance and the Play pre-launch report's checks both want a role on an actionable element.

Tab also gains accessibilityState.selected. Sizes are already fine: the modal buttons clear 48 on padding alone.

AppModal and Tab had no test file at all, so they get one; AppModal's also pins the destructive confirm painting in error, which nothing covered. Prettier reflowed AppModal's button style array, which had drifted because CI runs eslint but not the prettier check.