### PR TITLE
feat(theme): an elevation ladder, and three more guard rules

### DIFF
--- a/apps/mobile/src/__tests__/designSystemGuard.test.ts
+++ b/apps/mobile/src/__tests__/designSystemGuard.test.ts
@@ -31,7 +31,13 @@ const RULES = [
   { name: "spacing", pattern: /(?:padding|margin|gap|rowGap|columnGap)[A-Za-z]*:\s*(?:4|8|12|16|24|32)\b/ },
   { name: "radius", pattern: /borderRadius:\s*(?:4|8|12|16)\b/ },
   { name: "fontSize", pattern: /fontSize:\s*(?:10|11|12|13|14|15|16|18|20|24|28)\b/ },
-  { name: "iconSize", pattern: /size=\{(?:16|20|24)\}/ }
+  { name: "iconSize", pattern: /size=\{(?:16|20|24)\}/ },
+  // These three ban a property outright rather than a value, because the scale covers every case:
+  // elevation names its four levels, fonts names its four weights, and the type spec has no
+  // letter spacing at all.
+  { name: "elevation", pattern: /elevation:\s*\d/ },
+  { name: "fontWeight", pattern: /fontWeight:\s*"?\d/ },
+  { name: "letterSpacing", pattern: /letterSpacing:/ }
 ] as const
 
 function sourceFiles(): string[] {

--- a/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
+++ b/apps/mobile/src/components/features/dashboard/CoordinateDisplay.tsx
@@ -71,8 +71,7 @@ const styles = StyleSheet.create({
   },
   coordValue: {
     fontSize: fontSizes.input,
-    ...fonts.bold,
-    letterSpacing: -0.3
+    ...fonts.bold
   },
   coordUnit: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
+++ b/apps/mobile/src/components/features/dashboard/DatabaseStatistics.tsx
@@ -91,7 +91,6 @@ const styles = StyleSheet.create({
   },
   statValue: {
     ...type.figure,
-    letterSpacing: -0.5,
     marginBottom: 2
   }
 })

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -615,7 +615,7 @@ const styles = StyleSheet.create({
     ...fonts.regular
   },
   dayDist: {
-    fontSize: 9,
+    fontSize: fontSizes.micro,
     ...fonts.medium,
     marginTop: 1
   },

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -10,7 +10,7 @@ import type { NativeSyntheticEvent } from "react-native"
 import { MapPinOff, X, Check, Trash2, Split } from "lucide-react-native"
 import { ThemeColors, Trip } from "../../../types/global"
 import { getTripColor } from "../../../utils/trips"
-import { fontSizes } from "../../../styles/typography"
+import { fontSizes, fonts } from "../../../styles/typography"
 import { MapCenterButton } from "../map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../map/ColotaMapView"
 import { EmptyState } from "../../ui/EmptyState"
@@ -22,7 +22,7 @@ import {
   type TrackLocation
 } from "../map/mapUtils"
 import { getSpeedUnit } from "../../../utils/geo"
-import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, size, space } from "../../../constants"
+import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, size, space, elevation } from "../../../constants"
 import { radius } from "@colota/shared"
 
 const HAS_NOTE = ["!=", ["get", "note"], ""]
@@ -438,7 +438,7 @@ const styles = StyleSheet.create({
     right: 10,
     padding: space.md,
     borderRadius: radius.md,
-    elevation: 6,
+    elevation: elevation.overlay,
     zIndex: 10
   },
   popupHeader: {
@@ -454,7 +454,7 @@ const styles = StyleSheet.create({
     gap: 20
   },
   popupTime: {
-    fontWeight: "600",
+    ...fonts.semiBold,
     fontSize: fontSizes.description
   },
   popupRow: {
@@ -463,10 +463,10 @@ const styles = StyleSheet.create({
   },
   popupLabel: {
     fontSize: fontSizes.small,
-    fontWeight: "600"
+    ...fonts.semiBold
   },
   popupValue: {
-    fontWeight: "500",
+    ...fonts.medium,
     fontSize: fontSizes.caption
   },
   noteSection: {
@@ -499,7 +499,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     padding: space.sm,
     gap: space.xs,
-    elevation: 4,
+    elevation: elevation.floating,
     zIndex: 10
   },
   legendItem: {
@@ -514,6 +514,6 @@ const styles = StyleSheet.create({
   },
   legendLabel: {
     fontSize: fontSizes.small,
-    fontWeight: "500"
+    ...fonts.medium
   }
 })

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -11,7 +11,7 @@ import type { NativeSyntheticEvent } from "react-native"
 import { Compass, Info, X } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
-import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_DARK, MAP_STYLE_URL_LIGHT, size, space } from "../../../constants"
+import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_DARK, MAP_STYLE_URL_LIGHT, size, space, elevation } from "../../../constants"
 import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
@@ -279,7 +279,7 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     borderRadius: 10,
     gap: space.sm,
-    elevation: 8
+    elevation: elevation.overlay
   },
   attributionPopupText: {
     fontSize: fontSizes.description

--- a/apps/mobile/src/components/features/map/MapActionButton.tsx
+++ b/apps/mobile/src/components/features/map/MapActionButton.tsx
@@ -3,6 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
+import { elevation } from "../../../constants"
 import React from "react"
 import { Pressable, StyleSheet, ViewStyle, StyleProp, PressableProps } from "react-native"
 import { useTheme } from "../../../hooks/useTheme"
@@ -47,7 +48,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     justifyContent: "center",
     alignItems: "center",
-    elevation: 5,
+    elevation: elevation.floating,
     zIndex: 10
   },
   right: { right: 16 },

--- a/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
+++ b/apps/mobile/src/components/features/map/UserLocationOverlay.tsx
@@ -3,6 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
+import { elevation } from "../../../constants"
 import React, { useMemo } from "react"
 import { View, StyleSheet } from "react-native"
 import { GeoJSONSource, Layer, Marker } from "@maplibre/maplibre-react-native"
@@ -87,6 +88,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.pill,
     borderWidth: 3,
     borderColor: "white",
-    elevation: 4
+    elevation: elevation.floating
   }
 })

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -10,7 +10,7 @@ import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts, lineHeights, type } from "../../styles/typography"
 import { radius } from "@colota/shared"
 import { type ModalRequest, type AlertVariant, registerModalHandler } from "../../services/modalService"
-import { space, STATE_LAYER_ALPHA } from "../../constants"
+import { space, STATE_LAYER_ALPHA, elevation } from "../../constants"
 
 const VARIANT_ICONS = {
   info: Info,
@@ -140,7 +140,7 @@ const styles = StyleSheet.create({
   card: {
     width: "100%",
     padding: space.xl,
-    elevation: 8
+    elevation: elevation.overlay
   },
   iconContainer: {
     width: 56,

--- a/apps/mobile/src/components/ui/BottomTabBar.tsx
+++ b/apps/mobile/src/components/ui/BottomTabBar.tsx
@@ -8,7 +8,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Settings, House, CircleDot, Route } from "lucide-react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { size, space, STATE_LAYER_ALPHA } from "../../constants"
+import { size, space, STATE_LAYER_ALPHA, elevation } from "../../constants"
 import type { RootStackRoute } from "../../types/navigation"
 
 type TabIcon = React.ComponentType<{ size?: number; color?: string; strokeWidth?: number }>
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     paddingTop: space.sm,
     paddingBottom: 6,
-    elevation: 0
+    elevation: elevation.flat
   },
   tab: {
     flex: 1,

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@
 import React from "react"
 import { View, Pressable, StyleSheet, ViewStyle, StyleProp, AccessibilityRole, AccessibilityState } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
-import { space, STATE_LAYER_ALPHA } from "../../constants"
+import { space, STATE_LAYER_ALPHA, elevation } from "../../constants"
 import { radius } from "@colota/shared"
 
 type CardVariant = "default" | "elevated" | "outlined" | "interactive"
@@ -63,7 +63,7 @@ export function Card({
           backgroundColor: colors.cardElevated,
           borderColor: "transparent",
           borderWidth: 0,
-          elevation: 1
+          elevation: elevation.raised
         }
       case "outlined":
         return {

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -8,7 +8,7 @@ import { Modal, View, Text, Pressable, StyleSheet, BackHandler } from "react-nat
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts, lineHeights, type } from "../../styles/typography"
 import { radius } from "@colota/shared"
-import { space, STATE_LAYER_ALPHA } from "../../constants"
+import { space, STATE_LAYER_ALPHA, elevation } from "../../constants"
 
 interface DisclosureModalProps {
   icon: React.ReactNode
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
   card: {
     width: "100%",
     padding: space.xl,
-    elevation: 8
+    elevation: elevation.overlay
   },
   iconContainer: {
     width: 56,

--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -9,7 +9,7 @@ import { View, Text, StyleSheet, Animated } from "react-native"
 import { Check } from "lucide-react-native"
 import { SpinningLoader } from "./SpinningLoader"
 import { fontSizes, fonts } from "../../styles/typography"
-import { size, space } from "../../constants"
+import { size, space, elevation } from "../../constants"
 
 interface Props {
   saving: boolean
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: space.md,
     borderRadius: radius.pill,
-    elevation: 8
+    elevation: elevation.overlay
   },
   text: { fontSize: fontSizes.body, ...fonts.semiBold }
 })

--- a/apps/mobile/src/components/ui/LoadingOverlay.tsx
+++ b/apps/mobile/src/components/ui/LoadingOverlay.tsx
@@ -6,7 +6,7 @@
 import { ActivityIndicator, Modal, StyleSheet, Text, View } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
-import { space } from "../../constants"
+import { space, elevation } from "../../constants"
 import { radius } from "@colota/shared"
 
 type Props = {
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
     padding: space.xxl,
     borderRadius: radius.lg,
     alignItems: "center",
-    elevation: 8,
+    elevation: elevation.overlay,
     minWidth: 240
   },
   title: {

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -46,6 +46,21 @@ export const HIT_SLOP_MD = { top: 8, right: 8, bottom: 8, left: 8 } as const
 export const HIT_SLOP_LG = { top: 12, right: 12, bottom: 12, left: 12 } as const
 
 // Map
+/**
+ * Material's elevation levels, named for the job rather than the number: 0, 1, 3 and 6 are levels
+ * 0 to 3. The app had 0, 1, 4, 5, 6 and 8, and 4 and 5 are not levels at all.
+ */
+export const elevation = {
+  /** Sits on the ground: the tab bar. */
+  flat: 0,
+  /** An elevated card, lifted off the ground but not over anything. */
+  raised: 1,
+  /** A control or badge floating over content, usually the map. */
+  floating: 3,
+  /** A dialog, a popup or a toast, over everything. */
+  overlay: 6
+} as const
+
 export const DEFAULT_MAP_ZOOM = 15
 export const WORLD_MAP_ZOOM = 2
 export const MAX_MAP_ZOOM = 18

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -26,7 +26,7 @@ import { logger, LOG_LEVELS, DEFAULT_LOG_LEVELS, type LogLevel } from "../utils/
 import { getMergedLogs, exportLogs, MergedLogEntry } from "../utils/logExport"
 import NativeLocationService from "../services/NativeLocationService"
 import { ScreenProps } from "../types/global"
-import { HIT_SLOP_MD, size, space } from "../constants"
+import { HIT_SLOP_MD, size, space, elevation } from "../constants"
 import { radius } from "@colota/shared"
 
 type FilterLevel = LogLevel
@@ -393,7 +393,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.pill,
     alignItems: "center",
     justifyContent: "center",
-    elevation: 4
+    elevation: elevation.floating
   },
   followingBadge: {
     position: "absolute",

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -790,8 +790,7 @@ const styles = StyleSheet.create({
   },
   fieldLabel: {
     fontSize: fontSizes.description,
-    ...fonts.bold,
-    letterSpacing: 0.5
+    ...fonts.bold
   },
   modifiedBadge: {
     paddingHorizontal: 6,
@@ -799,9 +798,8 @@ const styles = StyleSheet.create({
     borderRadius: radius.xs
   },
   modifiedText: {
-    fontSize: 9,
-    ...fonts.bold,
-    letterSpacing: 0.3
+    fontSize: fontSizes.micro,
+    ...fonts.bold
   },
   fieldDescription: {
     fontSize: fontSizes.small,

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -379,7 +379,7 @@ const styles = StyleSheet.create({
   },
   strengthLabel: {
     fontSize: fontSizes.caption,
-    fontWeight: "600",
+    ...fonts.semiBold,
     minWidth: 60,
     textAlign: "right"
   },

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -20,7 +20,7 @@ import {
   DatabaseStatistics,
   WelcomeCard
 } from "../components"
-import { MIN_STATS_INTERVAL_MS, STATS_REFRESH_IDLE, space } from "../constants"
+import { MIN_STATS_INTERVAL_MS, STATS_REFRESH_IDLE, space, elevation } from "../constants"
 import { Square, Play } from "lucide-react-native"
 import { logger } from "../utils/logger"
 
@@ -300,7 +300,7 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   controlButton: {
-    elevation: 4,
+    elevation: elevation.floating,
     minWidth: 200
   },
   content: {

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -15,15 +15,7 @@ import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { X, CircleCheckBig, RefreshCw, TriangleAlert } from "lucide-react-native"
 import { Button, Card, Container, EmptyState, IconButton, SectionTitle, TextField } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
-import {
-  DEFAULT_MAP_ZOOM,
-  HIT_SLOP_MD,
-  MAP_ANIMATION_DURATION_MS,
-  MAP_STYLE_URL_LIGHT,
-  WORLD_MAP_ZOOM,
-  size,
-  space
-} from "../constants"
+import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT, WORLD_MAP_ZOOM, size, space, elevation } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { logger } from "../utils/logger"
@@ -926,7 +918,7 @@ const styles = StyleSheet.create({
     right: 14,
     padding: space.md,
     borderRadius: radius.md,
-    elevation: 8,
+    elevation: elevation.overlay,
     zIndex: 5,
     alignItems: "center"
   },


### PR DESCRIPTION
The plan enforcement section lists nine rules and the guard implemented three. This closes what is left of it honestly.

Elevation had no scale at all. The app used 0, 1, 4, 5, 6 and 8, and 4 and 5 are not Material levels, so five sites sat on numbers with no name. The token has four roles on levels 0, 1, 3 and 6. Nine surfaces get a marginally softer shadow: dialogs move from 8 to 6, which is the level Material actually specifies for them, and five map controls that were split across 4 and 5 for no reason agree at 3.

Numeric fontWeight and letterSpacing are cleared and banned. Both ban the property rather than a value, since fonts names its four weights and the type spec has no letter spacing.

Three of the nine rules are deliberately not added. shadowColor and textTransform have zero occurrences, so a rule would be dead. borderWidth cannot be banned as written: TextField focus ring and Card danger state are exactly that property used correctly, and the screen-level abuse is already covered by wrapperStyleGuard.

Clearing the letter spacing turned up fontSize: 9 in two places, under the floor and unnamed. No literal fontSize remains in the tree.