### PR TITLE
fix(tracking): a revoked permission turns the toggle off

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -164,7 +164,9 @@ deliberately survives process death and reboot. Whether a service exists right n
 `LocationForegroundService.isRunning`. Anything asking "is tracking alive" must read `isRunning`,
 because a service the system killed leaves the flag true. Recovery is layered: the app reconciles
 the two whenever it reaches the foreground, and `TrackingWatchdogScheduler` covers the window while
-the app stays closed.
+the app stays closed. Reconciling can also drop the intent rather than honour it: a revoked location
+permission means no service can be started again, so the foreground reconciler clears the flag and
+the watchdog stops re-arming itself.
 
 ### NotificationHelper
 

--- a/apps/docs/docs/development/permissions.md
+++ b/apps/docs/docs/development/permissions.md
@@ -117,4 +117,4 @@ Lets Colota briefly hold the CPU awake when a heartbeat alarm fires during Doze.
 
 ## Revoking Permissions
 
-You can revoke any permission at any time through Android Settings → Apps → Colota → Permissions. Revoking location permissions will stop tracking. Other permissions can be toggled without affecting the core tracking functionality.
+You can revoke any permission at any time through Android Settings → Apps → Colota → Permissions. Revoking a location permission stops the tracking service, and Colota turns the tracking toggle off the next time you open the app. Other permissions can be toggled without affecting the core tracking functionality.

--- a/apps/mobile/src/hooks/__tests__/useLocationTracking.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useLocationTracking.test.ts
@@ -13,13 +13,15 @@ const mockStop = jest.fn()
 const mockGetMostRecentLocation = jest.fn().mockResolvedValue(null)
 const mockIsTrackingActive = jest.fn().mockResolvedValue(false)
 const mockIsServiceRunning = jest.fn().mockResolvedValue(true)
+const mockSaveSetting = jest.fn().mockResolvedValue(undefined)
 
 jest.mock("../../services/NativeLocationService", () => ({
   start: (...args: any[]) => mockStart(...args),
   stop: (...args: any[]) => mockStop(...args),
   getMostRecentLocation: (...args: any[]) => mockGetMostRecentLocation(...args),
   isTrackingActive: (...args: any[]) => mockIsTrackingActive(...args),
-  isServiceRunning: (...args: any[]) => mockIsServiceRunning(...args)
+  isServiceRunning: (...args: any[]) => mockIsServiceRunning(...args),
+  saveSetting: (...args: any[]) => mockSaveSetting(...args)
 }))
 
 // Mock permissions
@@ -50,6 +52,7 @@ beforeEach(() => {
   // clearAllMocks keeps implementations, so restore the defaults each test explicitly overrides
   mockIsTrackingActive.mockResolvedValue(false)
   mockIsServiceRunning.mockResolvedValue(true)
+  mockSaveSetting.mockResolvedValue(undefined)
   mockCheckPermissions.mockResolvedValue({ location: true, background: true, notifications: true })
   jest.spyOn(console, "log").mockImplementation()
   jest.spyOn(console, "error").mockImplementation()
@@ -470,19 +473,31 @@ describe("useLocationTracking", () => {
       expect(mockStart).toHaveBeenCalledTimes(1)
     })
 
-    it("does not restart a dead service when location permission is gone", async () => {
+    it("turns tracking off when the permission was revoked under a running service", async () => {
+      // Revoking location stops the service without killing the process, so no onTrackingStopped
+      // arrives and the DB intent stays true. Offering Stop for a service that can never come back
+      // is the state the user sees until the next cold start, so the hook has to clear it here.
       mockIsTrackingActive.mockResolvedValue(true)
-      mockIsServiceRunning.mockResolvedValue(false)
-      mockCheckPermissions.mockResolvedValue({ location: false, background: false, notifications: true })
       mockGetMostRecentLocation.mockResolvedValue(null)
 
-      renderHook(() => useLocationTracking(DEFAULT_SETTINGS, true))
+      const { result } = renderHook(() => useLocationTracking(DEFAULT_SETTINGS, true))
+
+      await act(async () => {
+        await result.current.startTracking(DEFAULT_SETTINGS)
+      })
+      expect(result.current.tracking).toBe(true)
+
+      mockIsServiceRunning.mockResolvedValue(false)
+      mockCheckPermissions.mockResolvedValue({ location: false, background: false, notifications: true })
+      mockStart.mockClear()
 
       await act(async () => {
         await appStateCallback("active")
       })
 
       expect(mockStart).not.toHaveBeenCalled()
+      expect(mockSaveSetting).toHaveBeenCalledWith("tracking_enabled", "false")
+      expect(result.current.tracking).toBe(false)
     })
 
     it("does nothing when transitioning to background", async () => {

--- a/apps/mobile/src/hooks/useLocationTracking.ts
+++ b/apps/mobile/src/hooks/useLocationTracking.ts
@@ -271,7 +271,13 @@ export function useLocationTracking(settings: Settings, settingsHydrated: boolea
 
       const perms = await checkPermissions()
       if (!perms.location) {
-        logger.warn("[useLocationTracking] Service is dead but location permission is gone, not restarting")
+        logger.warn("[useLocationTracking] Service is dead and location permission is gone - clearing tracking state")
+        await NativeLocationService.saveSetting("tracking_enabled", "false")
+        if (listenerRef.current) {
+          listenerRef.current.remove()
+          listenerRef.current = null
+        }
+        setTracking(false)
         return
       }
 


### PR DESCRIPTION
Revoking location stops the foreground service without always killing the process. Our own stop path only runs when the location stream is re-registered, so no onTrackingStopped is emitted and tracking_enabled stays true. reviveIfDead saw the dead service and the missing grant, logged, and returned, which left the UI offering Stop for a service that could never come back until the next cold start cleared the flag through hydration.

It now writes tracking_enabled=false, drops the location listener and sets tracking off, the same reconciliation the external-stop branch above it does.

A service that survives the revoke with a dead stream is a separate case: isServiceRunning still reports true, so reviveIfDead returns before this check. That needs a native permission check in the diagnostic heartbeat and is not in this change.