### PR TITLE
feat(theme): line height comes from a token

### DIFF
--- a/apps/mobile/src/__tests__/lineHeightGuard.test.ts
+++ b/apps/mobile/src/__tests__/lineHeightGuard.test.ts
@@ -1,0 +1,77 @@
+// See designSystemGuard for why this file declares the node corner it needs by hand.
+declare const __dirname: string
+
+type Entry = { name: string; isDirectory: () => boolean }
+const fs: {
+  readdirSync: (dir: string, options: { withFileTypes: true }) => Entry[]
+  readFileSync: (file: string, encoding: "utf8") => string
+} = require("fs")
+const path: { join: (...parts: string[]) => string } = require("path")
+
+import { fontSizes, lineHeights } from "../styles/typography"
+
+/**
+ * A line height written per style drifts: 12sp text sat at 16, 17 and 18 across three screens, and
+ * no render test compares two files. Every one comes from `lineHeights`, with no exemption.
+ */
+const SRC = path.join(__dirname, "..")
+const ROOTS = ["screens", "components", "styles"]
+const SIZE_FOR: Record<keyof typeof lineHeights, keyof typeof fontSizes> = {
+  body: "body",
+  description: "description",
+  caption: "caption",
+  small: "small",
+  mono: "caption"
+}
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(path.join(SRC, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") walk(rel)
+      } else if (/\.tsx?$/.test(entry.name)) {
+        found.push(rel)
+      }
+    }
+  }
+  ROOTS.forEach(walk)
+  return found.sort()
+}
+
+describe("line height guard", () => {
+  const files = sourceFiles()
+
+  it("finds the files it is meant to police", () => {
+    const withLineHeights = files.filter((f) => /lineHeight:/.test(fs.readFileSync(path.join(SRC, f), "utf8")))
+
+    expect(withLineHeights).toContain("components/ui/SettingRow.tsx")
+    expect(withLineHeights).toContain("screens/ApiSettingsScreen.tsx")
+    expect(withLineHeights.length).toBeGreaterThan(20)
+  })
+
+  it("takes every line height from the token", () => {
+    const literals: string[] = []
+
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(SRC, file), "utf8")
+      for (const match of source.matchAll(/lineHeight:\s*(\d+)/g)) {
+        literals.push(`${file}: lineHeight: ${match[1]}`)
+      }
+    }
+
+    expect(literals).toEqual([])
+  })
+
+  it("keeps every token within Material's leading range for its size", () => {
+    const tight: string[] = []
+
+    for (const [name, height] of Object.entries(lineHeights)) {
+      const ratio = height / fontSizes[SIZE_FOR[name as keyof typeof lineHeights]]
+      if (ratio < 1.3 || ratio > 1.5) tight.push(`${name}: ${height} / ${ratio.toFixed(2)}x`)
+    }
+
+    expect(tight).toEqual([])
+  })
+})

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -9,7 +9,7 @@ import { TriangleAlert } from "lucide-react-native"
 import { LocationCoords } from "../../../types/global"
 import { useTheme } from "../../../hooks/useTheme"
 import { useCoords } from "../../../contexts/TrackingProvider"
-import { fontSizes, fonts, type } from "../../../styles/typography"
+import { fontSizes, fonts, lineHeights, type } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MAP_ANIMATION_DURATION_MS, MAX_MAP_ZOOM, space } from "../../../constants"
 import { MapCenterButton } from "../map/MapCenterButton"
@@ -274,7 +274,7 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.body,
     textAlign: "center",
     marginTop: space.sm,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   statusBar: {
     position: "absolute",

--- a/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
+++ b/apps/mobile/src/components/features/log/FileLoggingPanel.tsx
@@ -8,7 +8,7 @@ import { View, Text, StyleSheet, ScrollView, ActivityIndicator } from "react-nat
 import { Card, Divider, SectionTitle } from "../../index"
 import { Button } from "../../ui/Button"
 import { useTheme } from "../../../hooks/useTheme"
-import { fonts, fontSizes } from "../../../styles/typography"
+import { fonts, fontSizes, lineHeights } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { logger } from "../../../utils/logger"
 import { showAlert, showChoice } from "../../../services/modalService"
@@ -134,11 +134,7 @@ export function FileLoggingPanel() {
           <View style={styles.toggleLabel}>
             <Text style={[styles.label, { color: colors.text }]}>Persistent file logging</Text>
           </View>
-          <Toggle
-            accessibilityLabel="Persistent file logging"
-            value={enabled}
-            onValueChange={handleToggle}
-          />
+          <Toggle accessibilityLabel="Persistent file logging" value={enabled} onValueChange={handleToggle} />
         </View>
 
         <Divider />
@@ -176,7 +172,7 @@ const styles = StyleSheet.create({
   intro: {
     marginBottom: space.md,
     fontSize: fontSizes.body,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   toggleRow: {
     flexDirection: "row",
@@ -198,7 +194,7 @@ const styles = StyleSheet.create({
   hint: {
     fontSize: fontSizes.description,
     ...fonts.regular,
-    lineHeight: 18,
+    lineHeight: lineHeights.description,
     marginBottom: space.md
   },
   sizeRow: {

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -11,7 +11,7 @@ import NativeLocationService from "../../../services/NativeLocationService"
 import { isEndpointAllowed } from "../../../utils/settingsValidation"
 import { isTraccarJsonFormat, isOverlandFormat } from "../../../utils/apiPayload"
 import { ensureLocalNetworkPermission } from "../../../services/LocationServicePermission"
-import { fontSizes, fonts } from "../../../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../../../styles/typography"
 import { SettingRow } from "../../ui/SettingRow"
 import { useTimeout } from "../../../hooks/useTimeout"
 import { TEST_RESULT_DISPLAY_MS, size, space } from "../../../constants"
@@ -260,7 +260,7 @@ const styles = StyleSheet.create({
   intro: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20,
+    lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
   section: {
@@ -284,5 +284,5 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.description,
     textAlign: "center",
     ...fonts.regular
-  },
+  }
 })

--- a/apps/mobile/src/components/features/settings/MtlsSection.tsx
+++ b/apps/mobile/src/components/features/settings/MtlsSection.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useCallback, useEffect } from "react"
 import { Text, StyleSheet, View } from "react-native"
 import { useTheme } from "../../../hooks/useTheme"
-import { fonts, fontSizes } from "../../../styles/typography"
+import { fonts, fontSizes, lineHeights } from "../../../styles/typography"
 import { SectionTitle, Card, Divider, Button, FieldMessage, TextField } from "../../index"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { ClientCertInfoResult } from "../../../types/global"
@@ -326,7 +326,7 @@ const styles = StyleSheet.create({
   muted: {
     fontSize: fontSizes.description,
     ...fonts.regular,
-    lineHeight: 18
+    lineHeight: lineHeights.description
   },
   importButton: {
     marginTop: space.md

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react"
 import { Text, StyleSheet, View, Pressable, AppState } from "react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
-import { fonts, fontSizes } from "../../../styles/typography"
+import { fonts, fontSizes, lineHeights } from "../../../styles/typography"
 import {
   HIT_SLOP_MD,
   OVERLAND_BATCH_MAX,
@@ -423,7 +423,7 @@ const styles = StyleSheet.create({
   intro: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20,
+    lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
   section: {
@@ -454,7 +454,7 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.description,
     ...fonts.regular,
     marginBottom: space.md,
-    lineHeight: 18
+    lineHeight: lineHeights.description
   },
   nestedSetting: {
     marginTop: space.md,

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -7,7 +7,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react"
 import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-native"
 import { Info, CircleAlert, TriangleAlert, CircleCheckBig } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fontSizes, fonts, type } from "../../styles/typography"
+import { fontSizes, fonts, lineHeights, type } from "../../styles/typography"
 import { radius } from "@colota/shared"
 import { type ModalRequest, type AlertVariant, registerModalHandler } from "../../services/modalService"
 import { space, STATE_LAYER_ALPHA } from "../../constants"
@@ -159,7 +159,7 @@ const styles = StyleSheet.create({
   body: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20,
+    lineHeight: lineHeights.body,
     textAlign: "center"
   },
   buttons: {

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react"
 import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fontSizes, fonts, type } from "../../styles/typography"
+import { fontSizes, fonts, lineHeights, type } from "../../styles/typography"
 import { radius } from "@colota/shared"
 import { space, STATE_LAYER_ALPHA } from "../../constants"
 
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
   body: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   bodySpaced: {
     marginTop: space.sm

--- a/apps/mobile/src/components/ui/EmptyState.tsx
+++ b/apps/mobile/src/components/ui/EmptyState.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { View, Text, StyleSheet, type StyleProp, type ViewStyle } from "react-native"
 import { type LucideIcon } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fontSizes, fonts } from "../../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../../styles/typography"
 import { size, space } from "../../constants"
 
 type EmptyStateProps = {
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
   hint: {
     fontSize: fontSizes.description,
     ...fonts.regular,
-    lineHeight: 20,
+    lineHeight: lineHeights.description,
     marginTop: space.xs
   }
 })

--- a/apps/mobile/src/components/ui/FormatOption.tsx
+++ b/apps/mobile/src/components/ui/FormatOption.tsx
@@ -6,7 +6,7 @@
 import React from "react"
 import { Text, StyleSheet, View, Pressable } from "react-native"
 import type { LucideIcon } from "lucide-react-native"
-import { fontSizes, fonts } from "../../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
 import { RadioDot } from "./RadioDot"
 import { size, space, STATE_LAYER_ALPHA } from "../../constants"
@@ -74,7 +74,7 @@ const styles = StyleSheet.create({
   },
   formatDescription: {
     fontSize: fontSizes.caption,
-    lineHeight: 16,
+    lineHeight: lineHeights.caption,
     marginTop: 2
   }
 })

--- a/apps/mobile/src/components/ui/NumericInput.tsx
+++ b/apps/mobile/src/components/ui/NumericInput.tsx
@@ -6,7 +6,7 @@
 import React from "react"
 import { View, Text, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { fontSizes, fonts } from "../../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../../styles/typography"
 import { space } from "../../constants"
 import { TextField } from "./TextField"
 
@@ -74,7 +74,7 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.description,
     ...fonts.regular,
     marginBottom: space.md,
-    lineHeight: 18
+    lineHeight: lineHeights.description
   },
   inputRow: {
     flexDirection: "row",

--- a/apps/mobile/src/components/ui/SettingRow.tsx
+++ b/apps/mobile/src/components/ui/SettingRow.tsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 import { View, Text, StyleSheet, type StyleProp, type ViewStyle } from "react-native"
-import { fontSizes, fonts } from "../../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../../styles/typography"
 import { useTheme } from "../../hooks/useTheme"
 import { space, size } from "../../constants"
 
@@ -57,6 +57,6 @@ const styles = StyleSheet.create({
   settingHint: {
     fontSize: fontSizes.description,
     ...fonts.regular,
-    lineHeight: 18
+    lineHeight: lineHeights.description
   }
 })

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -8,7 +8,7 @@ import { Text, StyleSheet, View, ScrollView, Image } from "react-native"
 import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
 import { Copy, Check } from "lucide-react-native"
-import { fontSizes, fonts, type } from "../styles/typography"
+import { fontSizes, fonts, lineHeights, type } from "../styles/typography"
 import { Button, Card, Container, Divider, SectionTitle, Footer } from "../components"
 import { useTimeout } from "../hooks/useTimeout"
 import NativeLocationService from "../services/NativeLocationService"
@@ -102,9 +102,6 @@ export function AboutScreen({}: ScreenProps) {
 
   // Reset tap count after 2 seconds
 
-
-
-
   const handleCopyDebugInfo = useCallback(async () => {
     if (!buildConfig) return
 
@@ -185,38 +182,36 @@ export function AboutScreen({}: ScreenProps) {
             <Image source={icon} style={styles.appIcon} resizeMode="contain" />
           </View>
           <Text style={[styles.title, { color: colors.text }]}>Colota</Text>
-          <Text style={[styles.version, { color: colors.textSecondary }]}>
-            Version {buildConfig.VERSION_NAME}
-          </Text>
+          <Text style={[styles.version, { color: colors.textSecondary }]}>Version {buildConfig.VERSION_NAME}</Text>
         </View>
 
         <>
+          <View style={styles.section}>
+            <SectionTitle>Build</SectionTitle>
+            <InfoCard rows={debugRows} />
+          </View>
+
+          {deviceRows.length > 0 && (
             <View style={styles.section}>
-              <SectionTitle>Build</SectionTitle>
-              <InfoCard rows={debugRows} />
+              <SectionTitle>Device</SectionTitle>
+              <InfoCard rows={deviceRows} />
             </View>
+          )}
 
-            {deviceRows.length > 0 && (
-              <View style={styles.section}>
-                <SectionTitle>Device</SectionTitle>
-                <InfoCard rows={deviceRows} />
-              </View>
-            )}
+          <View style={styles.debugActions}>
+            <Button
+              variant="secondary"
+              icon={copied ? Check : Copy}
+              title={copied ? "Copied!" : "Copy debug info"}
+              testID="copy-debug-info-btn"
+              onPress={handleCopyDebugInfo}
+            />
 
-            <View style={styles.debugActions}>
-              <Button
-                variant="secondary"
-                icon={copied ? Check : Copy}
-                title={copied ? "Copied!" : "Copy debug info"}
-                testID="copy-debug-info-btn"
-                onPress={handleCopyDebugInfo}
-              />
-
-              <Text style={[styles.logHint, { color: colors.textLight }]}>
-                View and export logs from Settings &gt; Logging.
-              </Text>
-            </View>
-          </>
+            <Text style={[styles.logHint, { color: colors.textLight }]}>
+              View and export logs from Settings &gt; Logging.
+            </Text>
+          </View>
+        </>
 
         <Footer />
       </ScrollView>
@@ -281,6 +276,6 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.caption,
     textAlign: "center",
     fontStyle: "italic",
-    lineHeight: 16
+    lineHeight: lineHeights.caption
   }
 })

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -21,7 +21,7 @@ import { useAutoSave } from "../hooks/useAutoSave"
 import { useTimeout } from "../hooks/useTimeout"
 import { useTracking } from "../contexts/TrackingProvider"
 import NativeLocationService from "../services/NativeLocationService"
-import { fontSizes, fonts, type } from "../styles/typography"
+import { fontSizes, fonts, lineHeights, type } from "../styles/typography"
 import {
   SectionTitle,
   FloatingSaveIndicator,
@@ -738,7 +738,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: fontSizes.body,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   section: {
     marginBottom: space.xl
@@ -799,7 +799,7 @@ const styles = StyleSheet.create({
   },
   fieldDescription: {
     fontSize: fontSizes.small,
-    lineHeight: 15
+    lineHeight: lineHeights.small
   },
   valueColumn: {
     flex: 1,
@@ -835,7 +835,7 @@ const styles = StyleSheet.create({
   },
   warningText: {
     fontSize: fontSizes.caption,
-    lineHeight: 18
+    lineHeight: lineHeights.caption
   },
   exampleSection: {
     marginBottom: 20

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -10,7 +10,7 @@ import { AuthConfig, AuthType, DEFAULT_AUTH_CONFIG, ScreenProps } from "../types
 import { useTheme } from "../hooks/useTheme"
 import { useAutoSave } from "../hooks/useAutoSave"
 import { useTracking } from "../contexts/TrackingProvider"
-import { fonts, fontSizes } from "../styles/typography"
+import { fonts, fontSizes, lineHeights } from "../styles/typography"
 import {
   SectionTitle,
   FloatingSaveIndicator,
@@ -345,7 +345,7 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   section: {
     marginBottom: space.xl
@@ -382,7 +382,7 @@ const styles = StyleSheet.create({
   },
   warningText: {
     fontSize: fontSizes.caption,
-    lineHeight: 18
+    lineHeight: lineHeights.caption
   },
   footer: {
     paddingVertical: space.lg,

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -36,7 +36,7 @@ import {
   isValidFilenameTemplate,
   renderFilenamePreview
 } from "../utils/exportConverters"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { formatExportDateTime, formatBytes } from "../utils/format"
 import { showAlert } from "../services/modalService"
@@ -694,7 +694,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: fontSizes.body,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   section: {
     marginTop: space.xl

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -15,7 +15,7 @@ import BackupService, {
 } from "../services/BackupService"
 import { showAlert, showConfirm, showChoice } from "../services/modalService"
 import { logger } from "../utils/logger"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { radius } from "@colota/shared"
 import type { ThemeColors } from "../types/global"
 import { space } from "../constants"
@@ -356,7 +356,7 @@ const styles = StyleSheet.create({
   intro: {
     marginBottom: space.md,
     fontSize: fontSizes.body,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   fieldGroup: {
     gap: space.lg,
@@ -385,7 +385,7 @@ const styles = StyleSheet.create({
   },
   hint: {
     fontSize: fontSizes.caption,
-    lineHeight: 18,
+    lineHeight: lineHeights.caption,
     marginTop: space.sm,
     marginBottom: space.lg
   },

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -19,7 +19,7 @@ import { Lightbulb } from "lucide-react-native"
 import { useFocusEffect } from "@react-navigation/native"
 import { ScreenProps, DatabaseStats } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
-import { fonts, fontSizes } from "../styles/typography"
+import { fonts, fontSizes, lineHeights } from "../styles/typography"
 import NativeLocationService from "../services/NativeLocationService"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Button, SectionTitle, Card, Container, Divider, FloatingSaveIndicator, TextField } from "../components"
@@ -430,7 +430,7 @@ const styles = StyleSheet.create({
   intro: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20,
+    lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
   keyboardAvoid: {
@@ -462,7 +462,7 @@ const styles = StyleSheet.create({
     ...fonts.regular,
     textAlign: "center",
     fontStyle: "italic",
-    lineHeight: 16,
+    lineHeight: lineHeights.caption,
     marginTop: space.sm
   },
   actionRow: {
@@ -485,7 +485,7 @@ const styles = StyleSheet.create({
   actionHint: {
     fontSize: fontSizes.caption,
     ...fonts.regular,
-    lineHeight: 16,
+    lineHeight: lineHeights.caption,
     marginTop: 2
   },
   actionBadge: {

--- a/apps/mobile/src/screens/ExportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ExportLocationsScreen.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { Text, StyleSheet, View, ScrollView } from "react-native"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { MapPinOff, Upload } from "lucide-react-native"
 import { Button, Card, Container, EmptyState, FormatSelector, LoadingOverlay, SectionTitle } from "../components"
 import { useTheme } from "../hooks/useTheme"
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
   intro: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20,
+    lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
   scrollContent: {

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -8,7 +8,7 @@ import { View, Text, StyleSheet, ScrollView, DeviceEventEmitter } from "react-na
 import { useTheme } from "../hooks/useTheme"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert, showConfirm } from "../services/modalService"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { Button, Card, Container, FieldMessage, SectionTitle, SettingRow, Toggle, TextField } from "../components"
 import { Check, Trash2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
@@ -367,7 +367,7 @@ const styles = StyleSheet.create({
   combinedNoteText: {
     fontSize: fontSizes.caption,
     ...fonts.regular,
-    lineHeight: 17,
+    lineHeight: lineHeights.caption,
     fontStyle: "italic"
   }
 })

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -10,7 +10,7 @@ import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { Geofence, ScreenProps } from "../types/global"
 import { useTracking, useCoords } from "../contexts/TrackingProvider"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { ChevronRight, Wifi, PersonStanding, MapPinHouse, Share2 } from "lucide-react-native"
 import { Button, Card, Container, EmptyState, SectionTitle, TextField } from "../components"
 import {
@@ -367,7 +367,12 @@ const styles = StyleSheet.create({
   map: { height: 450, overflow: "hidden" },
   list: { padding: 20, paddingBottom: 40 },
   section: { marginBottom: space.lg },
-  hint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18, marginBottom: space.lg },
+  hint: {
+    fontSize: fontSizes.description,
+    ...fonts.regular,
+    lineHeight: lineHeights.description,
+    marginBottom: space.lg
+  },
   inputRow: { flexDirection: "row", gap: space.md, marginBottom: space.lg },
   inputGroup: { flex: 1 },
   inputGroupName: {
@@ -390,5 +395,5 @@ const styles = StyleSheet.create({
   info: { flex: 1, marginEnd: space.md },
   name: { fontSize: fontSizes.input, ...fonts.semiBold, marginBottom: 2 },
   radiusRow: { flexDirection: "row", alignItems: "center", gap: space.xs },
-  radius: { fontSize: fontSizes.caption },
+  radius: { fontSize: fontSizes.caption }
 })

--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useEffect, useState } from "react"
 import { ScrollView, StyleSheet, Text, View } from "react-native"
 import { Download } from "lucide-react-native"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { Button, Card, Container, Divider, LoadingOverlay, SectionTitle } from "../components"
 import { useTheme } from "../hooks/useTheme"
 import NativeLocationService from "../services/NativeLocationService"
@@ -255,7 +255,7 @@ const styles = StyleSheet.create({
   intro: {
     marginBottom: space.md,
     fontSize: fontSizes.body,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   },
   formatRow: {
     flexDirection: "row",
@@ -272,7 +272,7 @@ const styles = StyleSheet.create({
   },
   formatDescription: {
     fontSize: fontSizes.caption,
-    lineHeight: 16,
+    lineHeight: lineHeights.caption,
     marginTop: 2
   }
 })

--- a/apps/mobile/src/screens/LegalScreen.tsx
+++ b/apps/mobile/src/screens/LegalScreen.tsx
@@ -11,7 +11,7 @@ import { useTheme } from "../hooks/useTheme"
 import { Card, Container, Divider, ListItem, SectionTitle } from "../components"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { space, OSM_COPYRIGHT_URL, PRIVACY_POLICY_URL, REPO_URL, TILE_SERVER_DOCS_URL } from "../constants"
 
 export function LegalScreen({}: ScreenProps) {
@@ -59,7 +59,7 @@ export function LegalScreen({}: ScreenProps) {
 
         <View style={styles.section}>
           <SectionTitle>Map data</SectionTitle>
-    <Card rows>
+          <Card rows>
             <ListItem
               label="OpenStreetMap"
               sub="Map data by OpenStreetMap contributors, ODbL"
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
   copyright: {
     fontSize: fontSizes.caption,
     ...fonts.regular,
-    lineHeight: 17,
+    lineHeight: lineHeights.caption,
     marginTop: space.xxl
   }
 })

--- a/apps/mobile/src/screens/MtlsSettingsScreen.tsx
+++ b/apps/mobile/src/screens/MtlsSettingsScreen.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { Text, StyleSheet, View, ScrollView } from "react-native"
 import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { Container } from "../components"
 import { MtlsSection } from "../components/features/settings/MtlsSection"
 import { space } from "../constants"
@@ -46,6 +46,6 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: fontSizes.body,
     ...fonts.regular,
-    lineHeight: 20
+    lineHeight: lineHeights.body
   }
 })

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -11,7 +11,7 @@ import { useTheme } from "../hooks/useTheme"
 import { showAlert, showConfirm } from "../services/modalService"
 import { ScreenProps } from "../types/global"
 import { useCoords } from "../contexts/TrackingProvider"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { X, CircleCheckBig, RefreshCw, TriangleAlert } from "lucide-react-native"
 import { Button, Card, Container, EmptyState, IconButton, SectionTitle, TextField } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
@@ -880,7 +880,12 @@ const styles = StyleSheet.create({
   map: { height: 450, overflow: "hidden", borderWidth: 2, borderColor: "transparent" },
   list: { padding: 20, paddingBottom: 40 },
   section: { marginBottom: space.lg },
-  hint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18, marginBottom: space.lg },
+  hint: {
+    fontSize: fontSizes.description,
+    ...fonts.regular,
+    lineHeight: lineHeights.description,
+    marginBottom: space.lg
+  },
   inputGroup: { marginBottom: space.lg },
   sizeEstimate: { fontSize: fontSizes.caption, ...fonts.regular, marginBottom: space.md },
   progressContainer: { gap: 10 },

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -10,7 +10,7 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { ProfileService } from "../services/ProfileService"
 import { showAlert, showConfirm } from "../services/modalService"
 import { TrackingProfile, ProfileConditionType } from "../types/global"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import {
   Button,
   Card,
@@ -492,7 +492,7 @@ const styles = StyleSheet.create({
   unit: { fontSize: fontSizes.body, ...fonts.medium, minWidth: 28 },
   syncLabelRow: { marginBottom: space.sm },
   settingLabel: { fontSize: fontSizes.label, ...fonts.semiBold, marginBottom: 2 },
-  settingHint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: 18 }, // ~3 per row with gap
+  settingHint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: lineHeights.description }, // ~3 per row with gap
   customSyncInput: { marginTop: space.md },
   sectionGap: { marginTop: space.xl }
 })

--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -8,7 +8,7 @@ import { View, Text, ScrollView, StyleSheet, Share } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
 import { Button, Card, Container, Divider, SectionTitle, SettingRow, Toggle } from "../components"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { Share2, TriangleAlert } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
@@ -213,7 +213,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: fontSizes.caption,
     ...fonts.regular,
-    lineHeight: 17
+    lineHeight: lineHeights.caption
   },
   actions: {
     marginTop: space.xl

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -10,7 +10,7 @@ import { useTracking } from "../contexts/TrackingProvider"
 import { ProfileService } from "../services/ProfileService"
 import { showAlert, showConfirm } from "../services/modalService"
 import { SavedTrackingProfile, ScreenProps } from "../types/global"
-import { fontSizes, fonts } from "../styles/typography"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { Button, Card, Container, EmptyState, IconButton, SectionTitle, Toggle } from "../components"
 import { Plus, X, Zap, Share2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
@@ -211,7 +211,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
 const styles = StyleSheet.create({
   list: { padding: space.lg, paddingBottom: 40 },
   header: { marginBottom: 20 },
-  subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: 20 },
+  subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: lineHeights.body },
   card: { marginBottom: space.md },
   row: { flexDirection: "row", alignItems: "center" },
   iconWrap: {

--- a/apps/mobile/src/styles/typography.ts
+++ b/apps/mobile/src/styles/typography.ts
@@ -11,6 +11,18 @@ import { fontFamily, fontSizes } from "@colota/shared"
 
 export { fontSizes }
 
+/**
+ * Keys are `fontSizes` names, minus the seven sizes that set no line height and run on the platform
+ * default. `mono` is the exception: it sits at caption size and takes more leading.
+ */
+export const lineHeights = {
+  body: 20,
+  description: 18,
+  caption: 16,
+  small: 16,
+  mono: 18
+} as const
+
 export const fonts: Record<string, Pick<TextStyle, "fontFamily">> = {
   regular: { fontFamily: `${fontFamily}-Regular` },
   medium: { fontFamily: `${fontFamily}-Medium` },
@@ -34,5 +46,5 @@ export const type = {
   /** A heading inside a screen, above a block rather than a group of rows. */
   heading: { fontSize: fontSizes.heading, ...fonts.bold },
   /** A block of code, a log line or a payload: the platform monospace, never Inter. */
-  mono: { fontSize: fontSizes.caption, fontFamily: "monospace", lineHeight: 18 }
+  mono: { fontSize: fontSizes.caption, fontFamily: "monospace", lineHeight: lineHeights.mono }
 } as const satisfies Record<string, TextStyle>


### PR DESCRIPTION
lineHeights pairs a leading with each font size that needs one: body 20, description 18, caption 16, small 16, plus mono 18 for the monospace role. All 37 literals in src now read from it and lineHeightGuard fails on a new one, holding each pair inside Material leading range.

Nine sites shift: seven caption blocks tighten from 17 or 18 to 16, EmptyState from 20 to 18, and one 11sp site from 15 to 16.