### PR TITLE
test: the typography mocks carry lineHeights

### DIFF
--- a/apps/mobile/src/components/features/inspector/__tests__/LocationTable.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/LocationTable.test.tsx
@@ -13,7 +13,8 @@ jest.mock("../../../../styles/typography", () => ({
   fonts: { regular: {}, bold: {}, semiBold: {} },
   // The real scale, not stubs: these tests render styles that read a named size, and a
   // stubbed object would let a renamed key through.
-  fontSizes: jest.requireActual("@colota/shared").fontSizes
+  fontSizes: jest.requireActual("@colota/shared").fontSizes,
+  lineHeights: jest.requireActual("../../../../styles/typography").lineHeights
 }))
 
 import { LocationTable } from "../LocationTable"

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -71,7 +71,8 @@ jest.mock("../../../../styles/typography", () => ({
   fonts: { regular: {}, bold: {}, semiBold: {} },
   // The real scale, not stubs: these tests render styles that read a named size, and a
   // stubbed object would let a renamed key through.
-  fontSizes: jest.requireActual("@colota/shared").fontSizes
+  fontSizes: jest.requireActual("@colota/shared").fontSizes,
+  lineHeights: jest.requireActual("../../../../styles/typography").lineHeights
 }))
 
 jest.mock("../../../../utils/geo", () => ({

--- a/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TripList.test.tsx
@@ -21,7 +21,8 @@ jest.mock("../../../../styles/typography", () => ({
   fonts: { regular: {}, bold: {}, semiBold: {} },
   // The real scale, not stubs: these tests render styles that read a named size, and a
   // stubbed object would let a renamed key through.
-  fontSizes: jest.requireActual("@colota/shared").fontSizes
+  fontSizes: jest.requireActual("@colota/shared").fontSizes,
+  lineHeights: jest.requireActual("../../../../styles/typography").lineHeights
 }))
 
 jest.mock("../../../../utils/exportConverters", () => ({

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -193,7 +193,8 @@ jest.mock("../../styles/typography", () => ({
   fonts: { regular: {}, bold: {}, semiBold: {} },
   // The real scale, not stubs: these tests render styles that read a named size, and a
   // stubbed object would let a renamed key through.
-  fontSizes: jest.requireActual("@colota/shared").fontSizes
+  fontSizes: jest.requireActual("@colota/shared").fontSizes,
+  lineHeights: jest.requireActual("../../styles/typography").lineHeights
 }))
 
 jest.mock("../../utils/logger", () => ({


### PR DESCRIPTION
Four suites mock styles/typography with a hand-written factory rather than requireActual, so the lineHeights token was missing from it and EmptyState threw reading lineHeights.description at import. Those suites have failed to load since 65ad235b.