### PR TITLE
fix(ui): a card keeps its content when its state changes

### DIFF
--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -46,12 +46,9 @@ const TripRow = React.memo(function TripRowItem({
 }: TripRowProps) {
   const duration = trip.endTime - trip.startTime
   const tripColor = getTripColor(trip.index)
-  const selectedBorderColor = isCabSelected ? colors.primary : null
-
-  const cardStyle = [
-    styles.tripCard,
-    selectedBorderColor && [styles.tripCardSelected, { borderColor: selectedBorderColor }]
-  ]
+  // Selection is a fill, not a stroke: toggling borderWidth on a card that clips its own
+  // corners leaves the children clipped away on Android until the list remounts.
+  const cardStyle = [styles.tripCard, isCabSelected && { backgroundColor: colors.primaryContainer }]
 
   const accessibilityRole = selectionMode ? "checkbox" : "button"
   const accessibilityState = selectionMode ? { checked: isCabSelected } : undefined
@@ -448,9 +445,6 @@ const styles = StyleSheet.create({
   listEmpty: { flexGrow: 1 },
   tripCard: {
     marginBottom: space.sm
-  },
-  tripCardSelected: {
-    borderWidth: 1.5
   },
   tripHeader: {
     flexDirection: "row",

--- a/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import { render, fireEvent, act } from "@testing-library/react-native"
+import { StyleSheet, View } from "react-native"
+import { lightColors } from "@colota/shared"
 import type { Trip } from "../../../../types/global"
 import type { ExportFormat } from "../../../../utils/exportConverters"
 
@@ -33,19 +35,7 @@ jest.mock("../../../../utils/exportConverters", () => ({
 }))
 
 jest.mock("../../../../hooks/useTheme", () => ({
-  useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#9ca3af",
-      border: "#e5e7eb",
-      card: "#fff",
-      cardElevated: "#f9fafb",
-      error: "#ef4444",
-      pressedOpacity: 0.7
-    }
-  })
+  useTheme: () => ({ colors: jest.requireActual("@colota/shared").lightColors })
 }))
 
 jest.mock("lucide-react-native", () => {
@@ -69,16 +59,9 @@ jest.mock("lucide-react-native", () => {
 
 import { TripList } from "../TripList"
 
-const colors = {
-  primary: "#0d9488",
-  text: "#000",
-  textSecondary: "#6b7280",
-  textDisabled: "#9ca3af",
-  border: "#e5e7eb",
-  card: "#fff",
-  error: "#ef4444",
-  pressedOpacity: 0.7
-} as any
+// The real palette, not a hand-written subset: a missing key reads undefined and the style
+// it feeds silently disappears.
+const colors = lightColors
 
 function makeTrip(index: number, distance = 1000): Trip {
   return {
@@ -98,6 +81,22 @@ function makeTrips(n: number): Trip[] {
 
 describe("TripList - CAB selection", () => {
   beforeEach(() => jest.clearAllMocks())
+
+  it("marks a selected trip with a fill, because a border that comes and goes clips the card", () => {
+    const { getByLabelText, UNSAFE_getAllByType } = render(
+      <TripList trips={makeTrips(3)} colors={colors} onTripSelect={jest.fn()} onExport={jest.fn()} />
+    )
+    const filled = () =>
+      UNSAFE_getAllByType(View).filter(
+        (v) => StyleSheet.flatten(v.props.style)?.backgroundColor === colors.primaryContainer
+      )
+
+    expect(filled()).toHaveLength(0)
+    fireEvent(getByLabelText(/Trip 1,/), "longPress")
+
+    expect(filled()).toHaveLength(1)
+    expect(StyleSheet.flatten(filled()[0].props.style).borderWidth).toBeUndefined()
+  })
 
   it("renders idle header with Export All when trips exist", () => {
     const { getByLabelText, queryByLabelText } = render(

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -810,7 +810,7 @@ export function OfflineMapsScreen({}: ScreenProps) {
     ]
   )
 
-  const mapDownloadingStyle = downloading ? { borderColor: colors.primary, borderWidth: 2 as const } : null
+  const mapDownloadingStyle = downloading ? { borderColor: colors.primary } : null
   const savedAreasFillStyle = { fillColor: colors.success, fillOpacity: 0.1 }
   const savedAreasBorderStyle = { lineColor: colors.success, lineWidth: 1.5, lineOpacity: 0.6 }
   const downloadAreaFillStyle = { fillColor: colors.info, fillOpacity: 0.2 }
@@ -875,7 +875,9 @@ export function OfflineMapsScreen({}: ScreenProps) {
 const styles = StyleSheet.create({
   // the list around it already insets its rows
   emptyInset: { paddingHorizontal: 0 },
-  map: { height: 450, overflow: "hidden" },
+  // The border is always drawn and only changes colour: a width that comes and goes on a
+  // view that clips leaves its children unpainted on Android.
+  map: { height: 450, overflow: "hidden", borderWidth: 2, borderColor: "transparent" },
   list: { padding: 20, paddingBottom: 40 },
   section: { marginBottom: space.lg },
   hint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18, marginBottom: space.lg },

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -113,7 +113,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
       const isActive = activeProfileName === item.name
 
       return (
-        <Card style={[styles.card, isActive && styles.activeCard, isActive && { borderColor: colors.primary }]}>
+        <Card style={[styles.card, isActive && { backgroundColor: colors.primaryContainer }]}>
           <Pressable
             style={({ pressed }) => [styles.row, pressed && { opacity: colors.pressedOpacity }]}
             onPress={() => navigation.navigate("Profile Editor", { profileId: item.id })}
@@ -179,11 +179,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
               </Text>
             </View>
 
-            <Button
-              title="Create profile"
-              icon={Plus}
-              onPress={() => navigation.navigate("Profile Editor", {})}
-            />
+            <Button title="Create profile" icon={Plus} onPress={() => navigation.navigate("Profile Editor", {})} />
 
             {profiles.length > 0 && (
               <View style={styles.activeHeader}>
@@ -217,7 +213,6 @@ const styles = StyleSheet.create({
   header: { marginBottom: 20 },
   subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: 20 },
   card: { marginBottom: space.md },
-  activeCard: { borderWidth: 2 },
   row: { flexDirection: "row", alignItems: "center" },
   iconWrap: {
     width: 36,
@@ -246,5 +241,5 @@ const styles = StyleSheet.create({
   settings: { fontSize: fontSizes.small, ...fonts.regular },
   actions: { alignItems: "center", gap: space.sm },
   activeHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  shareBtn: { padding: space.xs, marginBottom: space.md },
+  shareBtn: { padding: space.xs, marginBottom: space.md }
 })

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { StyleSheet } from "react-native"
+import { StyleSheet, View as RNView } from "react-native"
 import { render, fireEvent, waitFor, act } from "@testing-library/react-native"
 import { OfflineMapsScreen } from "../OfflineMapsScreen"
 import { logger } from "../../utils/logger"
@@ -184,6 +184,17 @@ beforeEach(() => {
 function renderScreen() {
   return render(<OfflineMapsScreen navigation={mockNavigation as any} />)
 }
+
+it("keeps the map's border drawn at rest, because a width that appears clips the map away", () => {
+  const { UNSAFE_getAllByType } = renderScreen()
+
+  const mapBox = UNSAFE_getAllByType(RNView)
+    .map((v) => StyleSheet.flatten(v.props.style))
+    .find((style) => style?.height === 450)
+
+  expect(mapBox?.borderWidth).toBe(2)
+  expect(mapBox?.borderColor).toBe("transparent")
+})
 
 // Waits for map bounds to be set and the estimate label to appear
 async function waitForMapReady(findByText: ReturnType<typeof render>["findByText"]) {

--- a/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { render, fireEvent, waitFor } from "@testing-library/react-native"
-import { Share } from "react-native"
+import { Share, StyleSheet, View as RNView } from "react-native"
+import { lightColors } from "@colota/shared"
 import { TrackingProfile } from "../../types/global"
 
 // --- Mocks ---
@@ -62,21 +63,7 @@ jest.mock("../../contexts/TrackingProvider", () => ({
 }))
 
 jest.mock("../../hooks/useTheme", () => ({
-  useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      textOnPrimary: "#fff"
-    }
-  })
+  useTheme: () => ({ colors: jest.requireActual("@colota/shared").lightColors })
 }))
 
 jest.mock("../../components", () => {
@@ -128,6 +115,20 @@ describe("TrackingProfilesScreen", () => {
   function renderScreen() {
     return render(<TrackingProfilesScreen navigation={mockNavigation as any} />)
   }
+
+  it("marks the active profile with a fill, because a border that comes and goes clips the card", async () => {
+    mockActiveProfileName = "Charging"
+
+    const { UNSAFE_getAllByType, findByText } = renderScreen()
+    await findByText("Active")
+
+    const filled = UNSAFE_getAllByType(RNView).filter(
+      (v) => StyleSheet.flatten(v.props.style)?.backgroundColor === lightColors.primaryContainer
+    )
+
+    expect(filled).toHaveLength(1)
+    expect(StyleSheet.flatten(filled[0].props.style).borderWidth).toBeUndefined()
+  })
 
   it("renders profile list", async () => {
     const { getByText } = renderScreen()


### PR DESCRIPTION
Select a trip, cancel the selection, and the row comes back as an empty card that still takes a tap. Scrolling does not repair it, only leaving the tab.

Toggling `borderWidth` on a `Card`, which clips its own rounded corners, stops Android painting the children. Export All never blanked a row and select-then-cancel always did, which ruled out the share sheet the symptom first suggested. State is a container fill now, on the selected trip and on the active profile card. The offline map cannot take a fill, so its border is drawn always and only the colour changes while a download runs.

Confirmed on device. Two test files were mocking `useTheme` with hand-written colour subsets that lack `primaryContainer`; both take the real palette now.