### PR TITLE
chore(history): remove the trip selection that never had a trigger

### DIFF
--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -20,7 +20,6 @@ interface TripListProps {
   trips: Trip[]
   colors: ThemeColors
   onTripSelect: (trip: Trip) => void
-  selectedTripIndex?: number | null
   onExport?: (format: ExportFormat, trips: Trip[]) => void
   onDelete?: (trips: Trip[]) => Promise<void>
   onMerge?: (trips: Trip[]) => Promise<void>
@@ -32,7 +31,6 @@ interface TripRowProps {
   stats: TripStats | undefined
   selectionMode: boolean
   isCabSelected: boolean
-  isMapSelected: boolean
   onPress: (trip: Trip) => void
   onLongPress: (trip: Trip) => void
 }
@@ -43,13 +41,12 @@ const TripRow = React.memo(function TripRowItem({
   stats,
   selectionMode,
   isCabSelected,
-  isMapSelected,
   onPress,
   onLongPress
 }: TripRowProps) {
   const duration = trip.endTime - trip.startTime
   const tripColor = getTripColor(trip.index)
-  const selectedBorderColor = isCabSelected ? colors.primary : isMapSelected ? tripColor : null
+  const selectedBorderColor = isCabSelected ? colors.primary : null
 
   const cardStyle = [
     styles.tripCard,
@@ -115,15 +112,7 @@ const TripRow = React.memo(function TripRowItem({
   )
 })
 
-export function TripList({
-  trips,
-  colors,
-  onTripSelect,
-  selectedTripIndex,
-  onExport,
-  onDelete,
-  onMerge
-}: TripListProps) {
+export function TripList({ trips, colors, onTripSelect, onExport, onDelete, onMerge }: TripListProps) {
   const [showExport, setShowExport] = useState(false)
   const [selected, setSelected] = useState<Set<number>>(new Set())
   const selectionMode = selected.size > 0
@@ -236,18 +225,15 @@ export function TripList({
         stats={statsCache.get(item.index)}
         selectionMode={selectionMode}
         isCabSelected={selected.has(item.index)}
-        isMapSelected={!selectionMode && selectedTripIndex === item.index}
         onPress={handleRowPress}
         onLongPress={handleRowLongPress}
       />
     ),
-    [colors, statsCache, selectionMode, selected, selectedTripIndex, handleRowPress, handleRowLongPress]
+    [colors, statsCache, selectionMode, selected, handleRowPress, handleRowLongPress]
   )
 
   if (trips.length === 0) {
-    return (
-      <EmptyState icon={Route} title="No trips for this day" hint="Need at least 2 points to form a trip" />
-    )
+    return <EmptyState icon={Route} title="No trips for this day" hint="Need at least 2 points to form a trip" />
   }
 
   return (
@@ -503,5 +489,5 @@ const styles = StyleSheet.create({
   statText: {
     fontSize: fontSizes.description,
     ...fonts.regular
-  },
+  }
 })

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -4,9 +4,8 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react"
-import { View, Text, StyleSheet, Pressable } from "react-native"
+import { View, StyleSheet, Pressable } from "react-native"
 import { useFocusEffect } from "@react-navigation/native"
-import { fontSizes, fonts } from "../styles/typography"
 import { ChartNoAxesColumn } from "lucide-react-native"
 import { Container } from "../components"
 import { Tab } from "../components/ui/Tab"
@@ -58,7 +57,6 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
   )
 
   const [boundaryOverrides, setBoundaryOverrides] = useState<Map<string, BoundaryAction>>(() => new Map())
-  const [selectedTrip, setSelectedTrip] = useState<Trip | null>(null)
   const [fitVersion, setFitVersion] = useState(0)
 
   // Calendar state
@@ -160,7 +158,6 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         setTrackLocations(result || [])
         setBoundaryOverrides(buildBoundaryOverrideMap(overrides))
         setNoteOverrides({})
-        setSelectedTrip(null)
         setFitVersion((v) => v + 1)
       }
     } catch (err) {
@@ -169,7 +166,6 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         setTrackLocations([])
         setBoundaryOverrides(new Map())
         setNoteOverrides({})
-        setSelectedTrip(null)
         setFitVersion((v) => v + 1)
       }
     }
@@ -231,11 +227,6 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
     },
     [mapDate]
   )
-
-  const handleShowFullDay = useCallback(() => {
-    setSelectedTrip(null)
-    setFitVersion((v) => v + 1)
-  }, [])
 
   const refreshAfterEdit = useCallback(async () => {
     const key = `${mapDate.getFullYear()}-${pad2(mapDate.getMonth() + 1)}`
@@ -392,8 +383,6 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
     [mapDate, fetchDaysWithData]
   )
 
-  const mapLocations = selectedTrip ? (selectedTrip.locations as LocationCoords[]) : trackLocations
-
   // The map gets the overrides as a prop rather than merged in here, because a new locations
   // identity closes its open popup.
   const tableLocations = useMemo(() => withNotes(trackLocations), [trackLocations, withNotes])
@@ -438,30 +427,16 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         <View style={styles.mapContainer}>
           {calendarPicker}
           <TrackMap
-            locations={mapLocations}
+            locations={trackLocations}
             colors={colors}
             noteOverrides={noteOverrides}
-            trips={selectedTrip ? undefined : trips}
+            trips={trips}
             trackColor={colors.primary}
             fitVersion={fitVersion}
             onPointNoteChange={handlePointNoteChange}
             onPointDelete={handlePointDelete}
             onPointSplit={handlePointSplit}
           />
-          {selectedTrip && (
-            <Pressable
-              onPress={handleShowFullDay}
-              style={({ pressed }) => [
-                styles.floatingPill,
-                { backgroundColor: colors.primary, borderRadius: colors.borderRadius },
-                pressed && { opacity: colors.pressedOpacity }
-              ]}
-            >
-              <Text style={[styles.floatingPillText, { color: colors.textOnPrimary }]}>
-                Trip {selectedTrip.index} · Show full day
-              </Text>
-            </Pressable>
-          )}
         </View>
       )}
 
@@ -472,7 +447,6 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
             trips={trips}
             colors={colors}
             onTripSelect={handleTripSelect}
-            selectedTripIndex={selectedTrip?.index ?? null}
             onExport={exportTrips}
             onDelete={handleDeleteTrips}
             onMerge={handleMergeTrips}
@@ -496,18 +470,6 @@ const styles = StyleSheet.create({
   },
   mapContainer: {
     flex: 1
-  },
-  floatingPill: {
-    position: "absolute",
-    bottom: 16,
-    alignSelf: "center",
-    paddingHorizontal: space.xl,
-    paddingVertical: space.md,
-    elevation: 4
-  },
-  floatingPillText: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold
   },
   tabBar: {
     flexDirection: "row",


### PR DESCRIPTION
selectedTrip was initialised null and its only three setters all passed null, so the state could never hold a trip. Everything behind it was unreachable: the Show full day pill over the map, handleShowFullDay, the mapLocations branch that would have isolated one trip's points, the trips prop that would have hidden the other routes, and TripList's selectedTripIndex with the isMapSelected border it drove.

git log -S says it was born this way in 741477a1 back in February. The feature it describes is tapping a route on the map to isolate that trip, and TrackMap has no press callback to hang that on, so it was never half-built, only sketched.

Nothing renders differently. If the feature is wanted it is a new one, starting with the tap TrackMap does not have.