### PR TITLE
fix(auto-export): Export now runs, and says that it is running

### DIFF
--- a/apps/docs/docs/guides/data-export.md
+++ b/apps/docs/docs/guides/data-export.md
@@ -63,7 +63,7 @@ Automatically export your location data on a schedule without opening the app.
 5. Pick the **Time** (24-hour) in your device's local timezone. For **Weekly**, also pick a day of week. For **Monthly**, pick a day of month (1-31)
 6. Enable the toggle
 
-You can also tap **Export Now** to trigger an immediate export using your current auto-export settings, without waiting for the next scheduled run.
+You can also tap **Export Now** to trigger an immediate export using your current auto-export settings, without waiting for the next scheduled run. It works whether or not the toggle is on: the toggle governs the schedule, not the button. A line under the button says the export is running, and it keeps running if you leave the screen.
 
 ### Export Range
 
@@ -95,7 +95,7 @@ If several devices export into the same folder and none of the templates include
 
 - Uses Android AlarmManager (`setAndAllowWhileIdle`) to fire at your configured wall-clock time. Typical accuracy is within minutes; Doze mode may delay by up to ~15 minutes
 - After each export the next alarm is armed automatically. Alarms also re-arm after device reboot
-- Exports fire at the configured time, not on enable. To run an export immediately for testing or backup, tap **Export Now**
+- Exports fire at the configured time, not on enable. To run an export immediately for testing or backup, tap **Export Now**, which needs only an export directory
 - Promotes to a foreground service during export, preventing Android from killing long-running exports
 - Streams data in chunks (10,000 locations at a time) to keep memory usage low even with very large datasets
 - Writes to a temporary file first, then copies to the export directory - if something goes wrong mid-export, you never get a partial or corrupted file

--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
@@ -29,6 +29,7 @@ import com.Colota.sync.UrlSafety
 import com.Colota.util.DeviceInfoHelper
 import com.Colota.export.AutoExportConfig
 import com.Colota.export.AutoExportScheduler
+import com.Colota.export.AutoExportWorker
 import com.Colota.export.ExportConverters
 import com.Colota.util.AppFileLogger
 import com.Colota.util.FileOperations
@@ -1031,6 +1032,7 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
 
         Arguments.createMap().apply {
             putBoolean("enabled", config.enabled)
+            putBoolean("running", AutoExportWorker.isRunning)
             putString("format", config.format)
             putString("interval", config.interval)
             putString("uri", config.uri)

--- a/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportWorker.kt
@@ -98,13 +98,14 @@ class AutoExportWorker(
         val db = DatabaseHelper.getInstance(appContext)
         val config = AutoExportConfig.from(db)
 
-        if (!config.enabled) {
+        if (!config.enabled && !isManualRun) {
             AppLogger.d(TAG, "Auto-export is disabled, skipping")
             return Result.success()
         }
 
         if (config.uri == null) {
             AppLogger.e(TAG, "No export directory configured")
+            if (isManualRun) LocationServiceModule.sendAutoExportEvent(false, null, 0, "No export directory configured")
             return Result.failure()
         }
 
@@ -163,6 +164,7 @@ class AutoExportWorker(
                 AppLogger.i(TAG, "No locations to export")
                 showNotification("Auto-Export", "No new locations to export.")
                 cleanupOldExports(dirUri, config)
+                if (isManualRun) LocationServiceModule.sendAutoExportEvent(true, null, 0, null)
                 return Result.success()
             }
 

--- a/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportWorkerRunTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportWorkerRunTest.kt
@@ -125,4 +125,29 @@ class AutoExportWorkerRunTest {
         assertTrue("expected the verification error, got ${config.lastError}", config.lastError!!.contains("Export verification failed"))
         verify { createdDoc.delete() }
     }
+
+    @Test
+    fun `Export now exports while auto-export is switched off`() {
+        // The screen offers Export now whenever a directory is set, and the enabled flag is the
+        // schedule's, so the button used to return success without writing anything.
+        db.saveSetting("autoExportEnabled", "false")
+
+        val result = runWorker()
+
+        assertTrue("expected success, got $result", result is ListenableWorker.Result.Success)
+        val csv = written.toString(Charsets.UTF_8.name())
+        assertTrue("expected rows to be written", csv.contains("1700000500"))
+        assertEquals(200, AutoExportConfig.from(db).lastRowCount)
+    }
+
+    @Test
+    fun `a scheduled run still skips while auto-export is switched off`() {
+        db.saveSetting("autoExportEnabled", "false")
+
+        val worker = TestListenableWorkerBuilder<AutoExportWorker>(context).build()
+        val result = runBlocking { worker.doWork() }
+
+        assertTrue("expected success, got $result", result is ListenableWorker.Result.Success)
+        assertEquals("", written.toString(Charsets.UTF_8.name()))
+    }
 }

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -5,9 +5,24 @@
 
 import React, { useState, useCallback, useEffect } from "react"
 import { useFocusEffect } from "@react-navigation/native"
-import { Text, StyleSheet, View, ScrollView, Pressable, DeviceEventEmitter } from "react-native"
+import { ActivityIndicator, Text, StyleSheet, View, ScrollView, Pressable, DeviceEventEmitter } from "react-native"
 import { FolderOpen, CircleCheckBig, Share2, TriangleAlert } from "lucide-react-native"
-import { Button, Card, ChipGroup, Container, Divider, FloatingSaveIndicator, FormatSelector, NumericInput, RadioRow, SectionTitle, SettingRow, TimePicker, Toggle, TextField } from "../components"
+import {
+  Button,
+  Card,
+  ChipGroup,
+  Container,
+  Divider,
+  FloatingSaveIndicator,
+  FormatSelector,
+  NumericInput,
+  RadioRow,
+  SectionTitle,
+  SettingRow,
+  TimePicker,
+  Toggle,
+  TextField
+} from "../components"
 import { useTheme } from "../hooks/useTheme"
 import { useTimeout } from "../hooks/useTimeout"
 import { ScreenProps } from "../types/global"
@@ -84,6 +99,7 @@ export function AutoExportScreen(_props: ScreenProps) {
   const [exportFiles, setExportFiles] = useState<ExportFile[]>([])
   const [loading, setLoading] = useState(true)
   const [exporting, setExporting] = useState(false)
+  const [exportRunning, setExportRunning] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
   const successTimeout = useTimeout()
@@ -92,6 +108,9 @@ export function AutoExportScreen(_props: ScreenProps) {
     try {
       const status = await NativeLocationService.getAutoExportStatus()
       setEnabled(status.enabled)
+      // Only ever turns it on: the worker's flag is still false between the enqueue and the run
+      // starting, and a reload in that window would wipe the line the press just put up.
+      if (status.running) setExportRunning(true)
       setFormat((status.format as ExportFormat) || "geojson")
       setInterval((status.interval as ExportInterval) || "daily")
       setMode((status.mode as ExportMode) || "all")
@@ -148,15 +167,19 @@ export function AutoExportScreen(_props: ScreenProps) {
     const listener = DeviceEventEmitter.addListener(
       "onAutoExportComplete",
       (event: { success: boolean; fileName: string | null; rowCount: number; error: string | null }) => {
-        if (event.success) {
+        if (!event.success) {
+          setLastError(event.error)
+          showAlert("Export Failed", event.error || "Unknown error", "error")
+        } else if (event.fileName) {
           setLastFileName(event.fileName)
           setLastRowCount(event.rowCount)
           setLastError(null)
           showAlert("Export Complete", `Exported ${event.rowCount} locations to ${event.fileName}`, "success")
         } else {
-          setLastError(event.error)
-          showAlert("Export Failed", event.error || "Unknown error", "error")
+          setLastError(null)
+          showAlert("Export Complete", "No new locations to export.", "success")
         }
+        setExportRunning(false)
         loadStatus()
         loadExportFiles()
       }
@@ -337,7 +360,7 @@ export function AutoExportScreen(_props: ScreenProps) {
     setExporting(true)
     try {
       await NativeLocationService.runAutoExportNow()
-      showAlert("Export Started", "Export is running in the background. The status will update when complete.", "info")
+      setExportRunning(true)
     } catch (error) {
       logger.error("[AutoExportScreen] Export now failed:", error)
       showAlert("Error", "Failed to start export.", "error")
@@ -364,7 +387,9 @@ export function AutoExportScreen(_props: ScreenProps) {
   if (loading)
     return (
       <Container>
-        <View />
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
       </Container>
     )
 
@@ -385,11 +410,7 @@ export function AutoExportScreen(_props: ScreenProps) {
             label="Enable Auto-Export"
             hint={enabled ? "Auto-Exports are scheduled" : "Auto-Exports are disabled"}
           >
-            <Toggle
-              accessibilityLabel="Enable auto-export"
-              value={enabled}
-              onValueChange={handleToggle}
-            />
+            <Toggle accessibilityLabel="Enable auto-export" value={enabled} onValueChange={handleToggle} />
           </SettingRow>
         </Card>
 
@@ -602,6 +623,14 @@ export function AutoExportScreen(_props: ScreenProps) {
               disabled={exporting}
               loading={exporting}
             />
+            {exportRunning && (
+              <View style={styles.runningRow} testID="export-running">
+                <ActivityIndicator size="small" color={colors.textSecondary} />
+                <Text style={[styles.runningText, { color: colors.textSecondary }]}>
+                  Export running. It continues if you leave this screen.
+                </Text>
+              </View>
+            )}
           </View>
         )}
 
@@ -641,6 +670,20 @@ export function AutoExportScreen(_props: ScreenProps) {
 }
 
 const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  runningRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: space.sm
+  },
+  runningText: {
+    flex: 1,
+    fontSize: fontSizes.caption
+  },
   scrollContent: {
     paddingHorizontal: space.lg,
     paddingBottom: 40

--- a/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoExportScreen.test.tsx
@@ -674,11 +674,88 @@ describe("AutoExportScreen", () => {
 
     await waitFor(() => {
       expect(mockRunAutoExportNow).toHaveBeenCalled()
-      expect(mockShowAlert).toHaveBeenCalledWith(
-        "Export Started",
-        "Export is running in the background. The status will update when complete.",
-        "info"
-      )
+    })
+  })
+
+  it("shows the export as running when the screen opens mid-run", async () => {
+    // The line is component state, so returning to the screen while the worker is still going
+    // would have shown nothing; the status map carries the worker's own flag for that.
+    mockGetAutoExportStatus.mockResolvedValue({
+      enabled: true,
+      running: true,
+      uri: "content://some-uri",
+      mode: "all",
+      lastExportTimestamp: 0,
+      nextExportTimestamp: 0,
+      fileCount: 0
+    })
+
+    const { getByTestId } = render(<AutoExportScreen {...mockProps} />)
+
+    await waitFor(() => {
+      expect(getByTestId("export-running")).toBeTruthy()
+    })
+  })
+
+  it("says so when a manual export found nothing new", async () => {
+    // The worker reports a zero-row run with no filename, which read as "Exported 0 locations to
+    // null" before.
+    mockGetAutoExportStatus.mockResolvedValue({
+      enabled: true,
+      uri: "content://some-uri",
+      mode: "incremental",
+      lastExportTimestamp: 0,
+      nextExportTimestamp: 0,
+      fileCount: 0
+    })
+
+    render(<AutoExportScreen {...mockProps} />)
+    await waitFor(() => expect(mockGetAutoExportStatus).toHaveBeenCalled())
+
+    act(() => {
+      DeviceEventEmitter.emit("onAutoExportComplete", { success: true, fileName: null, rowCount: 0, error: null })
+    })
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith("Export Complete", "No new locations to export.", "success")
+    })
+  })
+
+  it("keeps saying the export is running until the worker reports back", async () => {
+    // runAutoExportNow only enqueues, so the button's own spinner lasts about a frame while a
+    // real export runs for minutes. Nothing on the screen said the work was still going.
+    mockGetAutoExportStatus.mockResolvedValue({
+      enabled: true,
+      uri: "content://some-uri",
+      mode: "all",
+      lastExportTimestamp: 0,
+      nextExportTimestamp: 0,
+      fileCount: 0
+    })
+
+    const { getByText, getByTestId, queryByTestId } = render(<AutoExportScreen {...mockProps} />)
+
+    await waitFor(() => {
+      expect(getByText("Export now")).toBeTruthy()
+    })
+    expect(queryByTestId("export-running")).toBeNull()
+
+    fireEvent.press(getByText("Export now"))
+    await waitFor(() => {
+      expect(getByTestId("export-running")).toBeTruthy()
+    })
+
+    act(() => {
+      DeviceEventEmitter.emit("onAutoExportComplete", {
+        success: true,
+        fileName: "colota-2026-09-06.geojson",
+        rowCount: 12,
+        error: null
+      })
+    })
+
+    await waitFor(() => {
+      expect(queryByTestId("export-running")).toBeNull()
     })
   })
 

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -255,7 +255,6 @@ class NativeLocationService {
     )
   }
 
-
   // ============================================================================
   // CLEANUP OPERATIONS
   // ============================================================================
@@ -871,6 +870,7 @@ class NativeLocationService {
    */
   static async getAutoExportStatus(): Promise<{
     enabled: boolean
+    running: boolean
     format: string
     interval: string
     uri: string | null


### PR DESCRIPTION
Export now did nothing whenever auto-export was switched off. The worker returned success on the enabled check before it looked at whether the run was manual, and the button is offered as soon as a directory is set, so pressing it produced no export, no notification and no error. The flag governs the schedule, not a request the user just made.

Two more paths never reported back, so the screen could wait forever: no directory, and a run that found no new rows. Both send the event now on a manual run only, since a scheduled run hitting them is routine and an event there would pop a dialog on a quiet tick. A zero-row result reads as No new locations to export rather than Exported 0 locations to null.

The screen also said nothing while an export ran. runAutoExportNow only enqueues, so the button's spinner lasted about a frame against a job that takes minutes. A status line under the button holds from the enqueue until the worker reports back, and getAutoExportStatus now carries the worker's own running flag so returning to the screen mid-run picks it up again. That reload can only turn the line on: the flag is false between the enqueue and the run starting, and an authoritative read there would wipe the line the press just put up. Opening the screen no longer flashes a blank frame either.

The button stays enabled rather than being held disabled for the run, because AutoExportWorker already calls setForeground and Android's notification is the progress surface that survives leaving the screen.