### PR TITLE
fix(history): a trip row is a name, a time and one caption

### DIFF
--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from "react"
 import { View, Text, FlatList, Pressable, StyleSheet, BackHandler } from "react-native"
-import { Clock, Route, Share, TrendingUp, TrendingDown, Gauge, Trash2, X, Merge } from "lucide-react-native"
+import { Check, Route, Share, Trash2, X, Merge } from "lucide-react-native"
 import { Card } from "../../ui/Card"
 import { EmptyState } from "../../ui/EmptyState"
 import { fontSizes, fonts } from "../../../styles/typography"
@@ -46,9 +46,20 @@ const TripRow = React.memo(function TripRowItem({
 }: TripRowProps) {
   const duration = trip.endTime - trip.startTime
   const tripColor = getTripColor(trip.index)
+  const statLine = [
+    formatDistance(trip.distance),
+    formatDuration(duration),
+    stats && stats.avgSpeed > 0 ? formatSpeed(stats.avgSpeed) : null,
+    stats && stats.elevationGain > 0 ? `+${Math.round(stats.elevationGain)} m` : null,
+    stats && stats.elevationLoss > 0 ? `-${Math.round(stats.elevationLoss)} m` : null
+  ]
+    .filter(Boolean)
+    .join("  ·  ")
   // Selection is a fill, not a stroke: toggling borderWidth on a card that clips its own
   // corners leaves the children clipped away on Android until the list remounts.
-  const cardStyle = [styles.tripCard, isCabSelected && { backgroundColor: colors.primaryContainer }]
+  const cardStyle = isCabSelected && { backgroundColor: colors.primaryContainer }
+  const content = isCabSelected ? colors.onPrimaryContainer : colors.text
+  const subContent = isCabSelected ? colors.onPrimaryContainer : colors.textSecondary
 
   const accessibilityRole = selectionMode ? "checkbox" : "button"
   const accessibilityState = selectionMode ? { checked: isCabSelected } : undefined
@@ -69,42 +80,21 @@ const TripRow = React.memo(function TripRowItem({
     >
       <View style={styles.tripHeader}>
         <View style={styles.tripTitleRow}>
-          <View style={[styles.tripDot, { backgroundColor: tripColor }]} />
-          <Text style={[styles.tripTitle, { color: colors.text }]}>Trip {trip.index}</Text>
+          <View style={styles.tripLead}>
+            {isCabSelected ? (
+              <Check size={size.icon.sm} color={content} />
+            ) : (
+              <View style={[styles.tripDot, { backgroundColor: tripColor }]} />
+            )}
+          </View>
+          <Text style={[styles.tripTitle, { color: content }]}>Trip {trip.index}</Text>
         </View>
-        <Text style={[styles.tripTime, { color: colors.textSecondary }]}>
+        <Text style={[styles.tripTime, { color: content }]}>
           {formatTime(trip.startTime)} - {formatTime(trip.endTime)}
         </Text>
       </View>
 
-      <View style={styles.tripStats}>
-        <View style={styles.stat}>
-          <Route size={size.icon.sm} color={colors.textSecondary} />
-          <Text style={[styles.statText, { color: colors.text }]}>{formatDistance(trip.distance)}</Text>
-        </View>
-        <View style={styles.stat}>
-          <Clock size={size.icon.sm} color={colors.textSecondary} />
-          <Text style={[styles.statText, { color: colors.text }]}>{formatDuration(duration)}</Text>
-        </View>
-        {stats && stats.avgSpeed > 0 && (
-          <View style={styles.stat}>
-            <Gauge size={size.icon.sm} color={colors.textSecondary} />
-            <Text style={[styles.statText, { color: colors.text }]}>{formatSpeed(stats.avgSpeed)}</Text>
-          </View>
-        )}
-        {stats && stats.elevationGain > 0 && (
-          <View style={styles.stat}>
-            <TrendingUp size={size.icon.sm} color={colors.textSecondary} />
-            <Text style={[styles.statText, { color: colors.text }]}>{Math.round(stats.elevationGain)}m</Text>
-          </View>
-        )}
-        {stats && stats.elevationLoss > 0 && (
-          <View style={styles.stat}>
-            <TrendingDown size={size.icon.sm} color={colors.textSecondary} />
-            <Text style={[styles.statText, { color: colors.text }]}>{Math.round(stats.elevationLoss)}m</Text>
-          </View>
-        )}
-      </View>
+      <Text style={[styles.tripStats, { color: subContent }]}>{statLine}</Text>
     </Card>
   )
 })
@@ -439,13 +429,13 @@ const styles = StyleSheet.create({
   },
   list: {
     paddingHorizontal: space.md,
-    paddingBottom: space.lg
+    // gap spaces the rows against each other; the first one still needs clearing the header.
+    paddingTop: space.sm,
+    paddingBottom: space.lg,
+    gap: space.sm
   },
   // so an empty state has room to centre in
   listEmpty: { flexGrow: 1 },
-  tripCard: {
-    marginBottom: space.sm
-  },
   tripHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -457,6 +447,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: space.sm
   },
+  // Both leading marks sit in the same width, so the title does not shift when a row is picked.
+  tripLead: {
+    width: size.icon.sm,
+    alignItems: "center"
+  },
   tripDot: {
     width: 8,
     height: 8,
@@ -464,24 +459,16 @@ const styles = StyleSheet.create({
   },
   tripTitle: {
     fontSize: fontSizes.input,
-    ...fonts.bold
+    ...fonts.medium
   },
   tripTime: {
-    fontSize: fontSizes.description,
-    ...fonts.regular
+    fontSize: fontSizes.input,
+    ...fonts.medium,
+    fontVariant: ["tabular-nums"]
   },
   tripStats: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: space.md
-  },
-  stat: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: space.xs
-  },
-  statText: {
-    fontSize: fontSizes.description,
-    ...fonts.regular
+    fontSize: fontSizes.caption,
+    ...fonts.regular,
+    fontVariant: ["tabular-nums"]
   }
 })

--- a/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
@@ -43,12 +43,9 @@ jest.mock("lucide-react-native", () => {
   const { Text } = require("react-native")
   const stub = (name: string) => (_props: any) => R.createElement(Text, null, name)
   return {
-    Clock: stub("Clock"),
+    Check: stub("Check"),
     Route: stub("Route"),
     Share: stub("Share"),
-    TrendingUp: stub("TrendingUp"),
-    TrendingDown: stub("TrendingDown"),
-    Gauge: stub("Gauge"),
     Trash2: stub("Trash2"),
     X: stub("X"),
     Merge: stub("Merge"),
@@ -96,6 +93,28 @@ describe("TripList - CAB selection", () => {
 
     expect(filled()).toHaveLength(1)
     expect(StyleSheet.flatten(filled()[0].props.style).borderWidth).toBeUndefined()
+  })
+
+  it("puts every stat on one line, so a row is a name, a time and a caption", () => {
+    // The stats were five icon and text pairs that wrapped at three columns on a narrow phone.
+    const { getByText, queryByText } = render(
+      <TripList trips={makeTrips(1)} colors={colors} onTripSelect={jest.fn()} onExport={jest.fn()} />
+    )
+
+    // One node holding every stat, separated by the middot, rather than one node per stat
+    expect(getByText(/· 1m$/)).toBeTruthy()
+    expect(queryByText("Route")).toBeNull()
+  })
+
+  it("swaps the trip colour dot for a check when selected, so the fill is not the only signal", () => {
+    const { getByLabelText, queryByText } = render(
+      <TripList trips={makeTrips(3)} colors={colors} onTripSelect={jest.fn()} onExport={jest.fn()} />
+    )
+
+    expect(queryByText("Check")).toBeNull()
+    fireEvent(getByLabelText(/Trip 1,/), "longPress")
+
+    expect(queryByText("Check")).toBeTruthy()
   })
 
   it("renders idle header with Export All when trips exist", () => {

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -13,6 +13,8 @@ type CardVariant = "default" | "elevated" | "outlined" | "interactive"
 
 type CardProps = {
   children: React.ReactNode
+  /** Lands on the surface inside the Pressable, so a margin here grows the ripple box past the
+   *  card it paints. Spacing between cards belongs to the list. */
   style?: StyleProp<ViewStyle>
   danger?: boolean
   variant?: CardVariant

--- a/apps/mobile/src/components/ui/__tests__/Card.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Card.test.tsx
@@ -37,6 +37,20 @@ describe("Card", () => {
     expect(getByText("Trip 1")).toBeTruthy()
   })
 
+  it("takes the caller's style on the surface, which is why a margin there spills the ripple", () => {
+    // The trip row spaced itself with marginBottom, which grew the Pressable 8 past the card and
+    // the ripple with it. The margin belongs to the list, and this pins where the style lands.
+    const tree = render(
+      <Card variant="interactive" onPress={jest.fn()} style={{ backgroundColor: lightColors.primaryContainer }}>
+        <Text>Trip 1</Text>
+      </Card>
+    )
+
+    const rippleBox = tree.UNSAFE_getAllByType(View)[0]
+    expect(StyleSheet.flatten(rippleBox.props.style).backgroundColor).toBeUndefined()
+    expect(surfaceOf(tree).backgroundColor).toBe(lightColors.primaryContainer)
+  })
+
   it("pays its own padding unless rows are told to carry it", () => {
     const padded = render(
       <Card>


### PR DESCRIPTION
The row carried five icon and text pairs that wrapped to a second line on a narrow phone, and the time sat as a small secondary caption under its own header. It reads as the survey draws it now: a dot and the name, the time range as the row's right-hand figure, and every stat on one tabular caption below. The icons go with them.

Selection already used the container fill. A check replaces the trip colour dot in the leading column, which is where the survey puts bulk selection, so the state does not rest on colour alone. Both marks share one width so the title does not shift, and the content switches to onPrimaryContainer against the fill.

The ripple also spilled past the bottom of the card. A Card's style lands on the surface inside its Pressable, so tripCard's marginBottom grew the ripple box 8 taller than the card it painted. The list owns that spacing now, with a top pad so the first row clears the selection bar, and a Card test pins where the style lands so the next caller does not repeat it.

The Map, Trips and Data tabs are untouched, and the row keeps its card: every other repeating list in the app is carded, so de-carding this one alone would make it the odd one out.