### PR TITLE
feat(profiles): delete a profile from its editor

### DIFF
--- a/apps/docs/docs/guides/tracking-profiles.md
+++ b/apps/docs/docs/guides/tracking-profiles.md
@@ -26,6 +26,8 @@ Tracking profiles automatically adjust GPS interval, distance filter, and sync s
 5. Set a priority (higher priority profiles take precedence when multiple conditions match)
 6. Tap **Create Profile** to save
 
+Tap a profile in the list to edit it.
+
 ## Condition Types
 
 | Condition       | Trigger                                                   |

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -8,14 +8,35 @@ import { View, Text, StyleSheet, ScrollView } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { ProfileService } from "../services/ProfileService"
-import { showAlert } from "../services/modalService"
+import { showAlert, showConfirm } from "../services/modalService"
 import { TrackingProfile, ProfileConditionType } from "../types/global"
 import { fontSizes, fonts } from "../styles/typography"
-import { Button, Card, ChipGroup, Container, Divider, FieldMessage, NumericInput, RadioRow, SectionTitle, SettingRow, TextField } from "../components"
-import { Check } from "lucide-react-native"
+import {
+  Button,
+  Card,
+  ChipGroup,
+  Container,
+  Divider,
+  FieldMessage,
+  NumericInput,
+  RadioRow,
+  SectionTitle,
+  SettingRow,
+  TextField
+} from "../components"
+import { Check, Trash2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
-import { MS_TO_KMH, PROFILE_CONDITIONS, STATIONARY_MAX_INTERVAL_SECONDS, SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, defaultProfileDelays, size, space } from "../constants"
+import {
+  MS_TO_KMH,
+  PROFILE_CONDITIONS,
+  STATIONARY_MAX_INTERVAL_SECONDS,
+  SYNC_INTERVAL_LABELS,
+  SYNC_INTERVAL_PRESETS,
+  defaultProfileDelays,
+  size,
+  space
+} from "../constants"
 import type { RootScreenProps } from "../types/navigation"
 
 function formatSyncDefault(seconds: number): string {
@@ -139,6 +160,24 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
     }
   }, [])
 
+  const handleDelete = useCallback(async () => {
+    if (!profileId) return
+    const confirmed = await showConfirm({
+      title: "Delete profile",
+      message: `Delete "${profile.name}"?`,
+      confirmText: "Delete",
+      destructive: true
+    })
+    if (!confirmed) return
+    try {
+      await ProfileService.deleteProfile(profileId)
+      navigation.goBack()
+    } catch (err) {
+      logger.error("[ProfileEditor] Delete failed:", err)
+      showAlert("Error", "Failed to delete profile.", "error")
+    }
+  }, [profileId, profile.name, navigation])
+
   const handleSave = useCallback(async () => {
     if (!profile.name.trim()) {
       showAlert("Missing Name", "Please enter a profile name.", "warning")
@@ -172,7 +211,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
   const isSpeed = profile.condition.type === "speed_above" || profile.condition.type === "speed_below"
   const isCustomSyncInterval = !SYNC_INTERVAL_PRESETS.includes(profile.syncInterval)
-
 
   return (
     <Container>
@@ -426,6 +464,15 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
           loading={saving}
           onPress={handleSave}
         />
+        {isEditing && (
+          <Button
+            testID="delete-profile-btn"
+            title="Delete profile"
+            icon={Trash2}
+            variant="danger"
+            onPress={handleDelete}
+          />
+        )}
       </ScrollView>
     </Container>
   )

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -22,19 +22,23 @@ const mockProfiles: TrackingProfile[] = [
 const mockGetProfiles = jest.fn().mockResolvedValue(mockProfiles)
 const mockCreateProfile = jest.fn().mockResolvedValue(1)
 const mockUpdateProfile = jest.fn().mockResolvedValue(true)
+const mockDeleteProfile = jest.fn().mockResolvedValue(true)
 
 jest.mock("../../services/ProfileService", () => ({
   ProfileService: {
     getProfiles: () => mockGetProfiles(),
     createProfile: (p: any) => mockCreateProfile(p),
-    updateProfile: (p: any) => mockUpdateProfile(p)
+    updateProfile: (p: any) => mockUpdateProfile(p),
+    deleteProfile: (id: number) => mockDeleteProfile(id)
   }
 }))
 
 const mockShowAlert = jest.fn()
+const mockShowConfirm = jest.fn()
 
 jest.mock("../../services/modalService", () => ({
-  showAlert: (...args: any[]) => mockShowAlert(...args)
+  showAlert: (...args: any[]) => mockShowAlert(...args),
+  showConfirm: (...args: any[]) => mockShowConfirm(...args)
 }))
 
 jest.mock("../../utils/geo", () => ({
@@ -475,6 +479,41 @@ describe("ProfileEditorScreen", () => {
         expect(getByDisplayValue("3600")).toBeTruthy()
       })
       expect(getByText(/may miss the first \d+ minutes of a trip/)).toBeTruthy()
+    })
+  })
+
+  describe("delete", () => {
+    it("offers Delete only while editing, since a draft has nothing to remove", async () => {
+      const { queryByTestId } = renderNewProfile()
+
+      await waitFor(() => expect(queryByTestId("delete-profile-btn")).toBeNull())
+    })
+
+    it("confirms before deleting, then leaves the screen", async () => {
+      // The list could delete a profile and the editor could not, so a profile opened for editing
+      // had to be backed out of and found again.
+      mockShowConfirm.mockResolvedValue(true)
+      const { getByTestId } = renderEditProfile(1)
+
+      await waitFor(() => expect(getByTestId("delete-profile-btn")).toBeTruthy())
+      fireEvent.press(getByTestId("delete-profile-btn"))
+
+      await waitFor(() => {
+        expect(mockDeleteProfile).toHaveBeenCalledWith(1)
+        expect(mockGoBack).toHaveBeenCalled()
+      })
+    })
+
+    it("deletes nothing when the confirm is dismissed", async () => {
+      mockShowConfirm.mockResolvedValue(false)
+      const { getByTestId } = renderEditProfile(1)
+
+      await waitFor(() => expect(getByTestId("delete-profile-btn")).toBeTruthy())
+      fireEvent.press(getByTestId("delete-profile-btn"))
+
+      await waitFor(() => expect(mockShowConfirm).toHaveBeenCalled())
+      expect(mockDeleteProfile).not.toHaveBeenCalled()
+      expect(mockGoBack).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
The geofence editor ends with a danger Delete and the profile editor did not, so a profile opened for editing had to be backed out of and deleted from the list. The editor gets the same control, shown only when editing, confirming through showConfirm before returning to the list.

The sticky Save footer the plan pairs with it is not built: a floating footer overlays the scroll content, so the last rows are reachable only if the container pays bottom padding equal to its height. Both editors keep Save as the final child of the scroll view.