### PR TITLE
fix(ui): every SettingRow takes the same height

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -401,11 +401,7 @@ export function SyncStrategySettings({
             <View style={styles.paramGroup}>
               <SectionTitle>Quality filters</SectionTitle>
 
-              <SettingRow
-                style={styles.firstInGroup}
-                label="Filter inaccurate locations"
-                hint="Reject fixes the GPS chip reports as imprecise"
-              >
+              <SettingRow label="Filter inaccurate locations" hint="Reject fixes the GPS chip reports as imprecise">
                 <Toggle
                   accessibilityLabel="Filter inaccurate locations"
                   value={settings.filterInaccurateLocations}
@@ -472,15 +468,9 @@ const styles = StyleSheet.create({
   paramGroup: {
     marginBottom: space.xs
   },
-  // A block is a row whose control wraps below the label rather than sitting beside it. It
-  // pays nothing on top: the heading's own margin is the whole gap, so every group under a
-  // heading starts at the same distance whatever its first element is.
   settingBlock: {
+    paddingTop: space.lg,
     paddingBottom: space.lg
-  },
-  // SettingRow pads itself, which would double the gap when it is the first thing in a group.
-  firstInGroup: {
-    paddingTop: 0
   },
   blockLabel: {
     fontSize: fontSizes.label,
@@ -493,8 +483,6 @@ const styles = StyleSheet.create({
     marginBottom: space.md,
     lineHeight: 18
   },
-  // A dependent control lines up with its parent's text; position carries the relationship,
-  // so there is no rule to draw.
   nestedSetting: {
     marginTop: space.md,
     marginStart: space.lg

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -208,7 +208,6 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
     }
   }, [geofenceId, name, navigation])
 
-
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
@@ -240,7 +239,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
 
         <SectionTitle>GPS pause options</SectionTitle>
         <Card rows style={[styles.card, styles.cardTail]}>
-          <SettingRow label="Don't record in zone" hint="Pause saving and syncing" style={styles.toggleRow}>
+          <SettingRow label="Don't record in zone" hint="Pause saving and syncing">
             <Toggle
               accessibilityLabel="Don't record in zone"
               testID="pause-tracking-toggle"
@@ -249,12 +248,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
             />
           </SettingRow>
 
-          <SettingRow
-            label="WiFi/Ethernet pause"
-            hint="Stop GPS on unmetered networks"
-            style={styles.toggleRow}
-            disabled={!pauseTracking}
-          >
+          <SettingRow label="WiFi/Ethernet pause" hint="Stop GPS on unmetered networks" disabled={!pauseTracking}>
             <Toggle
               accessibilityLabel="WiFi/Ethernet pause"
               testID="pause-wifi-toggle"
@@ -264,12 +258,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
             />
           </SettingRow>
 
-          <SettingRow
-            label="Motionless pause"
-            hint="Stop GPS after no motion for a set time"
-            style={styles.toggleRow}
-            disabled={!pauseTracking}
-          >
+          <SettingRow label="Motionless pause" hint="Stop GPS after no motion for a set time" disabled={!pauseTracking}>
             <Toggle
               accessibilityLabel="Motionless pause"
               testID="pause-motionless-toggle"
@@ -302,7 +291,6 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           <SettingRow
             label="Stationary heartbeat"
             hint="Periodic point at the zone center while paused"
-            style={styles.toggleRow}
             disabled={!pauseTracking}
           >
             <Toggle
@@ -362,15 +350,11 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
 }
 
 const styles = StyleSheet.create({
-  // rows drops the card\'s vertical padding for the first row; the last child
-  // here is not a row, so it takes the bottom inset back.
   cardTail: { paddingBottom: space.lg },
   content: { padding: 20, paddingBottom: 40 },
   card: { marginBottom: space.lg },
   nameInput: { flex: 1 },
   numInput: { width: size.numericField },
-  toggleRow: { paddingVertical: 10 },
-  // See SyncStrategySettings: a dependent control indents, it does not get a rule.
   nestedSetting: {
     marginTop: space.md,
     marginStart: space.lg


### PR DESCRIPTION
Two screens shortened rows with a padding override. The geofence editor's four pause toggles paid 10 instead of 16, putting two-line rows near 61, and its own Timeout and Interval rows had no override, so the run changed height mid-card. The sync settings' first quality filter paid nothing on top, which left it near 57 with its text sitting against the top edge rather than centred.

Both are now the default 56 one-line and 73 two-line, which is Material's list item. The sync override existed to line every group up under its heading whatever its first element was; settingBlock takes the same top inset instead, so that still holds without shortening a row.

The values sat outside the space scale, so designSystemGuard could not see either one.
