### PR TITLE
fix(share): the screen opens like its siblings and uses the danger card

### DIFF
--- a/apps/mobile/src/screens/ShareSetupScreen.tsx
+++ b/apps/mobile/src/screens/ShareSetupScreen.tsx
@@ -123,17 +123,10 @@ export function ShareSetupScreen() {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.content}>
-        <Card style={styles.headerCard}>
-          <View style={styles.headerRow}>
-            <Share2 size={28} color={colors.primary} />
-            <View style={styles.headerText}>
-              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                Choose what to bundle into a setup link, then share it. The recipient opens it to apply the same
-                configuration.
-              </Text>
-            </View>
-          </View>
-        </Card>
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>
+          Choose what to bundle into a setup link, then share it. The recipient opens it to apply the same
+          configuration.
+        </Text>
 
         <View style={styles.section}>
           <SectionTitle>Include</SectionTitle>
@@ -157,7 +150,7 @@ export function ShareSetupScreen() {
 
         {selection.credentials && hasCredentials && credentialFields.length > 0 && (
           <View style={styles.section}>
-            <Card style={[styles.warningCard, { borderColor: colors.error }]}>
+            <Card danger>
               <View style={styles.headerRow}>
                 <TriangleAlert size={size.icon.md} color={colors.error} />
                 <Text style={[styles.warningText, { color: colors.text }]}>
@@ -187,27 +180,19 @@ const styles = StyleSheet.create({
     padding: space.lg,
     paddingBottom: space.xxl
   },
-  headerCard: {
-    marginBottom: space.lg
-  },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: space.md
   },
-  headerText: {
-    flex: 1
-  },
-  subtitle: {
-    fontSize: fontSizes.description,
+  intro: {
+    fontSize: fontSizes.body,
     ...fonts.regular,
-    marginTop: 2
+    lineHeight: lineHeights.body,
+    marginBottom: space.md
   },
   section: {
     marginTop: space.sm
-  },
-  warningCard: {
-    borderWidth: StyleSheet.hairlineWidth
   },
   warningText: {
     flex: 1,

--- a/apps/mobile/src/screens/__tests__/ShareSetupScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ShareSetupScreen.test.tsx
@@ -92,6 +92,7 @@ jest.mock("../../services/NativeLocationService", () => ({
 jest.mock("../../services/modalService", () => ({ showAlert: jest.fn() }))
 
 import { ShareSetupScreen } from "../ShareSetupScreen"
+import { Card } from "../../components"
 
 const NO_AUTH = { authType: "none", username: "", password: "", bearerToken: "", customHeaders: {} }
 const BASIC_AUTH = { authType: "basic", username: "user", password: "secret", bearerToken: "", customHeaders: {} }
@@ -110,6 +111,18 @@ describe("ShareSetupScreen", () => {
   })
 
   afterEach(() => shareSpy.mockRestore())
+
+  it("warns through the Card danger variant rather than a border drawn by hand", async () => {
+    mockGetAuthConfig.mockResolvedValue(BASIC_AUTH)
+    const { getByTestId, UNSAFE_getAllByType } = render(<ShareSetupScreen />)
+    await waitFor(() => expect(mockGetAuthConfig).toHaveBeenCalled())
+
+    fireEvent(getByTestId("share-credentials"), "valueChange", true)
+
+    const warning = await waitFor(() => UNSAFE_getAllByType(Card).find((c) => c.props.danger))
+    expect(warning).toBeTruthy()
+    expect(warning!.props.style).toBeUndefined()
+  })
 
   it("shares nothing until a category is toggled on", async () => {
     const { getByText } = render(<ShareSetupScreen />)


### PR DESCRIPTION
Three things the guards cannot see, because each value sits outside the scale its rule matches.

The intro was wrapped in a Card, which is a neutral box for grouping and is what #726 took out everywhere else; its three sibling screens open with a bare paragraph. The hero glyph was size 28, off the 16/20/24 ladder, and goes with it. The credentials warning passed borderColor through style and added its own hairline instead of taking Card danger, so it drew a thinner border and no tint.