### PR TITLE
fix(a11y): a section heading is readable, and says it is a heading

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -203,7 +203,7 @@ export function SyncStrategySettings({
 
             {/* Tracking Parameters Group */}
             <View style={styles.paramGroup}>
-              <SectionTitle color={colors.textSecondary}>Tracking parameters</SectionTitle>
+              <SectionTitle>Tracking parameters</SectionTitle>
 
               <NumericInput
                 label="Tracking interval"
@@ -232,7 +232,7 @@ export function SyncStrategySettings({
 
                 {/* Network Parameters Group */}
                 <View style={styles.paramGroup}>
-                  <SectionTitle color={colors.textSecondary}>Network settings</SectionTitle>
+                  <SectionTitle>Network settings</SectionTitle>
 
                   {/* Sync Interval */}
                   <View style={styles.settingBlock}>
@@ -399,7 +399,7 @@ export function SyncStrategySettings({
 
             {/* Quality Parameters Group */}
             <View style={styles.paramGroup}>
-              <SectionTitle color={colors.textSecondary}>Quality filters</SectionTitle>
+              <SectionTitle>Quality filters</SectionTitle>
 
               <SettingRow
                 style={styles.firstInGroup}

--- a/apps/mobile/src/components/ui/SectionTitle.tsx
+++ b/apps/mobile/src/components/ui/SectionTitle.tsx
@@ -12,15 +12,16 @@ import { space } from "../../constants"
 type SectionTitleProps = {
   children: React.ReactNode
   style?: StyleProp<ViewStyle>
-  color?: string
 }
 
-export function SectionTitle({ children, style, color }: SectionTitleProps) {
+export function SectionTitle({ children, style }: SectionTitleProps) {
   const { colors } = useTheme()
 
   return (
     <View style={style}>
-      <Text style={[styles.sectionTitle, { color: color ? color : colors.primary }]}>{children}</Text>
+      <Text accessibilityRole="header" style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+        {children}
+      </Text>
     </View>
   )
 }

--- a/apps/mobile/src/components/ui/__tests__/SectionTitle.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/SectionTitle.test.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { lightColors, darkColors } from "@colota/shared"
+import { SectionTitle } from "../SectionTitle"
+
+let mockColors = lightColors
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: mockColors })
+}))
+
+/** WCAG AA for text under 18pt, which a 16px semiBold heading is. */
+const AA = 4.5
+
+function ratio(fg: string, bg: string): number {
+  const lum = (hex: string) => {
+    const c = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
+    const [r, g, b] = c.map((v) => (v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)))
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+  }
+  const [hi, lo] = [lum(fg), lum(bg)].sort((a, b) => b - a)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+describe("SectionTitle", () => {
+  afterEach(() => {
+    mockColors = lightColors
+  })
+
+  it("reads its colour from the theme, so a heading is legible in both", () => {
+    const { getByText, rerender } = render(<SectionTitle>Tracking</SectionTitle>)
+    expect(getByText("Tracking").props.style).toEqual(expect.arrayContaining([{ color: lightColors.textSecondary }]))
+
+    mockColors = darkColors
+    rerender(<SectionTitle>Tracking</SectionTitle>)
+
+    expect(getByText("Tracking").props.style).toEqual(expect.arrayContaining([{ color: darkColors.textSecondary }]))
+  })
+
+  it("announces itself as a heading, so a screen reader can jump between sections", () => {
+    const { getByText } = render(<SectionTitle>Tracking</SectionTitle>)
+
+    expect(getByText("Tracking").props.accessibilityRole).toBe("header")
+  })
+
+  it("keeps the arithmetic true: the heading clears AA where primary does not", () => {
+    for (const theme of [lightColors, darkColors]) {
+      expect(ratio(theme.textSecondary, theme.background)).toBeGreaterThanOrEqual(AA)
+      expect(ratio(theme.textSecondary, theme.card)).toBeGreaterThanOrEqual(AA)
+    }
+
+    // The reason this component changed: primary fails on both light surfaces.
+    expect(ratio(lightColors.primary, lightColors.background)).toBeLessThan(AA)
+    expect(ratio(lightColors.primary, lightColors.card)).toBeLessThan(AA)
+  })
+})


### PR DESCRIPTION
Every section heading in the app was `colors.primary` at 16px semiBold: **3.39:1** against the ground and **3.74:1** on a card, both under the 4.5 WCAG floor, and 16px semiBold is not large text. Dark was never the problem, at 10.06 and 7.40.

It takes `textSecondary` now, which is Material's own token for a list subheader and what three call sites in `SyncStrategySettings` were already passing by hand. Those overrides and the `color` prop are gone with them.

Second defect in the same component: it never carried `accessibilityRole="header"`, though the guide said it did, so TalkBack read 23 screens of headings as plain text. Fixed here too.

Nothing moves on screen. The test computes the ratios rather than asserting a hex, so it fails if `primary` comes back.