### PR TITLE
fix(data): the screen reads as structure, not four hues

### DIFF
--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -27,7 +27,6 @@ import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, size, space } from "../con
 import { useTimeout } from "../hooks/useTimeout"
 import { showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
-import { radius } from "@colota/shared"
 
 const BACKUP_TIP = "Tip: back up your data first (Settings -> Backup & Restore)."
 
@@ -253,20 +252,20 @@ export function DataManagementScreen({}: ScreenProps) {
             <SectionTitle>Database statistics</SectionTitle>
             <Card>
               {[
-                ["Total locations", stats.total.toLocaleString(), colors.text],
+                ["Total locations", stats.total.toLocaleString()],
                 ...(!isOfflineMode
                   ? [
-                      ["Sent", stats.sent.toLocaleString(), colors.success],
-                      ["Queued", stats.queued.toLocaleString(), colors.warning]
+                      ["Sent", stats.sent.toLocaleString()],
+                      ["Queued", stats.queued.toLocaleString()]
                     ]
                   : []),
-                ["Today", stats.today.toLocaleString(), colors.info],
-                ["Storage", `${stats.databaseSizeMB.toFixed(2)} MB`, colors.primary]
-              ].map(([label, value, color], i, arr) => (
+                ["Today", stats.today.toLocaleString()],
+                ["Storage", `${stats.databaseSizeMB.toFixed(2)} MB`]
+              ].map(([label, value], i, arr) => (
                 <React.Fragment key={i}>
                   <View style={styles.statRow}>
                     <Text style={[styles.statLabel, { color: colors.textSecondary }]}>{label}</Text>
-                    <Text style={[styles.statValue, { color }]}>{value}</Text>
+                    <Text style={[styles.statValue, { color: colors.text }]}>{value}</Text>
                   </View>
                   {i < arr.length - 1 && <Divider />}
                 </React.Fragment>
@@ -299,8 +298,6 @@ export function DataManagementScreen({}: ScreenProps) {
                   <ActionRow
                     label="Clear sent history"
                     hint="Delete all successfully sent locations"
-                    color={colors.success}
-                    textColor={colors.textLight}
                     value={stats.sent.toLocaleString()}
                     onPress={handleClearSentHistory}
                     disabled={isProcessing || stats.sent === 0}
@@ -311,8 +308,6 @@ export function DataManagementScreen({}: ScreenProps) {
                   <ActionRow
                     label="Clear queue"
                     hint="Delete all pending locations"
-                    color={colors.warning}
-                    textColor={colors.textLight}
                     value={stats.queued.toLocaleString()}
                     onPress={handleClearQueue}
                     disabled={isProcessing || stats.queued === 0}
@@ -325,8 +320,6 @@ export function DataManagementScreen({}: ScreenProps) {
                   <ActionRow
                     label="Delete all locations"
                     hint="Remove all stored locations from the database"
-                    color={colors.error}
-                    textColor={colors.textLight}
                     value={stats.total.toLocaleString()}
                     onPress={handleDeleteAllLocations}
                     disabled={isProcessing || stats.total === 0}
@@ -353,7 +346,13 @@ export function DataManagementScreen({}: ScreenProps) {
                     placeholder="90"
                   />
                   <Text style={[styles.daysLabel, { color: colors.textSecondary }]}>days</Text>
-                  <Button onPress={handleDeleteOlderThan} disabled={isProcessing} title="Delete" />
+                  <Button
+                    testID="delete-older-btn"
+                    onPress={handleDeleteOlderThan}
+                    disabled={isProcessing}
+                    title="Delete"
+                    variant="danger"
+                  />
                 </View>
               </View>
               <Divider />
@@ -389,20 +388,15 @@ export function DataManagementScreen({}: ScreenProps) {
   )
 }
 
-// ActionRow Component
 const ActionRow = ({
   label,
   hint,
-  color,
-  textColor,
   value,
   onPress,
   disabled
 }: {
   label: string
   hint: string
-  color: string
-  textColor: string
   value: string
   onPress: () => void
   disabled: boolean
@@ -414,14 +408,17 @@ const ActionRow = ({
       style={({ pressed }) => [styles.actionRow, pressed && { opacity: colors.pressedOpacity }]}
       onPress={onPress}
       disabled={disabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      accessibilityLabel={`${label}, ${value}. ${hint}`}
     >
       <View style={styles.actionInfo}>
-        <Text style={[styles.actionLabel, { color }]}>{label}</Text>
-        <Text style={[styles.actionHint, { color: textColor }]}>{hint}</Text>
+        <Text style={[styles.actionLabel, { color: disabled ? colors.textDisabled : colors.error }]}>{label}</Text>
+        <Text style={[styles.actionHint, { color: disabled ? colors.textDisabled : colors.textLight }]}>{hint}</Text>
       </View>
-      <View style={[styles.actionBadge, { backgroundColor: color + "20" }]}>
-        <Text style={[styles.actionBadgeText, { color }]}>{value}</Text>
-      </View>
+      <Text style={[styles.actionCount, { color: disabled ? colors.textDisabled : colors.textSecondary }]}>
+        {value}
+      </Text>
     </Pressable>
   )
 }
@@ -455,13 +452,13 @@ const styles = StyleSheet.create({
   },
   statValue: {
     fontSize: fontSizes.label,
-    ...fonts.bold
+    ...fonts.bold,
+    fontVariant: ["tabular-nums"]
   },
   hint: {
     fontSize: fontSizes.caption,
     ...fonts.regular,
     textAlign: "center",
-    fontStyle: "italic",
     lineHeight: lineHeights.caption,
     marginTop: space.sm
   },
@@ -488,14 +485,10 @@ const styles = StyleSheet.create({
     lineHeight: lineHeights.caption,
     marginTop: 2
   },
-  actionBadge: {
-    paddingHorizontal: space.md,
-    paddingVertical: 6,
-    borderRadius: radius.lg
-  },
-  actionBadgeText: {
+  actionCount: {
     fontSize: fontSizes.description,
-    ...fonts.bold
+    ...fonts.medium,
+    fontVariant: ["tabular-nums"]
   },
   daysInputRow: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import { render, fireEvent, waitFor } from "@testing-library/react-native"
+import { StyleSheet } from "react-native"
+import { lightColors } from "@colota/shared"
 
 // --- Mocks ---
 
@@ -8,26 +10,7 @@ jest.mock("@react-navigation/native", () => ({
 }))
 
 jest.mock("../../hooks/useTheme", () => ({
-  useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      card: "#fff",
-      border: "#e5e7eb",
-      background: "#fff",
-      backgroundElevated: "#f9fafb",
-      success: "#22c55e",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      error: "#ef4444",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff",
-      overlay: "rgba(0,0,0,0.5)"
-    }
-  })
+  useTheme: () => ({ colors: jest.requireActual("@colota/shared").lightColors })
 }))
 
 jest.mock("../../hooks/useTimeout", () => ({
@@ -99,9 +82,16 @@ jest.mock("../../components", () => {
       })
     },
     Button: function (props: any) {
+      // variant and testID ride through, so a screen test can assert which button it asked for.
       return R.createElement(
         RN.Pressable,
-        { onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
+        {
+          testID: props.testID,
+          variant: props.variant ?? "primary",
+          onPress: props.onPress,
+          disabled: props.disabled,
+          accessibilityRole: "button"
+        },
         R.createElement(RN.Text, null, props.title)
       )
     },
@@ -164,6 +154,38 @@ describe("DataManagementScreen", () => {
   function renderScreen() {
     return render(<DataManagementScreen navigation={{} as any} />)
   }
+
+  it("says a cleanup row is a button, because nothing but the label marks it as one", async () => {
+    const { getByLabelText } = renderScreen()
+
+    await waitFor(() => expect(getByLabelText(/^Clear sent history,/)).toBeTruthy())
+    expect(getByLabelText(/^Clear sent history,/).props.accessibilityRole).toBe("button")
+  })
+
+  it("paints every cleanup label in error, since all three delete locations for good", async () => {
+    const { getByText } = renderScreen()
+
+    await waitFor(() => expect(getByText("Clear sent history")).toBeTruthy())
+    for (const label of ["Clear sent history", "Clear queue"]) {
+      expect(StyleSheet.flatten(getByText(label).props.style).color).toBe(lightColors.error)
+    }
+  })
+
+  it("recedes a cleanup row with nothing to clear, so error does not advertise a dead action", async () => {
+    mockGetStats.mockResolvedValue({ queued: 0, sent: 100, total: 100, today: 3, databaseSizeMB: 1.5 })
+    const { getByText } = renderScreen()
+
+    await waitFor(() => expect(getByText("Clear queue")).toBeTruthy())
+    expect(StyleSheet.flatten(getByText("Clear queue").props.style).color).toBe(lightColors.textDisabled)
+    expect(StyleSheet.flatten(getByText("Clear sent history").props.style).color).toBe(lightColors.error)
+  })
+
+  it("gives the retention Delete the danger fill, since it drops locations like the rows above it", async () => {
+    const { getByTestId } = renderScreen()
+
+    await waitFor(() => expect(getByTestId("delete-older-btn")).toBeTruthy())
+    expect(getByTestId("delete-older-btn").props.variant).toBe("danger")
+  })
 
   it("renders Data Management title", async () => {
     const { getByText } = renderScreen()


### PR DESCRIPTION
Data management was the last screen filling a shape with a semantic colour, which #710 removed everywhere else and #776 took out of the format rows. Five stat values were green, orange, blue, teal and ink for numbers that carry no status, and each cleanup action put its count in a pill tinted with its own hue.

Values are ink and tabular. The count is plain text. Colour is now one signal: error marks a control that deletes locations, which covers the three cleanup rows and the retention Delete button that had been shipping as a teal primary. A disabled row recedes rather than showing a live-looking action that does nothing.

Three things found on the way: ActionRow had no accessibilityRole, so TalkBack announced nothing for three destructive actions; the theme mock used a hand-written palette matching no real token; and the Button stub dropped testID and variant, which is why no test had ever caught the primary Delete.