### PR TITLE
fix(ui): a button paints its own corner

### DIFF
--- a/apps/mobile/src/__tests__/wrapperStyleGuard.test.ts
+++ b/apps/mobile/src/__tests__/wrapperStyleGuard.test.ts
@@ -1,0 +1,79 @@
+// See designSystemGuard for why this file declares the node corner it needs by hand.
+export {}
+
+declare const __dirname: string
+
+type Entry = { name: string; isDirectory: () => boolean }
+const fs: {
+  readdirSync: (dir: string, options: { withFileTypes: true }) => Entry[]
+  readFileSync: (file: string, encoding: "utf8") => string
+} = require("fs")
+const path: { join: (...parts: string[]) => string } = require("path")
+
+/**
+ * `Button` and `TextField` put a caller's `style` on their outer view and paint the control inside
+ * it, so a fill, corner or border passed from a screen lands on a transparent box and is never
+ * drawn. It cost four inputs a double border and left the Start control at the default corner while
+ * its own style said otherwise. Layout is fine to pass; paint is not.
+ */
+const SRC = path.join(__dirname, "..")
+const ROOTS = ["screens", "components"]
+const WRAPPERS = ["Button", "TextField"]
+const PAINT = /\b(backgroundColor|borderRadius|borderWidth|borderColor)\s*:/
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(path.join(SRC, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") walk(rel)
+      } else if (/\.tsx$/.test(entry.name)) {
+        found.push(rel)
+      }
+    }
+  }
+  ROOTS.forEach(walk)
+  return found.sort()
+}
+
+function styleBodies(source: string): Record<string, string> {
+  const bodies: Record<string, string> = {}
+  for (const style of source.matchAll(/(\w+):\s*\{([^{}]*)\}/g)) bodies[style[1]] = style[2]
+  return bodies
+}
+
+function stylesHandedToAWrapper(source: string): string[] {
+  const names: string[] = []
+  for (const wrapper of WRAPPERS) {
+    const tag = new RegExp(`<${wrapper}\\b[^>]*?style=\\{styles\\.(\\w+)\\}`, "gs")
+    for (const use of source.matchAll(tag)) names.push(use[1])
+  }
+  return names
+}
+
+describe("wrapper style guard", () => {
+  const files = sourceFiles()
+
+  it("finds the callers it is meant to police", () => {
+    const callers = files.filter((f) => stylesHandedToAWrapper(fs.readFileSync(path.join(SRC, f), "utf8")).length > 0)
+
+    expect(callers).toContain("screens/DashboardScreen.tsx")
+    expect(callers).toContain("components/features/settings/MtlsSection.tsx")
+  })
+
+  it("hands a wrapper layout only, because paint on it is never drawn", () => {
+    const painted: string[] = []
+
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(SRC, file), "utf8")
+      const bodies = styleBodies(source)
+      for (const name of stylesHandedToAWrapper(source)) {
+        const body = bodies[name]
+        if (body && PAINT.test(body)) painted.push(`${file}: ${name} sets ${body.match(PAINT)![1]}`)
+      }
+    }
+
+    expect(painted).toEqual([])
+  })
+})

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -18,8 +18,10 @@ import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { type LucideIcon } from "lucide-react-native"
 import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+import { radius } from "@colota/shared"
 
 type ButtonVariant = "primary" | "secondary" | "ghost" | "danger"
+type ButtonShape = "rounded" | "pill"
 
 type Props = {
   title: string
@@ -28,6 +30,8 @@ type Props = {
   style?: StyleProp<ViewStyle>
   color?: string
   variant?: ButtonVariant
+  /** The corner is painted inside, so a caller cannot set it through `style`. */
+  shape?: ButtonShape
   icon?: LucideIcon
   loading?: boolean
   expanded?: boolean
@@ -41,6 +45,7 @@ export function Button({
   style,
   color,
   variant = "primary",
+  shape = "rounded",
   icon: Icon,
   loading = false,
   expanded,
@@ -74,7 +79,7 @@ export function Button({
         accessibilityRole="button"
         accessibilityState={{ disabled: disabled || loading, expanded }}
         android_ripple={disabled || loading ? undefined : { color: v.text + STATE_LAYER_ALPHA }}
-        style={[styles.button, { backgroundColor: v.bg, borderRadius: colors.borderRadius }]}
+        style={[styles.button, { backgroundColor: v.bg, borderRadius: shape === "pill" ? radius.pill : radius.sm }]}
         onPress={onPress}
         disabled={disabled || loading}
       >

--- a/apps/mobile/src/components/ui/__tests__/Button.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Button.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render } from "@testing-library/react-native"
 import { StyleSheet, Text } from "react-native"
-import { lightColors } from "@colota/shared"
+import { lightColors, radius } from "@colota/shared"
 
 jest.mock("../../../hooks/useTheme", () => ({
   useTheme: () => ({ colors: require("@colota/shared").lightColors })
@@ -49,6 +49,20 @@ describe("Button variants", () => {
     rerender(<Button title="Reset all" onPress={jest.fn()} variant="ghost" disabled testID="reset-btn" />)
     expect(StyleSheet.flatten(label()).color).toBe(lightColors.textDisabled)
     expect(flat(getByTestId("reset-btn")).backgroundColor).toBe("transparent")
+  })
+
+  it("paints the corner itself, because a caller's style lands on the outer view", () => {
+    const { getByTestId } = render(
+      <Button title="Start tracking" onPress={jest.fn()} shape="pill" testID="start-btn" />
+    )
+
+    expect(flat(getByTestId("start-btn")).borderRadius).toBe(radius.pill)
+  })
+
+  it("keeps a plain button on the shape scale rather than the retired alias", () => {
+    const { getByTestId } = render(<Button title="Save" onPress={jest.fn()} testID="save-btn" />)
+
+    expect(flat(getByTestId("save-btn")).borderRadius).toBe(radius.sm)
   })
 
   it("keeps the touch target at the Android minimum", () => {

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useEffect, useState, useCallback, useRef } from "react"
-import { radius } from "@colota/shared"
 import { StyleSheet, View, ScrollView, DeviceEventEmitter, Animated, AppState } from "react-native"
 import { ScreenProps, DatabaseStats } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
@@ -230,6 +229,7 @@ export function DashboardScreen({ navigation }: ScreenProps) {
           >
             <Button
               style={styles.controlButton}
+              shape="pill"
               variant={tracking ? "danger" : "primary"}
               icon={tracking ? Square : Play}
               onPress={tracking ? handleStop : handleStart}
@@ -300,7 +300,6 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   controlButton: {
-    borderRadius: radius.pill,
     elevation: 4,
     minWidth: 200
   },


### PR DESCRIPTION
DashboardScreen.controlButton set borderRadius on the view Button hands the caller style to, which has no background, so the Start control drew the default 8 rather than the pill the design plan specifies. A shape prop paints it on the Pressable, and the retired colors.borderRadius alias gives way to radius.sm at the same value.

wrapperStyleGuard fails on a fill, corner or border in a style passed to Button or TextField. That is the same class that gave four number inputs a double border.

pill marks the primary action of a screen: it sits on the map where a stadium separates from the tiles, and colour there already encodes tracking state rather than hierarchy. The Start and Stop button is the one visible change.