### PR TITLE
feat(theme): type roles for the sizes used at one weight

### DIFF
--- a/apps/mobile/src/__tests__/fieldSpacingGuard.test.ts
+++ b/apps/mobile/src/__tests__/fieldSpacingGuard.test.ts
@@ -78,7 +78,7 @@ function stackedPairs(file: string, source: string): Pair[] {
   let prev: { end: number; indent: string; labelled: boolean } | null = null
 
   lines.forEach((line, index) => {
-    const opening = /^(\s*)<TextField\b/.exec(line)
+    const opening = /^(\s*)<\w*(?:TextField|Field)\b/.exec(line)
     if (!opening) {
       if (
         prev &&

--- a/apps/mobile/src/__tests__/typeRoleGuard.test.ts
+++ b/apps/mobile/src/__tests__/typeRoleGuard.test.ts
@@ -1,0 +1,92 @@
+// See designSystemGuard for why this file declares the node corner it needs by hand.
+declare const __dirname: string
+
+type Entry = { name: string; isDirectory: () => boolean }
+const fs: {
+  readdirSync: (dir: string, options: { withFileTypes: true }) => Entry[]
+  readFileSync: (file: string, encoding: "utf8") => string
+} = require("fs")
+const path: { join: (...parts: string[]) => string } = require("path")
+
+import { type, fontSizes } from "../styles/typography"
+
+/**
+ * A role is a size plus everything that always travels with it. Only the four sizes used at a
+ * single weight across the app are roles: `body`, `description`, `caption`, `label`, `input`,
+ * `small` and `micro` are each used at three or four weights, so a role for them would pick a
+ * weight for call sites that disagree, which is a reflow rather than a rename.
+ *
+ * This walks the tree for a style that composes a role's exact combination by hand, because that
+ * is how the app got here - two hundred styles writing size and weight separately, and a caption
+ * rendered in nine different size, weight and line-height combinations.
+ */
+const SRC = path.join(__dirname, "..")
+const ROOTS = ["screens", "components"]
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(path.join(SRC, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") walk(rel)
+      } else if (/\.tsx?$/.test(entry.name)) {
+        found.push(rel)
+      }
+    }
+  }
+  ROOTS.forEach(walk)
+  return found.sort()
+}
+
+/** A style body: every brace pair holding a fontSize and no nested object. */
+function styleBodies(source: string): string[] {
+  return [...source.matchAll(/\{([^{}]*fontSize[^{}]*)\}/g)].map((m) => m[1])
+}
+
+const ROLES: { role: string; size: keyof typeof fontSizes; weight?: string; mono?: boolean }[] = [
+  { role: "display", size: "screenTitle", weight: "bold" },
+  { role: "figure", size: "statValue", weight: "bold" },
+  { role: "title", size: "cardTitle", weight: "bold" },
+  { role: "heading", size: "heading", weight: "bold" },
+  { role: "mono", size: "caption", mono: true }
+]
+
+describe("type role guard", () => {
+  const files = sourceFiles()
+
+  it("finds the styles it is meant to police", () => {
+    const withText = files.filter((f) => styleBodies(fs.readFileSync(path.join(SRC, f), "utf8")).length > 0)
+
+    expect(withText.length).toBeGreaterThan(40)
+    expect(withText).toContain("components/ui/AppModal.tsx")
+  })
+
+  it("leaves no style composing a role by hand", () => {
+    const offenders: string[] = []
+    for (const file of files) {
+      for (const body of styleBodies(fs.readFileSync(path.join(SRC, file), "utf8"))) {
+        for (const { role, size, weight, mono } of ROLES) {
+          if (!new RegExp(`fontSize:\\s*fontSizes\\.${size}\\b`).test(body)) continue
+          if (weight && !new RegExp(`\\.\\.\\.fonts\\.${weight}\\b`).test(body)) continue
+          if (mono && !/fontFamily:\s*"monospace"/.test(body)) continue
+          offenders.push(`${file} rebuilds type.${role}`)
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it("keeps a figure tabular, so a counting number does not jitter", () => {
+    expect(type.figure.fontVariant).toContain("tabular-nums")
+  })
+
+  it("keeps every role on the shared size scale, so one scale still governs", () => {
+    const sizes: number[] = Object.values(fontSizes)
+
+    for (const role of Object.values(type)) {
+      expect(sizes).toContain(role.fontSize)
+    }
+  })
+})

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -9,7 +9,7 @@ import { TriangleAlert } from "lucide-react-native"
 import { LocationCoords } from "../../../types/global"
 import { useTheme } from "../../../hooks/useTheme"
 import { useCoords } from "../../../contexts/TrackingProvider"
-import { fontSizes, fonts } from "../../../styles/typography"
+import { fontSizes, fonts, type } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM, space } from "../../../constants"
 import { MapCenterButton } from "../map/MapCenterButton"
@@ -268,7 +268,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginBottom: space.lg
   },
-  stateTitle: { fontSize: fontSizes.heading, ...fonts.bold, textAlign: "center" },
+  stateTitle: { ...type.heading, textAlign: "center" },
   stateTitleSpaced: { marginTop: 20 },
   stateSubtext: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
+++ b/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
@@ -7,7 +7,7 @@ import { Text, StyleSheet, View } from "react-native"
 import { SectionTitle, Card } from "../.."
 import { useTheme } from "../../../hooks/useTheme"
 import { useTracking } from "../../../contexts/TrackingProvider"
-import { fontSizes, fonts } from "../../../styles/typography"
+import { fontSizes, fonts, type } from "../../../styles/typography"
 import { DatabaseStats } from "../../../types/global"
 import { getQueueColor } from "../../../utils/queueStatus"
 import { space } from "../../../constants"
@@ -90,8 +90,7 @@ const styles = StyleSheet.create({
     marginBottom: 6
   },
   statValue: {
-    fontSize: fontSizes.statValue,
-    ...fonts.bold,
+    ...type.figure,
     letterSpacing: -0.5,
     marginBottom: 2
   }

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -8,7 +8,7 @@ import { Text, StyleSheet, View, Pressable } from "react-native"
 import { Check, ChevronRight } from "lucide-react-native"
 import { Settings, ThemeColors } from "../../../types/global"
 import { useTracking } from "../../../contexts/TrackingProvider"
-import { fontSizes, fonts } from "../../../styles/typography"
+import { fontSizes, fonts, type } from "../../../styles/typography"
 import { Button } from "../../ui/Button"
 import { Card } from "../../ui/Card"
 import { size, space } from "../../../constants"
@@ -125,8 +125,7 @@ const styles = StyleSheet.create({
     marginBottom: space.lg
   },
   title: {
-    fontSize: fontSizes.cardTitle,
-    ...fonts.bold,
+    ...type.title,
     marginBottom: space.xs
   },
   subtitle: {

--- a/apps/mobile/src/components/features/settings/StatsCard.tsx
+++ b/apps/mobile/src/components/features/settings/StatsCard.tsx
@@ -9,7 +9,7 @@ import { useTracking } from "../../../contexts/TrackingProvider"
 import { useTheme } from "../../../hooks/useTheme"
 import { getQueueColor } from "../../../utils/queueStatus"
 import { formatCount } from "../../../utils/format"
-import { fontSizes, fonts } from "../../../styles/typography"
+import { fontSizes, fonts, type } from "../../../styles/typography"
 import { CRITICAL_QUEUE_THRESHOLD, HIGH_QUEUE_THRESHOLD, size, space } from "../../../constants"
 import { radius } from "@colota/shared"
 
@@ -154,8 +154,7 @@ const styles = StyleSheet.create({
     marginBottom: space.sm
   },
   statValue: {
-    fontSize: fontSizes.statValue,
-    ...fonts.bold,
+    ...type.figure,
     letterSpacing: -0.5
   },
   unit: {

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -7,7 +7,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react"
 import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-native"
 import { Info, CircleAlert, TriangleAlert, CircleCheckBig } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fontSizes, fonts } from "../../styles/typography"
+import { fontSizes, fonts, type } from "../../styles/typography"
 import { radius } from "@colota/shared"
 import { type ModalRequest, type AlertVariant, registerModalHandler } from "../../services/modalService"
 import { space, STATE_LAYER_ALPHA } from "../../constants"
@@ -152,8 +152,7 @@ const styles = StyleSheet.create({
     marginBottom: space.lg
   },
   title: {
-    fontSize: fontSizes.cardTitle,
-    ...fonts.bold,
+    ...type.title,
     textAlign: "center",
     marginBottom: space.md
   },

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react"
 import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fontSizes, fonts } from "../../styles/typography"
+import { fontSizes, fonts, type } from "../../styles/typography"
 import { radius } from "@colota/shared"
 import { space, STATE_LAYER_ALPHA } from "../../constants"
 
@@ -123,8 +123,7 @@ const styles = StyleSheet.create({
     marginBottom: space.lg
   },
   title: {
-    fontSize: fontSizes.cardTitle,
-    ...fonts.bold,
+    ...type.title,
     textAlign: "center",
     marginBottom: space.lg
   },

--- a/apps/mobile/src/components/ui/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ui/ErrorBoundary.tsx
@@ -7,7 +7,7 @@ import { View, Text, StyleSheet } from "react-native"
 import { ThemeColors } from "../../types/global"
 import { useTheme } from "../../hooks/useTheme"
 import { logger } from "../../utils/logger"
-import { fonts, fontSizes } from "../../styles/typography"
+import { fontSizes, type } from "../../styles/typography"
 
 import { Button } from "./Button"
 
@@ -75,8 +75,7 @@ const styles = StyleSheet.create({
     padding: 20
   },
   errorTitle: {
-    fontSize: fontSizes.screenTitle,
-    ...fonts.bold,
+    ...type.display,
     marginBottom: 10
   },
   errorMessage: {

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -8,7 +8,7 @@ import { Text, StyleSheet, View, ScrollView, Image } from "react-native"
 import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
 import { Copy, Check } from "lucide-react-native"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, type } from "../styles/typography"
 import { Button, Card, Container, Divider, SectionTitle, Footer } from "../components"
 import { useTimeout } from "../hooks/useTimeout"
 import NativeLocationService from "../services/NativeLocationService"
@@ -249,8 +249,7 @@ const styles = StyleSheet.create({
     height: 80
   },
   title: {
-    fontSize: fontSizes.screenTitle,
-    ...fonts.bold,
+    ...type.display,
     marginBottom: space.xs
   },
   version: {

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -17,7 +17,7 @@ import {
 import { useFocusEffect } from "@react-navigation/native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Share2, Search, X, ArrowDown } from "lucide-react-native"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, type } from "../styles/typography"
 import { Container, EmptyState, SectionTitle } from "../components"
 import { Tab } from "../components/ui/Tab"
 import { FileLoggingPanel } from "../components/features/log/FileLoggingPanel"
@@ -369,10 +369,7 @@ const styles = StyleSheet.create({
     ...fonts.semiBold
   },
   logText: {
-    ...fonts.regular,
-    fontSize: fontSizes.caption,
-    fontFamily: "monospace",
-    lineHeight: 18
+    ...type.mono
   },
   centered: {
     flex: 1,

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -21,7 +21,7 @@ import { useAutoSave } from "../hooks/useAutoSave"
 import { useTimeout } from "../hooks/useTimeout"
 import { useTracking } from "../contexts/TrackingProvider"
 import NativeLocationService from "../services/NativeLocationService"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, type } from "../styles/typography"
 import {
   SectionTitle,
   FloatingSaveIndicator,
@@ -855,9 +855,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.sm
   },
   exampleCode: {
-    fontSize: fontSizes.caption,
-    fontFamily: "monospace",
-    lineHeight: 18
+    ...type.mono
   },
   footer: {
     paddingVertical: space.lg,

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -60,27 +60,30 @@ function restoreErrorMessage(e: unknown): string {
 }
 
 type PasswordFieldProps = {
+  /** Omitted in the restore prompt, where the modal's own title names the field. */
+  label?: string
   value: string
   onChangeText: (v: string) => void
   placeholder: string
   editable: boolean
   autoComplete: "password" | "new-password"
+  error?: string
 }
 
-function PasswordField({ value, onChangeText, placeholder, editable, autoComplete }: PasswordFieldProps) {
-  return (
-    <TextField
-      accessibilityLabel={placeholder}
-      secure
-      value={value}
-      onChangeText={onChangeText}
-      placeholder={placeholder}
-      autoCapitalize="none"
-      autoCorrect={false}
-      autoComplete={autoComplete}
-      disabled={!editable}
-    />
-  )
+function PasswordField({ label, value, onChangeText, placeholder, editable, autoComplete, error }: PasswordFieldProps) {
+  const field = {
+    error,
+    secure: true,
+    value,
+    onChangeText,
+    placeholder,
+    autoCapitalize: "none" as const,
+    autoCorrect: false,
+    autoComplete,
+    disabled: !editable
+  }
+
+  return label ? <TextField label={label} {...field} /> : <TextField accessibilityLabel={placeholder} {...field} />
 }
 
 function PasswordPromptModal({
@@ -267,42 +270,44 @@ export function BackupRestoreScreen({}: Props) {
               Bundle your locations, settings and credentials into a single encrypted file you can store anywhere.
             </Text>
 
-            <Text style={[styles.fieldLabel, { color: colors.text }]}>Password</Text>
-            <PasswordField
-              value={backupPassword}
-              onChangeText={setBackupPassword}
-              placeholder={`At least ${MIN_BACKUP_PASSWORD_LENGTH} characters`}
-              editable={busy === null}
-              autoComplete="new-password"
-            />
-            {backupPassword.length > 0 && (
-              <View style={styles.strengthRow}>
-                <View style={styles.strengthBar}>
-                  {Array.from({ length: SEGMENT_COUNT }).map((_, i) => (
-                    <View
-                      key={i}
-                      style={[
-                        styles.strengthSegment,
-                        {
-                          backgroundColor: i < strength.score ? meterColor : colors.borderLight
-                        }
-                      ]}
-                    />
-                  ))}
+            <View style={styles.fieldGroup}>
+              <PasswordField
+                label="Password"
+                value={backupPassword}
+                onChangeText={setBackupPassword}
+                placeholder={`At least ${MIN_BACKUP_PASSWORD_LENGTH} characters`}
+                editable={busy === null}
+                autoComplete="new-password"
+              />
+              {backupPassword.length > 0 && (
+                <View style={styles.strengthRow}>
+                  <View style={styles.strengthBar}>
+                    {Array.from({ length: SEGMENT_COUNT }).map((_, i) => (
+                      <View
+                        key={i}
+                        style={[
+                          styles.strengthSegment,
+                          {
+                            backgroundColor: i < strength.score ? meterColor : colors.borderLight
+                          }
+                        ]}
+                      />
+                    ))}
+                  </View>
+                  <Text style={[styles.strengthLabel, { color: meterColor }]}>{strength.label}</Text>
                 </View>
-                <Text style={[styles.strengthLabel, { color: meterColor }]}>{strength.label}</Text>
-              </View>
-            )}
+              )}
 
-            <Text style={[styles.fieldLabel, { color: colors.text }]}>Confirm password</Text>
-            <PasswordField
-              value={confirmPassword}
-              onChangeText={setConfirmPassword}
-              placeholder="Re-enter the same password"
-              editable={busy === null}
-              autoComplete="new-password"
-            />
-            {showMismatch && <Text style={[styles.errorText, { color: colors.error }]}>Passwords do not match.</Text>}
+              <PasswordField
+                label="Confirm password"
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+                placeholder="Re-enter the same password"
+                editable={busy === null}
+                autoComplete="new-password"
+                error={showMismatch ? "Passwords do not match." : undefined}
+              />
+            </View>
 
             <Text style={[styles.hint, { color: colors.textSecondary }]}>
               A random password from a password manager or a long passphrase is safest. Common words and phrases are
@@ -353,15 +358,13 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.body,
     lineHeight: 20
   },
-  fieldLabel: {
-    fontSize: fontSizes.body,
-    fontWeight: "500",
+  fieldGroup: {
+    gap: space.lg,
     marginBottom: space.sm
   },
   strengthRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: space.md,
     gap: space.sm
   },
   strengthBar: {
@@ -379,11 +382,6 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     minWidth: 60,
     textAlign: "right"
-  },
-  errorText: {
-    fontSize: fontSizes.caption,
-    marginTop: -4,
-    marginBottom: space.sm
   },
   hint: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -23,7 +23,7 @@ import { useTheme } from "../hooks/useTheme"
 import { DailyStat } from "../types/global"
 import NativeLocationService from "../services/NativeLocationService"
 import { formatDistance, formatDuration, startOfDaySec } from "../utils/geo"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, type } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { size, space } from "../constants"
 
@@ -292,8 +292,7 @@ const styles = StyleSheet.create({
     gap: 2
   },
   summaryValue: {
-    fontSize: fontSizes.heading,
-    ...fonts.bold
+    ...type.heading
   },
   summaryLabel: {
     fontSize: fontSizes.micro,

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -8,7 +8,7 @@ import { View, Text, ScrollView, StyleSheet } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Button, Card, Container, SectionTitle, Toggle } from "../components"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, type } from "../styles/typography"
 import { CircleAlert, CircleCheckBig, Import } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
@@ -259,8 +259,7 @@ const styles = StyleSheet.create({
     flex: 1
   },
   title: {
-    fontSize: fontSizes.heading,
-    ...fonts.bold
+    ...type.heading
   },
   subtitle: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -19,7 +19,7 @@ import {
   type LucideIcon
 } from "lucide-react-native"
 import { useTheme } from "../hooks/useTheme"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, type } from "../styles/typography"
 import { Button } from "../components/ui/Button"
 import { Card } from "../components/ui/Card"
 import { Container } from "../components/ui/Container"
@@ -465,8 +465,7 @@ const styles = StyleSheet.create({
     borderRadius: 6
   },
   title: {
-    fontSize: fontSizes.cardTitle,
-    ...fonts.bold
+    ...type.title
   },
   subtitle: {
     fontSize: fontSizes.description,

--- a/apps/mobile/src/styles/typography.ts
+++ b/apps/mobile/src/styles/typography.ts
@@ -7,9 +7,9 @@
  */
 
 import { TextStyle } from "react-native"
-import { fontFamily } from "@colota/shared"
+import { fontFamily, fontSizes } from "@colota/shared"
 
-export { fontSizes } from "@colota/shared"
+export { fontSizes }
 
 export const fonts: Record<string, Pick<TextStyle, "fontFamily">> = {
   regular: { fontFamily: `${fontFamily}-Regular` },
@@ -17,3 +17,22 @@ export const fonts: Record<string, Pick<TextStyle, "fontFamily">> = {
   semiBold: { fontFamily: `${fontFamily}-SemiBold` },
   bold: { fontFamily: `${fontFamily}-Bold` }
 }
+
+/**
+ * A role is a size and everything that always travels with it, so a caller names the job rather
+ * than composing one. Only the sizes that are used at a single weight across the app are roles:
+ * `body`, `description` and `caption` are each used at three or four weights, so a role for them
+ * would pick a weight for call sites that disagree. Those keep composing `fontSizes` by hand.
+ */
+export const type = {
+  /** The one screen-owning number or title, as on About and the error boundary. */
+  display: { fontSize: fontSizes.screenTitle, ...fonts.bold },
+  /** A stat's value. Tabular so the digits do not jitter as it counts. */
+  figure: { fontSize: fontSizes.statValue, ...fonts.bold, fontVariant: ["tabular-nums"] },
+  /** A card or dialog title. */
+  title: { fontSize: fontSizes.cardTitle, ...fonts.bold },
+  /** A heading inside a screen, above a block rather than a group of rows. */
+  heading: { fontSize: fontSizes.heading, ...fonts.bold },
+  /** A block of code, a log line or a payload: the platform monospace, never Inter. */
+  mono: { fontSize: fontSizes.caption, fontFamily: "monospace", lineHeight: 18 }
+} as const satisfies Record<string, TextStyle>


### PR DESCRIPTION
A role carries a size and everything that always travels with it. `screenTitle`, `statValue`, `cardTitle` and `heading` are each used at exactly one weight across the app, so they become `display`, `figure`, `title` and `heading`. `mono` takes the size the two code blocks already shared. Thirteen styles adopt them.

The other seven sizes keep composing `fontSizes` by hand: `caption` is used in nine distinct size, weight and line-height combinations, `description` at five weights, `body` at four. A role for those picks a weight for the sites that disagree, which changes the screen rather than the source.

`figure` adds tabular figures to the two stat values, which is the only visual change. `coord` was written and dropped: nothing matches it, and adding it would change the coordinate display.

`BackupRestoreScreen` labelled its fields with its own `Text` above a local `PasswordField` wrapper, leaving no space between the password field and the confirm label. The wrapper takes `label`, the pair takes `gap: space.lg`, and three now-dead styles go with it. `fieldSpacingGuard` matched `<TextField` only and missed the wrapper; it matches any `*Field` tag now.