### PR TITLE
fix(auto-export): enqueue Export now as unique work

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportScheduler.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/export/AutoExportScheduler.kt
@@ -10,6 +10,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.WorkerThread
+import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.Colota.data.DatabaseHelper
@@ -55,7 +56,8 @@ object AutoExportScheduler {
         val request = OneTimeWorkRequestBuilder<AutoExportWorker>()
             .addTag(IMMEDIATE_WORK_TAG)
             .build()
-        WorkManager.getInstance(context.applicationContext).enqueue(request)
+        WorkManager.getInstance(context.applicationContext)
+            .enqueueUniqueWork(IMMEDIATE_WORK_TAG, ExistingWorkPolicy.KEEP, request)
         AppLogger.i(TAG, "Enqueued immediate auto-export")
     }
 

--- a/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportSchedulerTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/export/AutoExportSchedulerTest.kt
@@ -115,6 +115,16 @@ class AutoExportSchedulerTest {
     }
 
     @Test
+    fun `a second Export now while one is queued does not enqueue a second run`() {
+        // Each run writes its own file, so a double tap produced two exports a second apart.
+        AutoExportScheduler.runNow(context)
+        AutoExportScheduler.runNow(context)
+
+        val wm = WorkManager.getInstance(context)
+        assertEquals(1, wm.getWorkInfosByTag(AutoExportWorker::class.java.name).get().size)
+    }
+
+    @Test
     fun `the alarm receiver re-arms the alarm before enqueuing so a failed enqueue cannot end the schedule`() {
         mockkObject(AutoExportScheduler)
         every { AutoExportScheduler.enqueueScheduled(any()) } throws RuntimeException("WorkManager not initialized")


### PR DESCRIPTION
runNow used a bare enqueue, so a double tap queued two exports and wrote two files a second apart. It is unique work under IMMEDIATE_WORK_TAG with ExistingWorkPolicy.KEEP now.

A manual run alongside a scheduled one is still not de-duplicated, which the guide records as intended: each run writes its own temp file, so overlapping workers cannot truncate each other. cancel works by the worker's class tag, so the unique name never hides work from it.