### PR TITLE
fix(export): the format rows carry one selection signal

### DIFF
--- a/apps/mobile/src/components/ui/FormatOption.tsx
+++ b/apps/mobile/src/components/ui/FormatOption.tsx
@@ -10,7 +10,6 @@ import { fontSizes, fonts } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
 import { RadioDot } from "./RadioDot"
 import { size, space, STATE_LAYER_ALPHA } from "../../constants"
-import { radius } from "@colota/shared"
 
 export const FormatOption = ({
   icon: Icon,
@@ -38,37 +37,16 @@ export const FormatOption = ({
       onPress={onPress}
       accessibilityRole="radio"
       accessibilityState={{ checked: selected }}
+      accessibilityLabel={`${title}, ${extension}, ${subtitle}`}
     >
-      <View style={styles.formatContent}>
-        <View style={styles.leftContent}>
-          <Icon size={size.icon.md} color={colors.textLight} />
-          <View style={styles.textContent}>
-            <View style={styles.titleRow}>
-              <Text
-                style={[
-                  styles.formatTitle,
-                  selected ? { color: colors.primaryDark, ...fonts.bold } : { color: colors.text }
-                ]}
-              >
-                {title}
-              </Text>
-              <View
-                style={[
-                  styles.extensionBadge,
-                  {
-                    backgroundColor: selected ? colors.primary + "20" : colors.primary + "15"
-                  }
-                ]}
-              >
-                <Text style={[styles.extensionText, { color: colors.primaryDark }]}>{extension}</Text>
-              </View>
-            </View>
-            <Text style={[styles.formatSubtitle, { color: colors.textSecondary }]}>{subtitle}</Text>
-            <Text style={[styles.formatDescription, { color: colors.textLight }]}>{description}</Text>
-          </View>
-        </View>
-
-        <RadioDot selected={selected} />
+      <RadioDot selected={selected} />
+      <Icon size={size.icon.md} color={colors.textLight} />
+      <View style={styles.textContent}>
+        <Text style={[styles.formatTitle, { color: colors.text }]}>{title}</Text>
+        <Text style={[styles.formatSubtitle, { color: colors.textSecondary }]}>
+          {subtitle} · {extension}
+        </Text>
+        <Text style={[styles.formatDescription, { color: colors.textLight }]}>{description}</Text>
       </View>
     </Pressable>
   )
@@ -76,50 +54,27 @@ export const FormatOption = ({
 
 const styles = StyleSheet.create({
   formatOption: {
-    paddingVertical: space.sm,
-    borderRadius: radius.sm,
-    overflow: "hidden"
-  },
-  formatContent: {
-    flexDirection: "row",
-    alignItems: "center"
-  },
-  leftContent: {
-    flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    gap: space.lg
+    gap: space.md,
+    paddingVertical: space.md,
+    marginHorizontal: -space.lg,
+    paddingHorizontal: space.lg
   },
   textContent: {
     flex: 1
   },
-  titleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: space.sm,
-    marginBottom: 2
-  },
   formatTitle: {
     fontSize: fontSizes.label,
-    ...fonts.semiBold,
-    letterSpacing: -0.2
-  },
-  extensionBadge: {
-    paddingHorizontal: space.sm,
-    paddingVertical: 3,
-    borderRadius: 6
-  },
-  extensionText: {
-    fontSize: fontSizes.micro,
-    ...fonts.bold,
-    letterSpacing: 0.3
+    ...fonts.semiBold
   },
   formatSubtitle: {
     fontSize: fontSizes.description,
-    marginBottom: 2
+    marginTop: 2
   },
   formatDescription: {
     fontSize: fontSizes.caption,
-    lineHeight: 16
+    lineHeight: 16,
+    marginTop: 2
   }
 })

--- a/apps/mobile/src/components/ui/FormatSelector.tsx
+++ b/apps/mobile/src/components/ui/FormatSelector.tsx
@@ -20,7 +20,7 @@ export const FormatSelector = ({
     {(Object.entries(EXPORT_FORMATS) as [ExportFormat, (typeof EXPORT_FORMATS)[ExportFormat]][]).map(
       ([key, config], index) => (
         <React.Fragment key={key}>
-          {index > 0 && <Divider />}
+          {index > 0 && <Divider tight />}
           <FormatOption
             icon={config.icon}
             title={config.label}

--- a/apps/mobile/src/components/ui/__tests__/FormatOption.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/FormatOption.test.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+import { Globe } from "lucide-react-native"
+import { FormatOption } from "../FormatOption"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: jest.requireActual("@colota/shared").lightColors })
+}))
+
+function renderOption(selected = false) {
+  const onPress = jest.fn()
+  const view = render(
+    <FormatOption
+      icon={Globe}
+      title="GeoJSON"
+      subtitle="Geographic Data"
+      description="Mapbox, Leaflet, QGIS."
+      extension=".geojson"
+      selected={selected}
+      onPress={onPress}
+    />
+  )
+  return { ...view, onPress }
+}
+
+describe("FormatOption", () => {
+  it("carries the extension as text, so no badge paints the accent", () => {
+    const { getByText } = renderOption()
+
+    expect(getByText("Geographic Data · .geojson")).toBeTruthy()
+  })
+
+  it("marks selection with the dot alone, leaving the title one colour", () => {
+    const unselected = renderOption(false)
+    const selected = renderOption(true)
+
+    expect(unselected.getByText("GeoJSON").props.style).toEqual(selected.getByText("GeoJSON").props.style)
+  })
+
+  it("says what it is to a screen reader, including the extension the badge used to carry", () => {
+    const { getByRole } = renderOption(true)
+    const row = getByRole("radio")
+
+    expect(row.props.accessibilityLabel).toBe("GeoJSON, .geojson, Geographic Data")
+    expect(row.props.accessibilityState).toMatchObject({ checked: true })
+  })
+
+  it("reports the choice", () => {
+    const { getByRole, onPress } = renderOption()
+
+    fireEvent.press(getByRole("radio"))
+
+    expect(onPress).toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -441,7 +441,7 @@ export function AutoExportScreen(_props: ScreenProps) {
         {/* Format */}
         <View style={styles.section}>
           <SectionTitle>Format</SectionTitle>
-          <Card>
+          <Card rows>
             <FormatSelector selectedFormat={format} onSelectFormat={handleFormatChange} />
           </Card>
         </View>
@@ -686,7 +686,7 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingHorizontal: space.lg,
-    paddingBottom: 40
+    paddingBottom: space.xxl
   },
   header: {
     marginTop: 20,

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -79,7 +79,10 @@ export function ExportLocationsScreen({}: ScreenProps) {
 
   return (
     <Container>
-      <ScrollView contentContainerStyle={[styles.scrollContent, totalLocations === 0 && styles.scrollEmpty]} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        contentContainerStyle={[styles.scrollContent, totalLocations === 0 && styles.scrollEmpty]}
+        showsVerticalScrollIndicator={false}
+      >
         <Text style={[styles.intro, { color: colors.textSecondary }]}>
           {totalLocations.toLocaleString()} locations. Save them to a file, once
         </Text>
@@ -92,11 +95,10 @@ export function ExportLocationsScreen({}: ScreenProps) {
           />
         ) : (
           <>
-
             {/* Format Selection */}
             <View style={styles.section}>
               <SectionTitle>Select format</SectionTitle>
-              <Card>
+              <Card rows>
                 <FormatSelector selectedFormat={selectedFormat} onSelectFormat={setSelectedFormat} />
               </Card>
             </View>
@@ -132,8 +134,8 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingHorizontal: space.lg,
-    paddingTop: 20,
-    paddingBottom: 40
+    paddingTop: space.lg,
+    paddingBottom: space.xxl
   },
   // so an empty state has room to centre in
   scrollEmpty: { flexGrow: 1 },

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -86,18 +86,10 @@ const FormatRow = ({ entry, colors }: { entry: (typeof SUPPORTED_FORMATS)[number
     <View style={styles.formatRow}>
       <Icon size={size.icon.md} color={colors.textLight} />
       <View style={styles.formatTextContent}>
-        <View style={styles.formatTitleRow}>
-          <Text style={[styles.formatTitle, { color: colors.text }]}>{entry.title}</Text>
-          <View
-            style={[
-              styles.extensionBadge,
-              { backgroundColor: colors.primary + "15" }
-            ]}
-          >
-            <Text style={[styles.extensionText, { color: colors.primaryDark }]}>{entry.extension}</Text>
-          </View>
-        </View>
-        <Text style={[styles.formatDescription, { color: colors.textLight }]}>{entry.description}</Text>
+        <Text style={[styles.formatTitle, { color: colors.text }]}>{entry.title}</Text>
+        <Text style={[styles.formatDescription, { color: colors.textLight }]}>
+          {entry.extension} · {entry.description}
+        </Text>
       </View>
     </View>
   )
@@ -219,10 +211,10 @@ export function ImportLocationsScreen({}: ScreenProps) {
         {/* Supported formats */}
         <View style={styles.section}>
           <SectionTitle>Supported formats</SectionTitle>
-          <Card>
+          <Card rows>
             {SUPPORTED_FORMATS.map((entry, i) => (
               <React.Fragment key={entry.title}>
-                {i > 0 && <Divider />}
+                {i > 0 && <Divider tight />}
                 <FormatRow entry={entry} colors={colors} />
               </React.Fragment>
             ))}
@@ -254,8 +246,8 @@ export function ImportLocationsScreen({}: ScreenProps) {
 const styles = StyleSheet.create({
   scrollContent: {
     paddingHorizontal: space.lg,
-    paddingTop: 20,
-    paddingBottom: 40
+    paddingTop: space.lg,
+    paddingBottom: space.xxl
   },
   section: {
     marginBottom: space.xl
@@ -268,35 +260,19 @@ const styles = StyleSheet.create({
   formatRow: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 10,
-    gap: space.lg
+    paddingVertical: space.md,
+    gap: space.md
   },
   formatTextContent: {
     flex: 1
   },
-  formatTitleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: space.sm,
-    marginBottom: space.xs,
-    flexWrap: "wrap"
-  },
   formatTitle: {
-    fontSize: fontSizes.input,
-    ...fonts.semiBold,
-    letterSpacing: -0.2
-  },
-  extensionBadge: {
-    paddingHorizontal: space.sm,
-    paddingVertical: 3,
-    borderRadius: 6
-  },
-  extensionText: {
-    fontSize: fontSizes.micro,
-    ...fonts.bold
+    fontSize: fontSizes.label,
+    ...fonts.semiBold
   },
   formatDescription: {
     fontSize: fontSizes.caption,
-    lineHeight: 16
+    lineHeight: 16,
+    marginTop: 2
   }
 })


### PR DESCRIPTION
The format picker painted selection twice: a trailing radio dot and an accent-filled extension badge. The dot now leads the row, the extension reads as caption text next to the subtitle, and the import screen rows match on title size, text gap and card padding. Ripple fills the full card width. Adds the component test FormatOption never had.