### PR TITLE
fix(a11y): every Pressable says what it is

### DIFF
--- a/apps/mobile/src/__tests__/pressableRoleGuard.test.ts
+++ b/apps/mobile/src/__tests__/pressableRoleGuard.test.ts
@@ -1,0 +1,101 @@
+// See designSystemGuard for why this file declares the node corner it needs by hand.
+export {}
+
+declare const __dirname: string
+
+type Entry = { name: string; isDirectory: () => boolean }
+const fs: {
+  readdirSync: (dir: string, options: { withFileTypes: true }) => Entry[]
+  readFileSync: (file: string, encoding: "utf8") => string
+} = require("fs")
+const path: { join: (...parts: string[]) => string } = require("path")
+
+/**
+ * A bare `Pressable` announces nothing to TalkBack: no role, so it does not read as a control, and
+ * usually no name either, so there is nothing to read out. Data management shipped three
+ * destructive actions that way and the offline-maps delete disc sat silent beside an IconButton
+ * that looks identical.
+ *
+ * `none` is a real answer for a modal scrim and for the view that swallows a tap inside it, which
+ * is why this asks for a role rather than for a label.
+ */
+const SRC = path.join(__dirname, "..")
+const ROOTS = ["screens", "components"]
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(path.join(SRC, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") walk(rel)
+      } else if (/\.tsx$/.test(entry.name)) {
+        found.push(rel)
+      }
+    }
+  }
+  ROOTS.forEach(walk)
+  return found.sort()
+}
+
+/**
+ * Reads each opening tag by tracking brace depth. A regex cannot: `onPress={() => x}` puts a `>`
+ * inside the tag, so matching to the first one stops before the props that follow it and reports
+ * tags as bare when they are not.
+ */
+function openingTags(source: string): { tag: string; line: number }[] {
+  const tags: { tag: string; line: number }[] = []
+  let from = 0
+
+  for (;;) {
+    const start = source.indexOf("<Pressable", from)
+    if (start === -1) return tags
+
+    let i = start + "<Pressable".length
+    let depth = 0
+    let quote: string | null = null
+
+    for (; i < source.length; i++) {
+      const c = source[i]
+      if (quote) {
+        if (c === quote && source[i - 1] !== "\\") quote = null
+        continue
+      }
+      if (c === '"' || c === "'" || c === "`") quote = c
+      else if (c === "{") depth++
+      else if (c === "}") depth--
+      else if (c === ">" && depth === 0 && source[i - 1] !== "=") break
+    }
+
+    tags.push({ tag: source.slice(start, i), line: source.slice(0, start).split("\n").length })
+    from = i
+  }
+}
+
+describe("pressable role guard", () => {
+  const files = sourceFiles()
+
+  it("finds the Pressables it is meant to police", () => {
+    const total = files.reduce((n, f) => n + openingTags(fs.readFileSync(path.join(SRC, f), "utf8")).length, 0)
+
+    expect(total).toBeGreaterThan(50)
+  })
+
+  it("reads a tag past the arrow in an inline handler", () => {
+    const [only] = openingTags(`<Pressable onPress={() => go()} accessibilityRole="button">x</Pressable>`)
+
+    expect(only.tag).toContain("accessibilityRole")
+  })
+
+  it("gives every Pressable a role, so none of them announces as nothing", () => {
+    const bare: string[] = []
+
+    for (const file of files) {
+      for (const { tag, line } of openingTags(fs.readFileSync(path.join(SRC, file), "utf8"))) {
+        if (!/accessibilityRole/.test(tag)) bare.push(`${file}:${line}`)
+      }
+    }
+
+    expect(bare).toEqual([])
+  })
+})

--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -86,6 +86,7 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
 
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() => navigation.navigate("Connection")}
       style={({ pressed }) => [
         styles.container,

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -177,6 +177,7 @@ export function DashboardMap({
 
       {waitingForFix && locationOff && (
         <Pressable
+          accessibilityRole="button"
           onPress={() => NativeLocationService.openLocationSettings()}
           style={[
             styles.stateContainer,
@@ -224,6 +225,7 @@ export function DashboardMap({
 
       {showMap && locationOff && (
         <Pressable
+          accessibilityRole="button"
           onPress={() => NativeLocationService.openLocationSettings()}
           style={[styles.statusBar, { backgroundColor: colors.error + "DD" }]}
         >

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -55,7 +55,11 @@ function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps
 
   if (onPress && !completed) {
     return (
-      <Pressable onPress={onPress} style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}>
+      <Pressable
+        accessibilityRole="button"
+        onPress={onPress}
+        style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+      >
         {content}
       </Pressable>
     )
@@ -100,6 +104,7 @@ export function WelcomeCard({
         <View style={styles.linkRow}>
           {!isOfflineMode && (
             <Pressable
+              accessibilityRole="button"
               onPress={onNavigateToApiConfig}
               style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
             >
@@ -107,6 +112,7 @@ export function WelcomeCard({
             </Pressable>
           )}
           <Pressable
+            accessibilityRole="button"
             onPress={onNavigateToTrackingSync}
             style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
           >

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -233,6 +233,8 @@ export function CalendarPicker({
       {/* Compact header row */}
       <View style={styles.row}>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Previous day"
           onPress={goBack}
           hitSlop={HIT_SLOP_LG}
           style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
@@ -263,6 +265,9 @@ export function CalendarPicker({
         </Pressable>
 
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Next day"
+          accessibilityState={{ disabled: isToday }}
           onPress={goForward}
           hitSlop={HIT_SLOP_LG}
           style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
@@ -274,6 +279,7 @@ export function CalendarPicker({
 
       {!isToday && !isExpanded && (
         <Pressable
+          accessibilityRole="button"
           onPress={goToToday}
           hitSlop={HIT_SLOP_LG}
           style={({ pressed }) => [
@@ -427,6 +433,8 @@ export function CalendarPicker({
                   return (
                     <Pressable
                       key={cell.key}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: isSelected, disabled: isFuture }}
                       style={styles.dayCell}
                       onPress={() => selectDay(cell.day!)}
                       disabled={isFuture}

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -334,6 +334,8 @@ export function TrackMap({
                 </Pressable>
               )}
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Close point details"
                 onPress={() => {
                   setPopup(null)
                   setSelectedPoint(null)
@@ -379,6 +381,8 @@ export function TrackMap({
                   {noteDraft.trim() !== popup.note && (
                     <Pressable
                       testID="popup-note-save"
+                      accessibilityRole="button"
+                      accessibilityLabel="Save note"
                       onPress={handleSaveNote}
                       hitSlop={HIT_SLOP_MD}
                       style={({ pressed }) => [styles.noteSaveBtn, pressed && { opacity: colors.pressedOpacity }]}

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -220,8 +220,13 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
             animationType="fade"
             onRequestClose={() => setAttributionOpen(false)}
           >
-            <Pressable style={styles.attributionBackdrop} onPress={() => setAttributionOpen(false)}>
+            <Pressable
+              accessibilityRole="none"
+              style={styles.attributionBackdrop}
+              onPress={() => setAttributionOpen(false)}
+            >
               <Pressable
+                accessibilityRole="none"
                 onPress={() => {}}
                 style={[styles.attributionPopup, { backgroundColor: colors.card }]}
               >
@@ -237,6 +242,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
                 {attributionLinks.map((link) => (
                   <Pressable
                     key={link.url}
+                    accessibilityRole="link"
                     onPress={() => Linking.openURL(link.url)}
                     style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
                   >

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -106,6 +106,9 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
     () => (
       <View style={styles.headerButtons}>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Export log"
+          accessibilityState={{ disabled: exporting }}
           onPress={handleExport}
           disabled={exporting}
           style={({ pressed }) => [styles.headerButton, pressed && { opacity: colors.pressedOpacity }]}
@@ -217,7 +220,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
             autoCorrect={false}
           />
           {searchQuery.length > 0 && (
-            <Pressable onPress={() => setSearchQuery("")}>
+            <Pressable accessibilityRole="button" accessibilityLabel="Clear search" onPress={() => setSearchQuery("")}>
               <X size={size.icon.sm} color={colors.textLight} />
             </Pressable>
           )}
@@ -231,6 +234,9 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
             return (
               <Pressable
                 key={level}
+                accessibilityRole="button"
+                accessibilityLabel={`${level}, ${count}`}
+                accessibilityState={{ selected: active }}
                 onPress={() => toggleLevel(level)}
                 hitSlop={HIT_SLOP_MD}
                 style={[
@@ -294,6 +300,8 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
 
       {showScrollEnd ? (
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Scroll to newest"
           onPress={scrollToEnd}
           style={[styles.scrollEndButton, { backgroundColor: colors.primary, bottom: insets.bottom + 24 }]}
         >

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -176,6 +176,7 @@ export function AppearanceScreen({}: ScreenProps) {
                 </Text>
                 {mapStyleUrlLight.trim() || mapStyleUrlDark.trim() ? (
                   <Pressable
+                    accessibilityRole="button"
                     onPress={resetMapStyle}
                     style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
                   >

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -419,6 +419,7 @@ export function AutoExportScreen(_props: ScreenProps) {
           <SectionTitle>Export directory</SectionTitle>
           <Card>
             <Pressable
+              accessibilityRole="button"
               style={({ pressed }) => [styles.directoryRow, pressed && { opacity: colors.pressedOpacity }]}
               onPress={handlePickDirectory}
             >
@@ -652,6 +653,8 @@ export function AutoExportScreen(_props: ScreenProps) {
                       </Text>
                     </View>
                     <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`Share ${file.name}`}
                       style={({ pressed }) => [styles.shareButton, pressed && { opacity: colors.pressedOpacity }]}
                       onPress={() => handleShareFile(file)}
                     >

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -249,6 +249,8 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
       <Card style={styles.card}>
         <View style={styles.row}>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Show ${item.name} on the map`}
             onPress={() => handleZoomToGeofence(item)}
             hitSlop={HIT_SLOP_MD}
             style={({ pressed }) => [styles.zoomBtn, pressed && { opacity: colors.pressedOpacity }]}
@@ -257,6 +259,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
           </Pressable>
           <Pressable
             testID={`edit-geofence-${item.id}`}
+            accessibilityRole="button"
             style={({ pressed }) => [styles.editBtn, pressed && { opacity: colors.pressedOpacity }]}
             onPress={() => navigation.navigate("Geofence Editor", { geofenceId: item.id })}
           >
@@ -339,6 +342,8 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
                 <SectionTitle>Active Geofences ({geofences.length})</SectionTitle>
                 <Pressable
                   testID="share-geofences-btn"
+                  accessibilityRole="button"
+                  accessibilityLabel="Share all zones"
                   onPress={handleShareGeofences}
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [styles.shareBtn, pressed && { opacity: colors.pressedOpacity }]}

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -86,6 +86,8 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
   const headerRight = useCallback(
     () => (
       <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Location summary"
         onPress={() => navigation.navigate("Location Summary")}
         style={({ pressed }) => [styles.headerBtn, pressed && { opacity: colors.pressedOpacity }]}
       >

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -152,6 +152,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
   const renderDailyStat = useCallback(
     ({ item }: { item: DailyStat }) => (
       <Pressable
+        accessibilityRole="button"
         onPress={() => handleDayPress(item.day)}
         style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
       >

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -690,6 +690,8 @@ export function OfflineMapsScreen({}: ScreenProps) {
         <Card style={styles.card}>
           <View style={styles.row}>
             <Pressable
+              accessibilityRole="button"
+              accessibilityState={{ disabled: item.isActive }}
               style={({ pressed }) => [styles.info, pressed && { opacity: colors.pressedOpacity }]}
               onPress={() => fitToArea(item.name)}
               disabled={item.isActive}

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -115,6 +115,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
       return (
         <Card style={[styles.card, isActive && { backgroundColor: colors.primaryContainer }]}>
           <Pressable
+            accessibilityRole="button"
             style={({ pressed }) => [styles.row, pressed && { opacity: colors.pressedOpacity }]}
             onPress={() => navigation.navigate("Profile Editor", { profileId: item.id })}
           >
@@ -186,6 +187,8 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
                 <SectionTitle>Profiles ({profiles.length})</SectionTitle>
                 <Pressable
                   testID="share-profiles-btn"
+                  accessibilityRole="button"
+                  accessibilityLabel="Share all profiles"
                   onPress={handleShareProfiles}
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [styles.shareBtn, pressed && { opacity: colors.pressedOpacity }]}

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -214,6 +214,9 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
   const headerRight = useCallback(
     () => (
       <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Delete trip"
+        accessibilityState={{ disabled: deleting }}
         onPress={handleDelete}
         disabled={deleting}
         hitSlop={HIT_SLOP_MD}
@@ -268,6 +271,9 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
         <View style={styles.section}>
           <View style={styles.headerTitleRow}>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Previous trip"
+              accessibilityState={{ disabled: !prevTrip }}
               onPress={() => goToTrip(prevTrip)}
               disabled={!prevTrip}
               hitSlop={HIT_SLOP_LG}
@@ -285,6 +291,9 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               </Text>
             </View>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Next trip"
+              accessibilityState={{ disabled: !nextTrip }}
               onPress={() => goToTrip(nextTrip)}
               disabled={!nextTrip}
               hitSlop={HIT_SLOP_LG}
@@ -391,6 +400,8 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               {EXPORT_FORMAT_KEYS.map((fmt) => (
                 <Pressable
                   key={fmt}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Export as ${fmt.toUpperCase()}`}
                   onPress={() => handleExport(fmt)}
                   hitSlop={HIT_SLOP_MD}
                   style={({ pressed }) => [


### PR DESCRIPTION
Thirty-four Pressables had no accessibilityRole and mostly no label either, so TalkBack announced nothing at all for them. That is the defect Data management shipped on three destructive actions and the offline-maps delete disc shipped beside an IconButton that looks identical.

Icon-only controls gain a label because they have no text to fall back on. Text-bearing rows take a role and let their children name them. The map attribution scrim and its tap-swallowing inner view take role none, since neither is a control and TalkBack dismisses with back, which is why the guard asks for a role rather than a label.

The guard parses each opening tag by brace depth. A regex cannot: onPress={() => x} puts a > inside the tag, so matching to the first one stops early and reports tags as bare when they are not. That bug made the first count of this class 53 instead of 34, and a test pins the parser against it.