### PR TITLE
fix(a11y): four small controls reach the touch minimum

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -9,6 +9,7 @@ import { Lightbulb, ChevronDown, ChevronUp } from "lucide-react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
 import { fonts, fontSizes } from "../../../styles/typography"
 import {
+  HIT_SLOP_MD,
   OVERLAND_BATCH_MAX,
   OVERLAND_BATCH_MIN,
   SYNC_INTERVAL_LABELS,
@@ -16,7 +17,17 @@ import {
   size,
   space
 } from "../../../constants"
-import { Card, ChipGroup, Divider, ListItem, NumericInput, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
+import {
+  Card,
+  ChipGroup,
+  Divider,
+  ListItem,
+  NumericInput,
+  SectionTitle,
+  SettingRow,
+  TextField,
+  Toggle
+} from "../../index"
 import { PresetOption } from "./PresetOption"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
 import { isOverlandFormat } from "../../../utils/apiPayload"
@@ -361,6 +372,8 @@ export function SyncStrategySettings({
                         />
                         {currentSsid !== "" && currentSsid.toLowerCase() !== settings.syncSsid.toLowerCase() && (
                           <Pressable
+                            hitSlop={HIT_SLOP_MD}
+                            accessibilityRole="button"
                             style={({ pressed }) => [
                               styles.ssidFillButton,
                               { backgroundColor: colors.primary + "15" },
@@ -500,8 +513,10 @@ const styles = StyleSheet.create({
   },
   ssidFillButton: {
     alignSelf: "flex-start",
-    paddingHorizontal: 10,
-    paddingVertical: 6,
+    justifyContent: "center",
+    minHeight: size.chip,
+    paddingHorizontal: space.md,
+    paddingVertical: space.sm,
     borderRadius: radius.sm
   },
   ssidFillText: {

--- a/apps/mobile/src/components/ui/__tests__/AppModal.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/AppModal.test.tsx
@@ -29,8 +29,8 @@ describe("AppModal", () => {
   })
 
   it("paints a destructive confirm in the error colour", async () => {
-    // showConfirm puts the confirming button first and marks it destructive, so the colour is
-    // what separates it from the dismissal beside it.
+    // showConfirm renders the confirming button last, on the right, and marks it destructive, so
+    // the colour is what separates it from the dismissal beside it.
     const { getByRole } = render(<AppModal />)
 
     await act(async () => {

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -17,6 +17,7 @@ import { Button, Card, Container, EmptyState, IconButton, SectionTitle, TextFiel
 import { useFocusEffect } from "@react-navigation/native"
 import {
   DEFAULT_MAP_ZOOM,
+  HIT_SLOP_MD,
   MAP_ANIMATION_DURATION_MS,
   MAP_STYLE_URL_LIGHT,
   WORLD_MAP_ZOOM,
@@ -153,6 +154,8 @@ const DownloadForm = memo(
                 <Pressable
                   testID="cancel-download-btn"
                   onPress={onCancelDownload}
+                  hitSlop={HIT_SLOP_MD}
+                  accessibilityRole="button"
                   style={({ pressed }) => [styles.cancelBtn, pressed && { opacity: colors.pressedOpacity }]}
                 >
                   <Text style={[styles.cancelBtnText, { color: colors.error }]}>Cancel download</Text>
@@ -711,6 +714,8 @@ export function OfflineMapsScreen({}: ScreenProps) {
               <Pressable
                 onPress={() => handleCancelArea(item)}
                 disabled={isCanceling}
+                hitSlop={HIT_SLOP_MD}
+                accessibilityRole="button"
                 style={({ pressed }) => [styles.cancelAreaBtn, pressed && { opacity: colors.pressedOpacity }]}
               >
                 {isCanceling ? (
@@ -905,8 +910,10 @@ const styles = StyleSheet.create({
     justifyContent: "center"
   },
   cancelAreaBtn: {
+    justifyContent: "center",
+    minHeight: size.chip,
     paddingHorizontal: space.md,
-    paddingVertical: 6,
+    paddingVertical: space.sm,
     borderRadius: radius.sm
   },
   cancelAreaLabel: { fontSize: fontSizes.description, ...fonts.semiBold },

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -216,7 +216,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
       <Pressable
         onPress={handleDelete}
         disabled={deleting}
-        hitSlop={8}
+        hitSlop={HIT_SLOP_MD}
         style={({ pressed }) => [styles.headerBtn, (pressed || deleting) && { opacity: colors.pressedOpacity }]}
       >
         <Trash2 size={size.icon.md} color={colors.error} />

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -8,6 +8,7 @@ import { StyleSheet } from "react-native"
 import { render, fireEvent, waitFor, act } from "@testing-library/react-native"
 import { OfflineMapsScreen } from "../OfflineMapsScreen"
 import { logger } from "../../utils/logger"
+import { HIT_SLOP_MD } from "../../constants"
 
 // --- MapLibre ---
 jest.mock("@maplibre/maplibre-react-native", () => ({
@@ -345,6 +346,19 @@ describe("OfflineMapsScreen", () => {
     const style = StyleSheet.flatten(getByTestId("cancel-download-btn").props.style)
     expect(style.borderWidth).toBeUndefined()
     expect(style.backgroundColor).toBeUndefined()
+  })
+
+  it("gives the cancel a touch target, since 44 is under the Android minimum", async () => {
+    // 12 of padding around a body label lands at about 44, and it had no slop at all.
+    mockShowConfirm.mockResolvedValue(true)
+    mockCreateOfflinePack.mockReturnValue(new Promise(() => {}))
+    const { findByText, getByTestId, getByPlaceholderText } = renderScreen()
+    await waitForMapReady(findByText)
+    fireEvent.changeText(getByPlaceholderText("Home area, Trail..."), "my area")
+    fireEvent.press(getByTestId("download-btn"))
+    await findByText("Cancel download")
+
+    expect(getByTestId("cancel-download-btn").props.hitSlop).toEqual(HIT_SLOP_MD)
   })
 
   it("shows saved areas loaded on mount", async () => {


### PR DESCRIPTION
The SSID fill button was 28 high and the per-area cancel 30, both with no hitSlop, against Android's 48dp minimum. The download cancel was about 44, also with none, and Trip detail's delete passed a bare hitSlop of 8 where every other site names the constant. All three Pressables also gain the button role.

The two small ones take the chip recipe from PR 743, a 32 floor plus HIT_SLOP_MD, rather than bare slop: both are chip-shaped, and the horizontal slop then meets the neighbour's 8 gap instead of overlapping it. Their literal 10 and 6 paddings go to the scale. Growing 2 to 4 pixels is the only thing that moves.

The calendar's day cell is the fifth and is left alone on purpose. It is 40 in a seven-column grid with no gaps, so slop would overlap the days either side, and the padding that would reach 48 makes the calendar 48 taller over six rows.

Also corrects a comment from PR 751 that said showConfirm renders the confirming button first. It renders last, on the right.