### PR TITLE
fix(theme): quieten the primary container to a tint

### DIFF
--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -57,7 +57,7 @@ export const lightColors: ThemeColors = {
   // Brand (Teal)
   primary: "#0B7D73",
   primaryDark: "#115E59",
-  primaryContainer: "#A5F8E9",
+  primaryContainer: "#B9E4DC",
   onPrimaryContainer: "#115E59",
   well: "#E9EDF0",
 


### PR DESCRIPTION
primaryContainer was hue 169 at 86 percent saturation and 81 percent lightness, a vivid mint rather than a tint, against a primary at 84 and 32 in the same family. It paints the selected chip, the secondary button, the toggle track, the selected trip row, the active profile card and the calendar's viewed cell, so it was the loudest surface in the app.

Same hue and lightness at 45 percent saturation. onPrimaryContainer on it goes from 6.21 to 5.49 and still clears AA, the toggle thumb reaches 3.62 against its track, and the fill still separates from card and ground at 1.38 and 1.25.

Dark is unchanged: 0F3B36 was already a tint.