### PR TITLE
fix(offline-maps): a cancel gets a tint to sit in

### DIFF
--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -156,7 +156,11 @@ const DownloadForm = memo(
                   onPress={onCancelDownload}
                   hitSlop={HIT_SLOP_MD}
                   accessibilityRole="button"
-                  style={({ pressed }) => [styles.cancelBtn, pressed && { opacity: colors.pressedOpacity }]}
+                  style={({ pressed }) => [
+                    styles.cancelBtn,
+                    { backgroundColor: colors.error + "15" },
+                    pressed && { opacity: colors.pressedOpacity }
+                  ]}
                 >
                   <Text style={[styles.cancelBtnText, { color: colors.error }]}>Cancel download</Text>
                 </Pressable>
@@ -716,7 +720,11 @@ export function OfflineMapsScreen({}: ScreenProps) {
                 disabled={isCanceling}
                 hitSlop={HIT_SLOP_MD}
                 accessibilityRole="button"
-                style={({ pressed }) => [styles.cancelAreaBtn, pressed && { opacity: colors.pressedOpacity }]}
+                style={({ pressed }) => [
+                  styles.cancelAreaBtn,
+                  { backgroundColor: colors.error + "15" },
+                  pressed && { opacity: colors.pressedOpacity }
+                ]}
               >
                 {isCanceling ? (
                   <ActivityIndicator size="small" color={colors.error} />

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -331,10 +331,11 @@ describe("OfflineMapsScreen", () => {
     })
   })
 
-  it("says a cancel is destructive in error text, with no shape around it", async () => {
+  it("gives a cancel a tint to sit in, and no stroke", async () => {
     // It and the per-area cancel were the only two buttons in the app drawing a border, at two
-    // different widths. The plan has two destructive shapes, a filled danger for a confirm step
-    // and a danger ghost for everything else; a cancel is the second.
+    // different widths. Taking the stroke off left the words alone on the ground, so the tint
+    // carries the shape instead: a destructive action that is not a confirm step still has to
+    // read as a control.
     mockShowConfirm.mockResolvedValue(true)
     mockCreateOfflinePack.mockReturnValue(new Promise(() => {}))
     const { findByText, getByTestId, getByPlaceholderText } = renderScreen()
@@ -345,7 +346,7 @@ describe("OfflineMapsScreen", () => {
 
     const style = StyleSheet.flatten(getByTestId("cancel-download-btn").props.style)
     expect(style.borderWidth).toBeUndefined()
-    expect(style.backgroundColor).toBeUndefined()
+    expect(style.backgroundColor).toBe("#ef444415")
   })
 
   it("gives the cancel a touch target, since 44 is under the Android minimum", async () => {


### PR DESCRIPTION
PR 748 took the stroke off both Offline maps cancels, which was right, and took the per-area one's error tint off with it, which was not: it left the words alone on the ground with nothing saying they were a control. The argument for removing it was that the palette names no tonal error token, which is true and is a reason to add one in the colour pass, not to drop the affordance now.

Both carry a colours.error 15 percent fill behind the red label, and neither draws a border. A destructive action that is not a confirm step still has to look like something you can press.