### PR TITLE
fix(ui): render the loading overlay in a modal

### DIFF
--- a/apps/mobile/src/components/ui/LoadingOverlay.tsx
+++ b/apps/mobile/src/components/ui/LoadingOverlay.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import { ActivityIndicator, StyleSheet, Text, View } from "react-native"
+import { ActivityIndicator, Modal, StyleSheet, Text, View } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { space } from "../../constants"
@@ -19,24 +19,21 @@ export function LoadingOverlay({ visible, title, message }: Props) {
   const { colors } = useTheme()
   if (!visible) return null
   return (
-    <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
-      <View style={[styles.card, { backgroundColor: colors.card }]}>
-        <ActivityIndicator size="large" color={colors.primary} />
-        <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
-        {message ? <Text style={[styles.message, { color: colors.textSecondary }]}>{message}</Text> : null}
+    <Modal visible transparent animationType="fade" statusBarTranslucent>
+      <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
+        <View style={[styles.card, { backgroundColor: colors.card }]}>
+          <ActivityIndicator size="large" color={colors.primary} />
+          <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+          {message ? <Text style={[styles.message, { color: colors.textSecondary }]}>{message}</Text> : null}
+        </View>
       </View>
-    </View>
+    </Modal>
   )
 }
 
 const styles = StyleSheet.create({
   overlay: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: 999,
+    flex: 1,
     justifyContent: "center",
     alignItems: "center"
   },

--- a/apps/mobile/src/components/ui/__tests__/LoadingOverlay.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/LoadingOverlay.test.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { Modal } from "react-native"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { LoadingOverlay } from "../LoadingOverlay"
+
+describe("LoadingOverlay", () => {
+  it("renders nothing until it is asked to", () => {
+    const { queryByText, UNSAFE_queryAllByType } = render(<LoadingOverlay visible={false} title="Importing" />)
+
+    expect(queryByText("Importing")).toBeNull()
+    expect(UNSAFE_queryAllByType(Modal)).toHaveLength(0)
+  })
+
+  it("covers the header too, which an overlay inside the screen cannot", () => {
+    // Import and export run for minutes. Drawn as an absolute View it stopped at the screen's own
+    // tree, leaving the stack's back arrow live and the job navigable out from under.
+    const { getByText, UNSAFE_getByType } = render(
+      <LoadingOverlay visible title="Importing" message="1,204 of 8,000" />
+    )
+
+    expect(UNSAFE_getByType(Modal).props.transparent).toBe(true)
+    expect(getByText("Importing")).toBeTruthy()
+    expect(getByText("1,204 of 8,000")).toBeTruthy()
+  })
+})


### PR DESCRIPTION
LoadingOverlay was an absolutely positioned View at zIndex 999. That covers the screen body but not the stack header, so during an import or export the back arrow stayed live and hardware back was not caught.

It renders in a transparent Modal now, matching AppModal and DisclosureModal, and the overlay style drops from an absolute fill to flex 1. The scrim and card are unchanged.

Adds a test file; it had none, and ImportLocationsScreen has none either.