### PR TITLE
feat(import): the format rows read the same as the export picker

### DIFF
--- a/apps/mobile/src/screens/ImportLocationsScreen.tsx
+++ b/apps/mobile/src/screens/ImportLocationsScreen.tsx
@@ -27,7 +27,13 @@ const SYNC_WARN_THRESHOLD = 10_000
 
 const SUPPORTED_FORMATS = IMPORT_FORMAT_ORDER.map((key) => {
   const f = FILE_FORMATS[key]
-  return { icon: f.icon, title: f.label, extension: f.extension, description: importDescription(f) }
+  return {
+    icon: f.icon,
+    title: f.label,
+    subtitle: f.subtitle,
+    extension: f.extension,
+    description: importDescription(f)
+  }
 })
 
 function formatDate(unixSeconds: number | null): string {
@@ -87,9 +93,10 @@ const FormatRow = ({ entry, colors }: { entry: (typeof SUPPORTED_FORMATS)[number
       <Icon size={size.icon.md} color={colors.textLight} />
       <View style={styles.formatTextContent}>
         <Text style={[styles.formatTitle, { color: colors.text }]}>{entry.title}</Text>
-        <Text style={[styles.formatDescription, { color: colors.textLight }]}>
-          {entry.extension} · {entry.description}
+        <Text style={[styles.formatSubtitle, { color: colors.textSecondary }]}>
+          {entry.subtitle} · {entry.extension}
         </Text>
+        <Text style={[styles.formatDescription, { color: colors.textLight }]}>{entry.description}</Text>
       </View>
     </View>
   )
@@ -269,6 +276,10 @@ const styles = StyleSheet.create({
   formatTitle: {
     fontSize: fontSizes.label,
     ...fonts.semiBold
+  },
+  formatSubtitle: {
+    fontSize: fontSizes.description,
+    marginTop: 2
   },
   formatDescription: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/__tests__/ImportLocationsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ImportLocationsScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { render, fireEvent, waitFor } from "@testing-library/react-native"
+import { FILE_FORMATS, IMPORT_FORMAT_ORDER, importDescription } from "../../utils/fileFormats"
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({ colors: require("@colota/shared").lightColors })
@@ -111,6 +112,17 @@ describe("ImportLocationsScreen", () => {
     jest.clearAllMocks()
     mockGetStats.mockResolvedValue({ total: 100 })
     mockCancelImport.mockResolvedValue(undefined)
+  })
+
+  it("gives every listed format the same three lines the export picker shows", () => {
+    const { getByText } = renderScreen()
+
+    for (const key of IMPORT_FORMAT_ORDER) {
+      const format = FILE_FORMATS[key]
+      expect(getByText(format.label)).toBeTruthy()
+      expect(getByText(`${format.subtitle} · ${format.extension}`)).toBeTruthy()
+      expect(getByText(importDescription(format))).toBeTruthy()
+    }
   })
 
   it("does nothing when the picker is dismissed, so no staged import is left behind", async () => {

--- a/apps/mobile/src/utils/exportConverters.ts
+++ b/apps/mobile/src/utils/exportConverters.ts
@@ -30,7 +30,7 @@ export const EXPORT_FORMATS: Record<ExportFormat, ExportFormatConfig> = EXPORT_F
     const f = FILE_FORMATS[key]
     acc[key] = {
       label: f.label,
-      subtitle: f.subtitle!,
+      subtitle: f.subtitle,
       description: f.description,
       icon: f.icon,
       extension: f.extension,

--- a/apps/mobile/src/utils/fileFormats.ts
+++ b/apps/mobile/src/utils/fileFormats.ts
@@ -17,7 +17,7 @@ export interface FileFormat {
   extension: string
   exportable: boolean
   mimeType?: string // present for every exportable format
-  subtitle?: string // export picker only
+  subtitle: string // the name spelled out, shown by both pickers
   description: string
   importHint?: string
 }
@@ -37,6 +37,7 @@ export const FILE_FORMATS: Record<ImportFormat, FileFormat> = {
     icon: Database,
     extension: "Records.json",
     exportable: false,
+    subtitle: "Takeout Archive",
     description:
       "Older bulk Location History export from Google Takeout. Google removed this from Takeout in late 2024; use this for archived files."
   },
@@ -45,6 +46,7 @@ export const FILE_FORMATS: Record<ImportFormat, FileFormat> = {
     icon: MapPin,
     extension: ".json",
     exportable: false,
+    subtitle: "Location History",
     description: "On-device export from Android Settings -> Location -> Location services -> Timeline."
   },
   gpx: {


### PR DESCRIPTION
subtitle was marked export-picker-only and both Google Timeline entries lacked one, so the import rows ran title plus a combined caption while export ran title, subtitle with extension, then description. Adds Location History and Takeout Archive, makes the field required, and gives the import row the same three lines.