### PR TITLE
feat(theme): every colour pair clears its contrast floor

### DIFF
--- a/apps/mobile/src/__tests__/contrastGuard.test.ts
+++ b/apps/mobile/src/__tests__/contrastGuard.test.ts
@@ -52,22 +52,10 @@ const PAIRS: Pair[] = [
   ["primary", "well", UI]
 ]
 
-/** Measured 2026-09-06. Every one of these is a palette decision that has not been taken. */
+/** Empty on purpose: every pair clears its floor. A pin here is a palette decision not yet taken. */
 const DEFERRED: Record<string, Record<string, number>> = {
-  light: {
-    "textLight on background": 2.39,
-    "textLight on card": 2.64,
-    "textOnPrimary on primary": 3.74,
-    "primary on background": 3.39,
-    "primary on card": 3.74,
-    "info on background": 4.17
-  },
-  dark: {
-    "textLight on card": 3.89,
-    "primaryDark on card": 3.68,
-    "error on card": 3.95,
-    "info on card": 3.86
-  }
+  light: {},
+  dark: {}
 }
 
 function luminance(hex: string): number {

--- a/apps/mobile/src/components/ui/Toggle.tsx
+++ b/apps/mobile/src/components/ui/Toggle.tsx
@@ -21,13 +21,7 @@ type ToggleProps = {
  * track and thumb live here instead. Every switch takes the same hue: a semantic colour marks
  * a state, and a toggle being on is not a warning.
  */
-export function Toggle({
-  value,
-  onValueChange,
-  accessibilityLabel,
-  disabled = false,
-  testID
-}: ToggleProps) {
+export function Toggle({ value, onValueChange, accessibilityLabel, disabled = false, testID }: ToggleProps) {
   const { colors } = useTheme()
   return (
     <Switch
@@ -36,7 +30,7 @@ export function Toggle({
       onValueChange={onValueChange}
       disabled={disabled}
       accessibilityLabel={accessibilityLabel}
-      trackColor={{ false: undefined, true: colors.primary + "80" }}
+      trackColor={{ false: undefined, true: colors.primaryContainer }}
       thumbColor={value ? colors.primary : undefined}
     />
   )

--- a/apps/mobile/src/components/ui/__tests__/SectionTitle.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/SectionTitle.test.tsx
@@ -43,14 +43,10 @@ describe("SectionTitle", () => {
     expect(getByText("Tracking").props.accessibilityRole).toBe("header")
   })
 
-  it("keeps the arithmetic true: the heading clears AA where primary does not", () => {
+  it("keeps the arithmetic true: the heading clears AA on both surfaces", () => {
     for (const theme of [lightColors, darkColors]) {
       expect(ratio(theme.textSecondary, theme.background)).toBeGreaterThanOrEqual(AA)
       expect(ratio(theme.textSecondary, theme.card)).toBeGreaterThanOrEqual(AA)
     }
-
-    // The reason this component changed: primary fails on both light surfaces.
-    expect(ratio(lightColors.primary, lightColors.background)).toBeLessThan(AA)
-    expect(ratio(lightColors.primary, lightColors.card)).toBeLessThan(AA)
   })
 })

--- a/apps/mobile/src/components/ui/__tests__/Toggle.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Toggle.test.tsx
@@ -9,14 +9,16 @@ jest.mock("../../../hooks/useTheme", () => ({
 import { Toggle } from "../Toggle"
 
 describe("Toggle", () => {
-  it("paints the on state from the primary hue, which is what the twelve call sites each built by hand", () => {
+  it("puts the thumb on the container, not on its own colour at half alpha", () => {
     const { getByTestId } = render(
       <Toggle testID="t" value={true} onValueChange={jest.fn()} accessibilityLabel="Offline mode" />
     )
 
-    // RN resolves trackColor and thumbColor into these before they reach the platform.
+    // RN resolves trackColor and thumbColor into these before they reach the platform. The track
+    // was the accent at 50 percent, which left the thumb 2.4:1 against its own bar; the container
+    // takes that to 4.1 in light and 6.6 in dark.
     const el = getByTestId("t")
-    expect(el.props.onTintColor).toBe(lightColors.primary + "80")
+    expect(el.props.onTintColor).toBe(lightColors.primaryContainer)
     expect(el.props.thumbTintColor).toBe(lightColors.primary)
   })
 
@@ -42,7 +44,7 @@ describe("Toggle", () => {
     )
 
     const el = getByTestId("t")
-    expect(el.props.onTintColor).toBe(lightColors.primary + "80")
+    expect(el.props.onTintColor).toBe(lightColors.primaryContainer)
     expect(el.props.thumbTintColor).toBe(lightColors.primary)
   })
 

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -55,7 +55,7 @@ export interface ThemeColors {
 
 export const lightColors: ThemeColors = {
   // Brand (Teal)
-  primary: "#0d9488",
+  primary: "#0B7D73",
   primaryDark: "#115E59",
   primaryContainer: "#A5F8E9",
   onPrimaryContainer: "#115E59",
@@ -65,7 +65,7 @@ export const lightColors: ThemeColors = {
   success: "#2E7D32",
   warning: "#C2410C",
   error: "#D32F2F",
-  info: "#1976D2",
+  info: "#1870C8",
 
   // UI
   background: "#F1F4F6",
@@ -77,7 +77,7 @@ export const lightColors: ThemeColors = {
   // Text
   text: "#202124",
   textSecondary: "#5F6368",
-  textLight: "#9AA0A6",
+  textLight: "#697077",
   textDisabled: "#9AA0A6",
 
   // Border & divider
@@ -99,7 +99,7 @@ export const lightColors: ThemeColors = {
 export const darkColors: ThemeColors = {
   // Brand (Teal)
   primary: "#2DD4BF",
-  primaryDark: "#0d9488",
+  primaryDark: "#0FA698",
   primaryContainer: "#0F3B36",
   onPrimaryContainer: "#99F6E4",
   well: "#232323",
@@ -107,8 +107,8 @@ export const darkColors: ThemeColors = {
   // Status
   success: "#4CAF50",
   warning: "#FB923C",
-  error: "#EF5350",
-  info: "#4285F4",
+  error: "#F16765",
+  info: "#5793F5",
 
   // UI
   background: "#121212",
@@ -120,7 +120,7 @@ export const darkColors: ThemeColors = {
   // Text
   text: "#E8EAED",
   textSecondary: "#AAAAAA",
-  textLight: "#888888",
+  textLight: "#949494",
   textDisabled: "#666666",
 
   // Border & divider


### PR DESCRIPTION
The contrast guard landed with ten pinned failures. This clears all ten by moving seven values on the lightness axis, leaving hue and saturation alone, so no colour changes family.

| token | from | to |
| --- | --- | --- |
| light `primary` | `#0d9488` | `#0B7D73` |
| light `textLight` | `#9AA0A6` | `#697077` |
| light `info` | `#1976D2` | `#1870C8` |
| dark `textLight` | `#888888` | `#949494` |
| dark `primaryDark` | `#0d9488` | `#0FA698` |
| dark `error` | `#EF5350` | `#F16765` |
| dark `info` | `#4285F4` | `#5793F5` |

`textOnPrimary` is `#FFFFFF` and `card` is `#FFFFFF`, so white-on-primary and primary-on-card are one measurement: the teal fixes three pins.

Two are visible: `textLight` in light mode on chevrons and captions, and the accent one step deeper. The rest are at or below the just-noticeable threshold.

The toggle track was `primary` at 50 percent alpha, so the thumb sat 2.4:1 against its own bar. It is `primaryContainer` now, 4.1 in light and 6.6 in dark.

Checked on a device.