### PR TITLE
fix(backup): the restore dialog's cancel matches the other dialogs

### DIFF
--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -132,7 +132,7 @@ function PasswordPromptModal({
           />
           <View style={styles.modalButtonsRow}>
             <View style={styles.modalButton}>
-              <Button title="Cancel" onPress={onCancel} disabled={busy} variant="secondary" />
+              <Button title="Cancel" onPress={onCancel} disabled={busy} variant="ghost" color={colors.textSecondary} />
             </View>
             <View style={styles.modalButton}>
               <Button


### PR DESCRIPTION
AppModal and DisclosureModal draw a dismissal as transparent text in textSecondary. The restore password dialog builds its own Modal and used Button's secondary variant, a primaryContainer fill, so the same role looked like a filled button in one dialog and a text button in the other two.

Button's secondary stays a tonal fill for full-width row actions, which is what it is for elsewhere.