### PR TITLE
fix(ui): bound the tab bar ripple to the tab

### DIFF
--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -64,7 +64,7 @@ export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
             accessibilityRole="tab"
             accessibilityState={{ selected: active }}
             accessibilityLabel={tab.label}
-            android_ripple={{ color: colors.text + STATE_LAYER_ALPHA, borderless: true, radius: size.touch / 2 }}
+            android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
             style={styles.tab}
             onPress={() => onNavigate(tab.route)}
           >
@@ -79,7 +79,6 @@ export function BottomTabBar({ currentRoute, onNavigate }: BottomTabBarProps) {
     </View>
   )
 }
-
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
The tab passed borderless with a radius of half the touch target, which draws a disc centred on the item and is free to spill past the bar's top edge. That recipe belongs to IconButton, which is a round control; a tab is a full-width cell with an icon and a label.

The ripple takes the cell's own bounds now, which is the rule PR 711 set for every other primitive.

No test: react-native strips android_ripple from the host view and Pressable does not match by type in the renderer, so the shape is only visible on a device.