### PR TITLE
fix(geo): a duration in minutes reads min, not m

### DIFF
--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -245,7 +245,7 @@ describe("SettingsScreen", () => {
 
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    expect(getByText("Every 30s · syncs every 5m")).toBeTruthy()
+    expect(getByText("Every 30s · syncs every 5min")).toBeTruthy()
   })
 
   it("says instantly rather than every 0s when nothing is batched", () => {

--- a/apps/mobile/src/utils/__tests__/geo.test.ts
+++ b/apps/mobile/src/utils/__tests__/geo.test.ts
@@ -1,4 +1,5 @@
 import {
+  formatDuration,
   computeTotalDistance,
   formatDistance,
   formatShortDistance,
@@ -127,6 +128,16 @@ describe("formatDistance", () => {
       throw new Error("unsupported")
     })
     expect(formatDistance(5000)).toBe("5.0 km")
+  })
+})
+
+describe("formatDuration", () => {
+  it("abbreviates minutes as min, because m is metres and both appear on a trip", () => {
+    expect(formatDuration(34 * 60)).toBe("34min")
+  })
+
+  it("carries the hour when there is one", () => {
+    expect(formatDuration(3600 + 34 * 60)).toBe("1h 34min")
   })
 })
 

--- a/apps/mobile/src/utils/geo.ts
+++ b/apps/mobile/src/utils/geo.ts
@@ -107,13 +107,13 @@ export function getSpeedUnit(): { factor: number; unit: string } {
   return usesMiles() ? { factor: MPH_PER_MPS, unit: "mph" } : { factor: 3.6, unit: "km/h" }
 }
 
-/** Format seconds duration as "Xh Ym" or "Ym" */
+/** Format seconds duration as "Xh Ymin" or "Ymin" */
 export function formatDuration(seconds: number): string {
   const s = Math.max(0, seconds)
   const hours = Math.floor(s / 3600)
   const minutes = Math.floor((s % 3600) / 60)
-  if (hours > 0) return `${hours}h ${minutes}m`
-  return `${minutes}m`
+  if (hours > 0) return `${hours}h ${minutes}min`
+  return `${minutes}min`
 }
 
 /** Format a Unix-seconds timestamp as a localized time string. */


### PR DESCRIPTION
formatDuration returned 34m for thirty-four minutes while formatShortDistance returns 50m for fifty metres. On a trip they land in the same list, and Settings renders syncs every 5m on a screen full of distances.

The survey sheet lists this as unproven: the 50m distance next to 5m duration collision could not be found in the code and is treated as not real until someone points at a screen. It is real.

formatDuration had no test at all. It has one now, named for the reason.