### PR TITLE
fix(settings): report a failed save instead of logging it

### DIFF
--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -13,8 +13,7 @@ import { size, space } from "../../constants"
 
 interface Props {
   saving: boolean
-  success: boolean
-  /** Optional custom message. When provided, controls visibility instead of saving/success. */
+  /** Shown once the work is done; absent when there is nothing to report. */
   message?: string | null
   isError?: boolean
   colors: {
@@ -25,9 +24,9 @@ interface Props {
   }
 }
 
-export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, message, isError, colors }) => {
+export const FloatingSaveIndicator: React.FC<Props> = ({ saving, message, isError, colors }) => {
   const hasMessage = message != null
-  const visible = hasMessage || saving || success
+  const visible = hasMessage || saving
 
   const translateY = useRef(new Animated.Value(60)).current
   const opacity = useRef(new Animated.Value(0)).current
@@ -46,7 +45,7 @@ export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, messag
     }
   }, [visible, translateY, opacity])
 
-  const displayText = hasMessage ? message : saving ? "Saving & restarting..." : "Saved"
+  const displayText = hasMessage ? message : "Saving..."
 
   return (
     <Animated.View style={[styles.container, { opacity, transform: [{ translateY }] }]} pointerEvents="none">
@@ -60,9 +59,9 @@ export const FloatingSaveIndicator: React.FC<Props> = ({ saving, success, messag
       >
         {saving ? (
           <SpinningLoader size={size.icon.sm} color={colors.text} />
-        ) : !hasMessage ? (
+        ) : isError ? null : (
           <Check size={size.icon.sm} color={colors.text} />
-        ) : null}
+        )}
         <Text style={[styles.text, { color: colors.text }]}>{displayText}</Text>
       </View>
     </Animated.View>

--- a/apps/mobile/src/contexts/TrackingProvider.tsx
+++ b/apps/mobile/src/contexts/TrackingProvider.tsx
@@ -27,7 +27,7 @@ type TrackingContextType = {
   activeProfileName: string | null
   startTracking: () => Promise<void>
   stopTracking: () => void
-  restartTracking: (newSettings?: Settings) => Promise<void>
+  restartTracking: (newSettings?: Settings) => Promise<boolean>
 }
 
 const TrackingContext = createContext<TrackingContextType | null>(null)
@@ -295,10 +295,11 @@ export function TrackingProvider({ children }: { children: React.ReactNode }) {
   const restartTracking = useCallback(
     async (newSettings?: Settings) => {
       try {
-        await internalRestart(newSettings || settings)
+        const restarted = await internalRestart(newSettings || settings)
         if (isMountedRef.current) {
           setError(null)
         }
+        return restarted
       } catch (err) {
         logger.error("[TrackingContext] Failed to restart tracking:", err)
         if (isMountedRef.current) {

--- a/apps/mobile/src/hooks/__tests__/useAutoSave.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useAutoSave.test.ts
@@ -14,18 +14,18 @@ afterEach(() => {
 
 describe("useAutoSave", () => {
   describe("initial state", () => {
-    it("starts with saving=false and saveSuccess=false", () => {
+    it("starts with saving=false and nothing to say", () => {
       const { result } = renderHook(() => useAutoSave())
 
       expect(result.current.saving).toBe(false)
-      expect(result.current.saveSuccess).toBe(false)
+      expect(result.current.message).toBeNull()
     })
   })
 
   describe("debouncedSaveAndRestart", () => {
     it("does not call saveFn immediately", () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       act(() => {
@@ -37,7 +37,7 @@ describe("useAutoSave", () => {
 
     it("calls saveFn after debounce delay", async () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       act(() => {
@@ -54,7 +54,7 @@ describe("useAutoSave", () => {
     it("cancels previous debounce when called again", async () => {
       const saveFn1 = jest.fn().mockResolvedValue(undefined)
       const saveFn2 = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       act(() => {
@@ -75,7 +75,7 @@ describe("useAutoSave", () => {
 
     it("sets saving=true during save, then restarts immediately", async () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       act(() => {
@@ -91,9 +91,9 @@ describe("useAutoSave", () => {
       expect(restartFn).toHaveBeenCalledTimes(1)
     })
 
-    it("sets saveSuccess=true after restart completes, then clears it", async () => {
+    it("says the service was restarted, because nothing on screen shows that it was", async () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       act(() => {
@@ -105,19 +105,35 @@ describe("useAutoSave", () => {
         jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
       })
 
-      expect(result.current.saveSuccess).toBe(true)
+      expect(result.current.message).toBe("Tracking restarted")
+      expect(result.current.isError).toBe(false)
 
-      // Success display clears
       await act(async () => {
         jest.advanceTimersByTime(SAVE_SUCCESS_DISPLAY_MS)
       })
 
-      expect(result.current.saveSuccess).toBe(false)
+      expect(result.current.message).toBeNull()
     })
 
-    it("handles save failure gracefully", async () => {
+    it("stays quiet when the service was not running, since a plain write needs no confirming", async () => {
+      const saveFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(false)
+      const { result } = renderHook(() => useAutoSave())
+
+      act(() => {
+        result.current.debouncedSaveAndRestart(saveFn, restartFn)
+      })
+
+      await act(async () => {
+        jest.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS)
+      })
+
+      expect(result.current.message).toBeNull()
+    })
+
+    it("says a failed save failed, rather than looking exactly like a success", async () => {
       const saveFn = jest.fn().mockRejectedValue(new Error("save failed"))
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       act(() => {
@@ -129,10 +145,12 @@ describe("useAutoSave", () => {
       })
 
       expect(result.current.saving).toBe(false)
+      expect(result.current.message).toBe("Could not save")
+      expect(result.current.isError).toBe(true)
       expect(restartFn).not.toHaveBeenCalled()
     })
 
-    it("handles restart failure gracefully", async () => {
+    it("says a failed restart failed, which was silent before", async () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
       const restartFn = jest.fn().mockRejectedValue(new Error("restart failed"))
       const { result } = renderHook(() => useAutoSave())
@@ -147,14 +165,15 @@ describe("useAutoSave", () => {
       })
 
       expect(result.current.saving).toBe(false)
-      expect(result.current.saveSuccess).toBe(false)
+      expect(result.current.message).toBe("Could not restart tracking")
+      expect(result.current.isError).toBe(true)
     })
   })
 
   describe("immediateSaveAndRestart", () => {
     it("calls saveFn immediately", async () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       await act(async () => {
@@ -166,7 +185,7 @@ describe("useAutoSave", () => {
 
     it("sets saving=true immediately", () => {
       const saveFn = jest.fn().mockReturnValue(new Promise(() => {})) // never resolves
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       act(() => {
@@ -179,7 +198,7 @@ describe("useAutoSave", () => {
     it("cancels any pending debounced save", async () => {
       const debouncedSave = jest.fn().mockResolvedValue(undefined)
       const immediateSave = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       // Start a debounced save
@@ -202,7 +221,7 @@ describe("useAutoSave", () => {
 
     it("schedules debounced restart after save", async () => {
       const saveFn = jest.fn().mockResolvedValue(undefined)
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       await act(async () => {
@@ -221,7 +240,7 @@ describe("useAutoSave", () => {
 
     it("handles save failure gracefully", async () => {
       const saveFn = jest.fn().mockRejectedValue(new Error("save failed"))
-      const restartFn = jest.fn().mockResolvedValue(undefined)
+      const restartFn = jest.fn().mockResolvedValue(true)
       const { result } = renderHook(() => useAutoSave())
 
       await act(async () => {

--- a/apps/mobile/src/hooks/useAutoSave.ts
+++ b/apps/mobile/src/hooks/useAutoSave.ts
@@ -9,48 +9,65 @@ import { AUTOSAVE_DEBOUNCE_MS, SAVE_SUCCESS_DISPLAY_MS } from "../constants"
 import { logger } from "../utils/logger"
 
 /**
- * Hook that encapsulates the debounced auto-save pattern used across settings screens.
+ * The debounced auto-save behind the settings screens.
  *
- * Manages:
- * - Debounced and immediate save triggers
- * - Saving/success state for FloatingSaveIndicator
- * - Timeout cleanup on unmount (via useTimeout)
+ * A plain write is not announced: the control the user moved is the confirmation, which is how
+ * Android settings behave. Only two outcomes get a message - a restart, because the service
+ * cycling has nothing on screen to show for it, and a failure.
  */
 export function useAutoSave() {
   const [saving, setSaving] = useState(false)
-  const [saveSuccess, setSaveSuccess] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [isError, setIsError] = useState(false)
   const saveTimeout = useTimeout()
   const restartTimeout = useTimeout()
-  const successTimeout = useTimeout()
+  const messageTimeout = useTimeout()
+
+  const announce = useCallback(
+    (text: string, failed: boolean) => {
+      setMessage(text)
+      setIsError(failed)
+      messageTimeout.set(() => setMessage(null), SAVE_SUCCESS_DISPLAY_MS)
+    },
+    [messageTimeout]
+  )
+
+  const runRestart = useCallback(
+    async (restartFn: () => Promise<boolean>) => {
+      try {
+        if (await restartFn()) announce("Tracking restarted", false)
+      } catch (err) {
+        logger.error("[useAutoSave] Restart failed:", err)
+        announce("Could not restart tracking", true)
+      } finally {
+        setSaving(false)
+      }
+    },
+    [announce]
+  )
 
   /**
    * Schedules a debounced restart after settings are persisted.
    * Use when you need to save settings first, then restart tracking after the debounce.
    */
   const debouncedSaveAndRestart = useCallback(
-    (saveFn: () => Promise<void>, restartFn: () => Promise<void>) => {
+    (saveFn: () => Promise<void>, restartFn: () => Promise<boolean>) => {
       saveTimeout.set(async () => {
         setSaving(true)
         try {
           await saveFn()
-          // Restart immediately — input was already debounced by saveTimeout
-          restartTimeout.clear()
-          try {
-            await restartFn()
-            setSaveSuccess(true)
-            successTimeout.set(() => setSaveSuccess(false), SAVE_SUCCESS_DISPLAY_MS)
-          } catch (err) {
-            logger.error("[useAutoSave] Restart failed:", err)
-          } finally {
-            setSaving(false)
-          }
         } catch (err) {
           setSaving(false)
           logger.error("[useAutoSave] Save failed:", err)
+          announce("Could not save", true)
+          return
         }
+        // Restart immediately: the input was already debounced by saveTimeout.
+        restartTimeout.clear()
+        await runRestart(restartFn)
       }, AUTOSAVE_DEBOUNCE_MS)
     },
-    [saveTimeout, restartTimeout, successTimeout]
+    [saveTimeout, restartTimeout, runRestart, announce]
   )
 
   /**
@@ -59,34 +76,26 @@ export function useAutoSave() {
    * but batch the restart.
    */
   const immediateSaveAndRestart = useCallback(
-    (saveFn: () => Promise<void>, restartFn: () => Promise<void>) => {
+    (saveFn: () => Promise<void>, restartFn: () => Promise<boolean>) => {
       saveTimeout.clear()
       setSaving(true)
       saveFn()
         .then(() => {
-          restartTimeout.set(async () => {
-            try {
-              await restartFn()
-              setSaveSuccess(true)
-              successTimeout.set(() => setSaveSuccess(false), SAVE_SUCCESS_DISPLAY_MS)
-            } catch (err) {
-              logger.error("[useAutoSave] Restart failed:", err)
-            } finally {
-              setSaving(false)
-            }
-          }, AUTOSAVE_DEBOUNCE_MS)
+          restartTimeout.set(() => runRestart(restartFn), AUTOSAVE_DEBOUNCE_MS)
         })
         .catch((err) => {
           setSaving(false)
           logger.error("[useAutoSave] Save failed:", err)
+          announce("Could not save", true)
         })
     },
-    [saveTimeout, restartTimeout, successTimeout]
+    [saveTimeout, restartTimeout, runRestart, announce]
   )
 
   return {
     saving,
-    saveSuccess,
+    message,
+    isError,
     debouncedSaveAndRestart,
     immediateSaveAndRestart
   }

--- a/apps/mobile/src/hooks/useLocationTracking.ts
+++ b/apps/mobile/src/hooks/useLocationTracking.ts
@@ -211,19 +211,20 @@ export function useLocationTracking(settings: Settings, settingsHydrated: boolea
    * Includes delay for Android to release foreground service resources
    * @param newSettings Settings for the new service instance
    */
+  /** False when nothing was cycled: tracking was off, or a restart was already in flight. */
   const restartTracking = useCallback(
-    async (newSettings?: Settings) => {
+    async (newSettings?: Settings): Promise<boolean> => {
       // Only restart if tracking is active — settings are persisted separately,
       // so they'll be picked up when the user starts tracking later.
       if (!isTrackingRef.current) {
         logger.debug("[useLocationTracking] Not tracking, skip restart (settings saved separately)")
-        return
+        return false
       }
 
       if (restartingRef.current) {
         logger.debug("[useLocationTracking] Restart already in progress, queuing")
         restartQueuedRef.current = true
-        return
+        return false
       }
 
       logger.debug("[useLocationTracking] Restarting service")
@@ -237,6 +238,7 @@ export function useLocationTracking(settings: Settings, settingsHydrated: boolea
         await new Promise<void>((resolve) => setTimeout(resolve, SERVICE_RESTART_DELAY_MS))
 
         await startTracking(newSettings ?? settingsRef.current)
+        return true
       } finally {
         restartingRef.current = false
         setIsRestarting(false)

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -113,7 +113,13 @@ export function ApiSettingsScreen({}: ScreenProps) {
   const showDawarichChip = localTemplate === "dawarich"
   const batchDisabled = isInstantSync || isGetMethod
   const copiedTimeout = useTimeout()
-  const { saving, saveSuccess, debouncedSaveAndRestart, immediateSaveAndRestart } = useAutoSave()
+  const {
+    saving,
+    message: saveMessage,
+    isError: saveIsError,
+    debouncedSaveAndRestart,
+    immediateSaveAndRestart
+  } = useAutoSave()
 
   const referenceFieldMap = getReferenceFieldMap(localTemplate)
 
@@ -722,7 +728,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
       </ScrollView>
 
       {/* Floating Save Indicator */}
-      <FloatingSaveIndicator saving={saving} success={saveSuccess} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -46,7 +46,13 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
 
   const [config, setConfig] = useState<AuthConfig>(DEFAULT_AUTH_CONFIG)
   const [loading, setLoading] = useState(true)
-  const { saving, saveSuccess, debouncedSaveAndRestart, immediateSaveAndRestart } = useAutoSave()
+  const {
+    saving,
+    message: saveMessage,
+    isError: saveIsError,
+    debouncedSaveAndRestart,
+    immediateSaveAndRestart
+  } = useAutoSave()
 
   const nextIdRef = useRef(0)
   const assignId = () => nextIdRef.current++
@@ -319,7 +325,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
         </View>
       </ScrollView>
 
-      <FloatingSaveIndicator saving={saving} success={saveSuccess} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -24,7 +24,7 @@ import {
   TextField
 } from "../components"
 import { useTheme } from "../hooks/useTheme"
-import { useTimeout } from "../hooks/useTimeout"
+
 import { ScreenProps } from "../types/global"
 import NativeLocationService from "../services/NativeLocationService"
 import {
@@ -40,7 +40,7 @@ import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { formatExportDateTime, formatBytes } from "../utils/format"
 import { showAlert } from "../services/modalService"
-import { SAVE_SUCCESS_DISPLAY_MS, size, space } from "../constants"
+import { size, space } from "../constants"
 
 type ExportInterval = "daily" | "weekly" | "monthly"
 type ExportMode = "all" | "incremental"
@@ -101,8 +101,6 @@ export function AutoExportScreen(_props: ScreenProps) {
   const [exporting, setExporting] = useState(false)
   const [exportRunning, setExportRunning] = useState(false)
   const [saving, setSaving] = useState(false)
-  const [saveSuccess, setSaveSuccess] = useState(false)
-  const successTimeout = useTimeout()
 
   const loadStatus = useCallback(async () => {
     try {
@@ -187,22 +185,17 @@ export function AutoExportScreen(_props: ScreenProps) {
     return () => listener.remove()
   }, [loadStatus, loadExportFiles])
 
-  const saveSetting = useCallback(
-    async (key: string, value: string) => {
-      setSaving(true)
-      try {
-        await NativeLocationService.saveSetting(key, value)
-        setSaving(false)
-        setSaveSuccess(true)
-        successTimeout.set(() => setSaveSuccess(false), SAVE_SUCCESS_DISPLAY_MS)
-      } catch (error) {
-        setSaving(false)
-        logger.error("[AutoExportScreen] Save failed:", error)
-        showAlert("Error", "Failed to save setting. Please try again.", "error")
-      }
-    },
-    [successTimeout]
-  )
+  const saveSetting = useCallback(async (key: string, value: string) => {
+    setSaving(true)
+    try {
+      await NativeLocationService.saveSetting(key, value)
+      setSaving(false)
+    } catch (error) {
+      setSaving(false)
+      logger.error("[AutoExportScreen] Save failed:", error)
+      showAlert("Error", "Failed to save setting. Please try again.", "error")
+    }
+  }, [])
 
   const handleToggle = useCallback(
     async (value: boolean) => {
@@ -667,7 +660,7 @@ export function AutoExportScreen(_props: ScreenProps) {
           </View>
         )}
       </ScrollView>
-      <FloatingSaveIndicator saving={saving} success={saveSuccess} colors={colors} />
+      <FloatingSaveIndicator saving={saving} colors={colors} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/ConnectionScreen.tsx
+++ b/apps/mobile/src/screens/ConnectionScreen.tsx
@@ -17,7 +17,7 @@ import { space } from "../constants"
 export function ConnectionScreen({ navigation }: ScreenProps) {
   const { settings, setSettings, restartTracking } = useTracking()
   const { colors } = useTheme()
-  const { saving, saveSuccess, immediateSaveAndRestart } = useAutoSave()
+  const { saving, message: saveMessage, isError: saveIsError, immediateSaveAndRestart } = useAutoSave()
 
   const [endpointInput, setEndpointInput] = useState(settings.endpoint || "")
 
@@ -52,7 +52,7 @@ export function ConnectionScreen({ navigation }: ScreenProps) {
         />
       </ScrollView>
 
-      <FloatingSaveIndicator saving={saving} success={saveSuccess} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -378,7 +378,6 @@ export function DataManagementScreen({}: ScreenProps) {
         {/* Floating Feedback */}
         <FloatingSaveIndicator
           saving={isProcessing}
-          success={false}
           message={feedback}
           isError={feedback?.toLowerCase().includes("failed") ?? false}
           colors={colors}

--- a/apps/mobile/src/screens/TrackingSyncScreen.tsx
+++ b/apps/mobile/src/screens/TrackingSyncScreen.tsx
@@ -17,7 +17,13 @@ import { space } from "../constants"
 export function TrackingSyncScreen({}: ScreenProps) {
   const { settings, setSettings, updateSettingsLocal, restartTracking } = useTracking()
   const { colors } = useTheme()
-  const { saving, saveSuccess, debouncedSaveAndRestart, immediateSaveAndRestart } = useAutoSave()
+  const {
+    saving,
+    message: saveMessage,
+    isError: saveIsError,
+    debouncedSaveAndRestart,
+    immediateSaveAndRestart
+  } = useAutoSave()
 
   const handleDebouncedSave = useCallback(
     (newSettings: Settings) => {
@@ -55,7 +61,7 @@ export function TrackingSyncScreen({}: ScreenProps) {
         />
       </ScrollView>
 
-      <FloatingSaveIndicator saving={saving} success={saveSuccess} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
     </Container>
   )
 }

--- a/apps/mobile/src/types/global.ts
+++ b/apps/mobile/src/types/global.ts
@@ -60,7 +60,7 @@ export interface LocationTrackingResult {
   tracking: boolean
   startTracking: (overrideSettings?: Settings) => Promise<void>
   stopTracking: () => void
-  restartTracking: (newSettings?: Settings) => Promise<void>
+  restartTracking: (newSettings?: Settings) => Promise<boolean>
   reconnect: (settings?: Settings) => Promise<void>
   settings: Settings
 }


### PR DESCRIPTION
useAutoSave caught a failed save and a failed restart, called logger.error and returned. The spinner disappeared, no badge appeared, and the screen went on showing a value that had not persisted, so across six screens a failure looked exactly like a success. Both paths now surface an error.

The success badge is dropped. Android settings auto-save and confirm nothing, because the control the user just moved is the confirmation, and Material reserves a message for what the UI does not already show. One exception is real: saving a tracking setting restarts the service, which has nothing on screen to show for it. restartTracking returned early and undefined when tracking was off, so nothing downstream could tell a real restart from a no-op; it resolves a boolean now, and only a real restart is announced.

Auto-export does not use the hook and already alerts on failure, so it only loses the redundant badge and the timeout behind it. Data management keeps its own message path, since those operations genuinely have invisible outcomes.

Two of the hook tests were named "handles save failure gracefully" and asserted that nothing was announced. They passed because of the bug rather than despite it, and now assert the message.