### PR TITLE
test(offline-maps): the delete disc is named for a screen reader

### DIFF
--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -204,6 +204,15 @@ async function waitForMapReady(findByText: ReturnType<typeof render>["findByText
 // ---------------------------------------------------------------------------
 
 describe("OfflineMapsScreen", () => {
+  it("names the delete disc, which the hand-built Pressable beside its IconButton sibling never did", async () => {
+    mockLoadOfflineAreas.mockResolvedValue([{ name: "my park", sizeBytes: 2_000_000, isComplete: true, isActive: false }])
+    const { getByTestId } = renderScreen()
+
+    await waitFor(() => expect(getByTestId("delete-btn-my park")).toBeTruthy())
+
+    expect(getByTestId("delete-btn-my park").props.accessibilityLabel).toBe("Delete my park")
+  })
+
   it("renders the name input and download button", async () => {
     const { getByPlaceholderText, findByText, getByTestId } = renderScreen()
     await waitForMapReady(findByText)


### PR DESCRIPTION
The delete disc was a hand-rolled Pressable beside an IconButton that looks identical, with no accessibilityLabel, so a screen reader announced nothing for a destructive control. #783 converted it and this covers it. The 48dp target and the role stay asserted in IconButton own test, since the shared stub drops both.