### PR TITLE
fix(ui): a circle takes radius.pill instead of half its width

### DIFF
--- a/apps/mobile/src/__tests__/circleRadiusGuard.test.ts
+++ b/apps/mobile/src/__tests__/circleRadiusGuard.test.ts
@@ -1,0 +1,80 @@
+// See designSystemGuard for why this file declares the node corner it needs by hand.
+declare const __dirname: string
+
+type Entry = { name: string; isDirectory: () => boolean }
+const fs: {
+  readdirSync: (dir: string, options: { withFileTypes: true }) => Entry[]
+  readFileSync: (file: string, encoding: "utf8") => string
+} = require("fs")
+const path: { join: (...parts: string[]) => string } = require("path")
+
+import { radius } from "@colota/shared"
+
+/**
+ * A radius that is half a width is a circle stated as arithmetic, and it stops being one the moment
+ * the size changes. Two rounded a 24px dot with `radius.md`, which is a circle only by coincidence.
+ */
+const SRC = path.join(__dirname, "..")
+const ROOTS = ["screens", "components"]
+const SCALE: Record<string, number> = radius
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(path.join(SRC, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") walk(rel)
+      } else if (/\.tsx?$/.test(entry.name)) {
+        found.push(rel)
+      }
+    }
+  }
+  ROOTS.forEach(walk)
+  return found.sort()
+}
+
+function circlesWrittenAsArithmetic(source: string): string[] {
+  const found: string[] = []
+
+  for (const style of source.matchAll(/(\w+):\s*\{([^{}]*)\}/g)) {
+    const body = style[2]
+    const width = body.match(/\bwidth:\s*([\d.]+)/)
+    const height = body.match(/\bheight:\s*([\d.]+)/)
+    if (!width || !height || width[1] !== height[1]) continue
+
+    const literal = body.match(/borderRadius:\s*([\d.]+)/)
+    const token = body.match(/borderRadius:\s*radius\.(\w+)/)
+    const drawn = literal ? parseFloat(literal[1]) : token ? SCALE[token[1]] : null
+    if (drawn === null || drawn === undefined) continue
+
+    if (Math.abs(drawn - parseFloat(width[1]) / 2) < 0.01) {
+      found.push(`${style[1]}: ${width[1]}px with borderRadius ${literal ? literal[1] : `radius.${token![1]}`}`)
+    }
+  }
+
+  return found
+}
+
+describe("circle radius guard", () => {
+  const files = sourceFiles()
+
+  it("finds the shapes it is meant to police", () => {
+    const square = files.filter((f) => /\bwidth:\s*[\d.]+/.test(fs.readFileSync(path.join(SRC, f), "utf8")))
+
+    expect(square).toContain("components/ui/RadioDot.tsx")
+    expect(square.length).toBeGreaterThan(10)
+  })
+
+  it("draws every circle with radius.pill rather than half its own width", () => {
+    const arithmetic: string[] = []
+
+    for (const file of files) {
+      for (const style of circlesWrittenAsArithmetic(fs.readFileSync(path.join(SRC, file), "utf8"))) {
+        arithmetic.push(`${file}: ${style}`)
+      }
+    }
+
+    expect(arithmetic).toEqual([])
+  })
+})

--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -114,7 +114,7 @@ const styles = StyleSheet.create({
   dot: {
     width: 8,
     height: 8,
-    borderRadius: radius.xs,
+    borderRadius: radius.pill,
     marginEnd: space.md
   },
   host: {

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useRef, useEffect, useMemo, useCallback, useState } from "react"
+import { radius } from "@colota/shared"
 import { View, StyleSheet, Text, ActivityIndicator, DeviceEventEmitter, Image, Pressable } from "react-native"
 import { TriangleAlert } from "lucide-react-native"
 import { LocationCoords } from "../../../types/global"
@@ -263,7 +264,7 @@ const styles = StyleSheet.create({
   iconCircle: {
     width: 80,
     height: 80,
-    borderRadius: 40,
+    borderRadius: radius.pill,
     justifyContent: "center",
     alignItems: "center",
     marginBottom: space.lg

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -144,7 +144,7 @@ const styles = StyleSheet.create({
   checkCircle: {
     width: 24,
     height: 24,
-    borderRadius: radius.md,
+    borderRadius: radius.pill,
     borderWidth: 2,
     justifyContent: "center",
     alignItems: "center",

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -598,7 +598,7 @@ const styles = StyleSheet.create({
   dayCircle: {
     width: 32,
     height: 32,
-    borderRadius: radius.lg,
+    borderRadius: radius.pill,
     alignItems: "center",
     justifyContent: "center"
   },
@@ -614,7 +614,7 @@ const styles = StyleSheet.create({
   dataDot: {
     width: 4,
     height: 4,
-    borderRadius: 2,
+    borderRadius: radius.pill,
     marginTop: 2
   },
   noteDot: {
@@ -623,7 +623,7 @@ const styles = StyleSheet.create({
     right: 1,
     width: 7,
     height: 7,
-    borderRadius: 3.5,
+    borderRadius: radius.pill,
     borderWidth: 1
   }
 })

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -506,7 +506,7 @@ const styles = StyleSheet.create({
   legendDot: {
     width: 10,
     height: 10,
-    borderRadius: 5
+    borderRadius: radius.pill
   },
   legendLabel: {
     fontSize: fontSizes.small,

--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -455,7 +455,7 @@ const styles = StyleSheet.create({
   tripDot: {
     width: 8,
     height: 8,
-    borderRadius: radius.xs
+    borderRadius: radius.pill
   },
   tripTitle: {
     fontSize: fontSizes.input,

--- a/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
+++ b/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
   markerDot: {
     width: 24,
     height: 24,
-    borderRadius: radius.md,
+    borderRadius: radius.pill,
     borderWidth: 3,
     borderColor: "white",
     elevation: 4

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -145,7 +145,7 @@ const styles = StyleSheet.create({
   iconContainer: {
     width: 56,
     height: 56,
-    borderRadius: 28,
+    borderRadius: radius.pill,
     justifyContent: "center",
     alignItems: "center",
     alignSelf: "center",

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -116,7 +116,7 @@ const styles = StyleSheet.create({
   iconContainer: {
     width: 56,
     height: 56,
-    borderRadius: 28,
+    borderRadius: radius.pill,
     justifyContent: "center",
     alignItems: "center",
     alignSelf: "center",

--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useRef } from "react"
+import { radius } from "@colota/shared"
 import { View, Text, StyleSheet, Animated } from "react-native"
 import { Check } from "lucide-react-native"
 import { SpinningLoader } from "./SpinningLoader"
@@ -84,7 +85,7 @@ const styles = StyleSheet.create({
     gap: space.sm,
     paddingHorizontal: 20,
     paddingVertical: space.md,
-    borderRadius: 24,
+    borderRadius: radius.pill,
     elevation: 8
   },
   text: { fontSize: fontSizes.body, ...fonts.semiBold }

--- a/apps/mobile/src/components/ui/RadioDot.tsx
+++ b/apps/mobile/src/components/ui/RadioDot.tsx
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
   radio: {
     width: 24,
     height: 24,
-    borderRadius: radius.md,
+    borderRadius: radius.pill,
     borderWidth: 2,
     justifyContent: "center",
     alignItems: "center"
@@ -33,6 +33,6 @@ const styles = StyleSheet.create({
   inner: {
     width: 12,
     height: 12,
-    borderRadius: 6
+    borderRadius: radius.pill
   }
 })

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -382,7 +382,7 @@ const styles = StyleSheet.create({
     right: 24,
     width: 44,
     height: 44,
-    borderRadius: 22,
+    borderRadius: radius.pill,
     alignItems: "center",
     justifyContent: "center",
     elevation: 4

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState, useCallback, useRef } from "react"
+import { radius } from "@colota/shared"
 import { StyleSheet, View, ScrollView, DeviceEventEmitter, Animated, AppState } from "react-native"
 import { ScreenProps, DatabaseStats } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
@@ -299,7 +300,7 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   controlButton: {
-    borderRadius: 28,
+    borderRadius: radius.pill,
     elevation: 4,
     minWidth: 200
   },

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -920,7 +920,7 @@ const styles = StyleSheet.create({
   actionBtn: {
     width: 32,
     height: 32,
-    borderRadius: radius.lg,
+    borderRadius: radius.pill,
     alignItems: "center",
     justifyContent: "center"
   },

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -233,7 +233,7 @@ const styles = StyleSheet.create({
     paddingVertical: 2,
     borderRadius: radius.xs
   },
-  activeDot: { width: 6, height: 6, borderRadius: 3 },
+  activeDot: { width: 6, height: 6, borderRadius: radius.pill },
   activeBadgeText: { fontSize: fontSizes.micro, ...fonts.semiBold },
   priorityBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: radius.xs },
   priorityText: { fontSize: fontSizes.micro, ...fonts.semiBold },

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -462,7 +462,7 @@ const styles = StyleSheet.create({
   dot: {
     width: 12,
     height: 12,
-    borderRadius: 6
+    borderRadius: radius.pill
   },
   title: {
     ...type.title


### PR DESCRIPTION
A radius written as half a width is a circle only until the width changes, and eight of these were radius.xs, md or lg that matched half by coincidence: radius.md on a 24px RadioDot reads as a scale choice and is round by accident.

Rendering is unchanged everywhere. Android already clamps a radius to half the smaller dimension, so every one of these drew as a circle and radius.pill clamps to the same pixel. The guard is the durable part.

Two known gaps left alone: DashboardScreen.controlButton sets its corner on a Button wrapper that paints nothing, so the plan wanting the Start control to be a pill is still unimplemented, and AboutScreen appIconContainer is 20 on an 80px box, tracking the launcher tile proportion rather than the scale.