### PR TITLE
docs: the paths match what the app says

### DIFF
--- a/apps/docs/docs/api-reference.md
+++ b/apps/docs/docs/api-reference.md
@@ -10,7 +10,7 @@ Reference for the HTTP requests Colota sends to your server.
 
 **Method:** `POST` (default) or `GET`
 
-Configure the HTTP method in **Settings → API Field Mapping → HTTP Method**.
+Configure the HTTP method in **Settings → API field mapping → HTTP method**.
 
 ### POST (default)
 
@@ -86,7 +86,7 @@ A zone [heartbeat](/docs/guides/geofencing) produces the same kind of synthetic 
 still inside the zone: the zone centre, `acc` 0, timestamped when the heartbeat fired. Filter on both
 if you want to tell app-generated points from real fixes.
 
-### Custom Fields
+### Custom fields
 
 Custom static fields (configured in API Settings) are added to the payload first, then location fields are added. If a custom field has the same name as a location field, the location field overwrites it.
 
@@ -150,7 +150,7 @@ Your server only needs to return a 2xx status code. The response body is not rea
 There is no distinction between 4xx and 5xx in retry behavior - all failures are retried indefinitely,
 and failed items stay in the queue until they succeed.
 
-Clearing the queue in **Settings > Data Management** deletes those locations outright, not just their
+Clearing the queue in **Settings > Data management** deletes those locations outright, not just their
 place in the queue, so anything not yet sent is lost.
 
 ## Retry Strategy
@@ -165,7 +165,7 @@ Attempt 4: +300s delay (5 minutes)
 Attempt 5+: +900s delay (15 minutes)
 ```
 
-Failed items stay in the queue indefinitely until they succeed. The queue can be cleared manually in Settings > Data Management if needed.
+Failed items stay in the queue indefinitely until they succeed. The queue can be cleared manually in Settings > Data management if needed.
 
 ## Network Requirements
 

--- a/apps/docs/docs/configuration/authentication.md
+++ b/apps/docs/docs/configuration/authentication.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-Colota supports multiple authentication methods, configurable in **Settings → Connection → Authentication & Headers**.
+Colota supports multiple authentication methods, configurable in **Settings → Connection → Authentication & headers**.
 
 <ScreenshotGallery screenshots={[ { src: "/img/screenshots/Authentication.png", label: "Authentication" }, ]} />
 

--- a/apps/docs/docs/configuration/field-mapping.md
+++ b/apps/docs/docs/configuration/field-mapping.md
@@ -45,12 +45,12 @@ You can rename any field to match your backend. For example:
 }
 ```
 
-Configure field names in **Settings → API Field Mapping → Field Mappings**.
+Configure field names in **Settings → API field mapping → Field mappings**.
 
 ## Custom Static Fields
 
 Add arbitrary key-value pairs that are included in every API payload. For example, adding `_type: "location"` for OwnTracks-compatible backends.
 
-Configure in **Settings → API Field Mapping → Custom Fields**.
+Configure in **Settings → API field mapping → Custom fields**.
 
 **Note:** Custom field values are always sent as strings. Custom fields are added to the payload before location fields - if a custom field key matches a location field key, the location field takes precedence.

--- a/apps/docs/docs/configuration/mtls.md
+++ b/apps/docs/docs/configuration/mtls.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 Authenticate to your server with a client certificate at the TLS handshake, in addition to (or instead of) HTTP-level auth like Bearer or Basic. Useful when your reverse proxy enforces mTLS (e.g. nginx `ssl_verify_client`, Traefik, Cloudflare Access). If your server just needs a Bearer token or Basic Auth, you don't need this.
 
-Configure in **Settings -> Connection -> Authentication & Headers -> Client Certificate (mTLS)**.
+Configure in **Settings -> Connection -> Authentication & headers -> Client Certificate (mTLS)**.
 
 ## Setup
 
@@ -16,7 +16,7 @@ Two ways to provide a client certificate.
 
 If your cert is already installed in Android's KeyChain (via Android Settings -> Encryption & credentials):
 
-1. Open Colota -> Settings -> Connection -> Authentication & Headers -> **Client Certificate (mTLS)**
+1. Open Colota -> Settings -> Connection -> Authentication & headers -> **Client Certificate (mTLS)**
 2. Tap **Pick from device certificates**
 3. Android's system dialog appears. Select your cert.
 4. The screen now shows the cert's subject, issuer and expiry date.
@@ -28,7 +28,7 @@ Colota only remembers which cert you picked - the cert itself stays where it alr
 If you have a PKCS12 file but the cert isn't installed at the OS level:
 
 1. Move the `.p12` to your phone (any reasonably-secure transport works - syncthing, USB, etc.)
-2. Open Colota -> Settings -> Connection -> Authentication & Headers -> **Client Certificate (mTLS)**
+2. Open Colota -> Settings -> Connection -> Authentication & headers -> **Client Certificate (mTLS)**
 3. Tap **Import .p12 / .pfx**
 4. Pick the file, enter the password (leave blank if none), tap **Save**
 5. The screen now shows the cert's subject, issuer and expiry date

--- a/apps/docs/docs/configuration/server-settings.md
+++ b/apps/docs/docs/configuration/server-settings.md
@@ -7,13 +7,13 @@ sidebar_position: 3
 | Setting       | Description                            | Default         | Range       |
 | ------------- | -------------------------------------- | --------------- | ----------- |
 | Endpoint      | HTTP(S) URL of your server             | Empty (offline) | --          |
-| HTTP Method   | POST (JSON body) or GET (query params) | POST            | POST / GET  |
+| HTTP method   | POST (JSON body) or GET (query params) | POST            | POST / GET  |
 | Sync Interval | Batch mode interval                    | Instant (0)     | 0s - Custom |
 | Offline Mode  | Disable all network activity           | Disabled        | On/Off      |
 
 ## Endpoint URL
 
-Your server endpoint must accept HTTP or HTTPS requests (POST or GET depending on your HTTP Method setting). HTTPS is required for public endpoints. HTTP is restricted to private/local addresses at the network level - public HTTP endpoints will be blocked at request time.
+Your server endpoint must accept HTTP or HTTPS requests (POST or GET depending on your HTTP method setting). HTTPS is required for public endpoints. HTTP is restricted to private/local addresses at the network level - public HTTP endpoints will be blocked at request time.
 
 Self-signed and private-CA certificates are supported via three trust paths (system CAs, user-installed device CAs, or an in-app imported CA). Servers that require client-certificate authentication (mTLS) are also supported. See the [mTLS guide](./mtls) for setup.
 
@@ -68,7 +68,7 @@ The UI simplifies to remove sync-related elements that don't apply:
 **Hidden in offline mode:**
 
 - Server Endpoint and Test Connection
-- Authentication & Headers
+- Authentication & headers
 - API Field Mapping
 - Sync Interval, Sync Condition (Any / Wi-Fi / SSID / VPN)
 - Queue statistics (Queued / Sent counts)
@@ -101,6 +101,6 @@ Attempt 4: +300s delay (5 minutes)
 Attempt 5+: +900s delay (15 minutes)
 ```
 
-Failed uploads stay in the queue and are retried indefinitely until they succeed. No data is ever dropped due to failed sync attempts. You can clear the queue manually in Settings > Data Management if needed.
+Failed uploads stay in the queue and are retried indefinitely until they succeed. No data is ever dropped due to failed sync attempts. You can clear the queue manually in Settings > Data management if needed.
 
 The app also auto-syncs when network connectivity is restored.

--- a/apps/docs/docs/configuration/sync-presets.md
+++ b/apps/docs/docs/configuration/sync-presets.md
@@ -13,7 +13,7 @@ Colota includes built-in presets that configure tracking interval, movement thre
 | **Power Saver** | 60s      | 2m       | 15 minutes    | Long trips      |
 | **Custom**      | 1s-∞     | 0m-∞     | 0s-∞          | Advanced users  |
 
-Select a preset in **Settings → Tracking & Sync** or choose **Custom** to configure each parameter individually.
+Select a preset in **Settings → Tracking & sync** or choose **Custom** to configure each parameter individually.
 
 ## Sync Condition
 
@@ -32,8 +32,8 @@ This is useful for:
 - **Private backends** - Only sync when on your home network or VPN
 - **Roaming** - Prevent expensive data charges while traveling abroad
 
-Configure this in **Settings → Tracking & Sync → Advanced Settings → Network Settings → Sync Only On**.
+Configure this in **Settings → Tracking & sync → Network settings → Sync only on**.
 
 ## Offline Mode
 
-In [offline mode](/docs/configuration/server-settings#offline-mode), network settings (sync interval, retry behavior, sync condition) are hidden since no syncing occurs. Preset descriptions adjust to show only tracking parameters. For displaying the maps network requests are still made to maps.mxd.codes. See [Offline Maps](/docs/guides/offline-maps) for predownloading maps.
+In [offline mode](/docs/configuration/server-settings#offline-mode), network settings (sync interval, retry behavior, sync condition) are hidden since no syncing occurs. Preset descriptions adjust to show only tracking parameters. For displaying the maps network requests are still made to maps.mxd.codes. See [Offline maps](/docs/guides/offline-maps) for predownloading maps.

--- a/apps/docs/docs/configuration/tracking-settings.md
+++ b/apps/docs/docs/configuration/tracking-settings.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Tracking Settings
 
-Found under **Settings → Tracking & Sync → Tracking Configuration**.
+Found under **Settings → Tracking & sync → Tracking configuration**.
 
 ## Available Settings
 
@@ -55,5 +55,5 @@ Colota drops these automatically by comparing the chip's reported speed against 
 ## See also
 
 - [Sync Presets](sync-presets.md) - how often the queue is flushed to your server, and on which connections
-- [Tracking Profiles](/docs/guides/tracking-profiles) - switch interval and movement threshold automatically on charging, speed or a stationary phone
+- [Tracking profiles](/docs/guides/tracking-profiles) - switch interval and movement threshold automatically on charging, speed or a stationary phone
 - [Geofencing](/docs/guides/geofencing) - pause GPS entirely inside a zone

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -307,19 +307,20 @@ For backups, two `internal` methods support the export/import flow without expos
 | Screen | Purpose |
 | --- | --- |
 | `DashboardScreen` | Live map with tracking controls, coordinates, database stats, geofence and profile status |
-| `SettingsScreen` | Hub with stats card and navigation to Connection, Tracking & Sync, API Field Mapping, Tracking Profiles, Appearance and data/about screens |
+| `SettingsScreen` | Hub whose rows carry live state - host and queue, both cadences, theme and units, recorded count, the overriding profile - and navigate to Connection, Tracking & sync, API field mapping, Tracking profiles, Appearance and the data, Colota and about screens |
 | `ConnectionScreen` | Server endpoint URL, offline mode toggle and connection test |
 | `TrackingSyncScreen` | GPS interval, distance filter, accuracy threshold and sync strategy preset |
 | `AppearanceScreen` | Light/dark theme, unit system, time format and custom map tile URLs (light and dark) |
 | `ApiSettingsScreen` | Endpoint URL, HTTP method, field mapping with backend templates |
 | `AuthSettingsScreen` | Authentication method (None, Basic Auth, Bearer Token) and custom HTTP headers, with a link row to mTLS Settings |
 | `MtlsSettingsScreen` | Client certificate (PKCS12 import + Android Keystore storage) and Trusted Server CA management |
-| `GeofenceScreen` | Create, edit, and delete pause zones on an interactive map |
-| `GeofenceEditorScreen` | Configure a zone: name, radius, record pause, WiFi pause, motionless pause and timeout, stationary heartbeat |
+| `GeofenceScreen` | Pause zones as rows over a map. Create geofence opens the editor on an empty draft; deletion happens there |
+| `GeofenceEditorScreen` | Every property of a zone: name, radius, location, record pause, WiFi pause, motionless pause and timeout, stationary heartbeat |
+| `PlaceZoneScreen` | Picks a zone coordinate on a map with the radius drawn live, returning it to the editor with `popTo` and `merge` |
 | `TrackingProfilesScreen` | List and manage condition-based tracking profiles |
 | `ProfileEditorScreen` | Create/edit a profile's name, condition, GPS settings, priority, and deactivation delay |
-| `LocationInspectorScreen` | Calendar day picker with activity dots, map tab with trip-colored tracks, trips tab with trip cards, per-trip and multi-select export and multi-select delete |
-| `TripDetailScreen` | Full trip view with dedicated map, stats grid, speed and elevation profile charts, per-trip export, and per-trip delete |
+| `LocationHistoryScreen` | Calendar day picker with activity dots, map tab with trip-colored tracks, trips tab with trip rows, per-trip and multi-select export and multi-select delete |
+| `TripDetailScreen` | Full trip view with dedicated map, stat ledger rows, speed and elevation profile charts, per-trip export, and per-trip delete |
 | `LocationSummaryScreen` | Aggregated stats for selectable periods (week/month/30 days) with daily breakdown and tap-to-inspect navigation |
 | `ExportLocationsScreen` | Export all tracked locations via native streaming converters as CSV, GeoJSON, GPX, or KML |
 | `ImportLocationsScreen` | Import external location files (GeoJSON, Google Timeline legacy + new, GPX, KML, CSV) with auto format detection, dedup preview, and recovery vs migration (queue-for-sync) commit choice |
@@ -330,7 +331,8 @@ For backups, two `internal` methods support the export/import flow without expos
 | `SetupImportScreen` | Confirmation screen for `colota://setup` deep link imports |
 | `ShareSetupScreen` | Bundles selected config categories into a `colota://setup` link to share; credentials opt-in |
 | `ActivityLogScreen` | In-app log viewer with level filtering, search, and export |
-| `AboutScreen` | App version, device info, links to repository and privacy policy |
+| `AboutScreen` | App version, and the build and device details under them |
+| `LegalScreen` | Privacy policy, licence, source link and map attribution |
 
 ### Services
 

--- a/apps/docs/docs/faq.md
+++ b/apps/docs/docs/faq.md
@@ -44,19 +44,19 @@ To ensure modifications stay open source, especially server-side components.
 
 ### Can I use maps without internet?
 
-Yes. Go to **Settings → Offline Maps** to download map areas to your device. Pan and zoom the map to frame the area you want, give it a name, and tap **Download**. Downloaded tiles persist across app restarts and work without any network connection. See [Offline Maps](/docs/guides/offline-maps) for details.
+Yes. Go to **Settings → Offline maps** to download map areas to your device. Pan and zoom the map to frame the area you want, give it a name, and tap **Download**. Downloaded tiles persist across app restarts and work without any network connection. See [Offline maps](/docs/guides/offline-maps) for details.
 
 ### Can I export my location history?
 
-Yes. Go to **Settings → Export Locations** to export in CSV, GeoJSON, GPX or KML, or export a single day's trips from the **History** tab. **Settings → Auto-Export** writes the same formats to a folder you pick on a daily, weekly or monthly schedule. See [Data Export](/docs/guides/data-export) for details.
+Yes. Go to **Settings → Export locations** to export in CSV, GeoJSON, GPX or KML, or export a single day's trips from the **History** tab. **Settings → Auto-export** writes the same formats to a folder you pick on a daily, weekly or monthly schedule. See [Data Export](/docs/guides/data-export) for details.
 
 ### Can I import location history from another app?
 
-Yes. Go to **Settings → Import Locations** and pick a file. Colota reads GeoJSON, Google Timeline (both the legacy Takeout export and the new on-device one), GPX, KML and CSV, detects the format itself, and shows a preview with the duplicate and invalid counts before anything is written. Imports are additive and duplicates are skipped, so re-importing the same file changes nothing. See [Data Import](/docs/guides/data-import) for details.
+Yes. Go to **Settings → Import locations** and pick a file. Colota reads GeoJSON, Google Timeline (both the legacy Takeout export and the new on-device one), GPX, KML and CSV, detects the format itself, and shows a preview with the duplicate and invalid counts before anything is written. Imports are additive and duplicates are skipped, so re-importing the same file changes nothing. See [Data Import](/docs/guides/data-import) for details.
 
 ### Can I back up everything and move to a new device?
 
-Yes. Go to **Settings → Backup & Restore** to create a single password-encrypted `.colota` file containing your locations, settings, geofences and credentials. Restore it on the new device with the same password. See [Backup & Restore](/docs/guides/backup-restore) for details.
+Yes. Go to **Settings → Backup & restore** to create a single password-encrypted `.colota` file containing your locations, settings, geofences and credentials. Restore it on the new device with the same password. See [Backup & restore](/docs/guides/backup-restore) for details.
 
 ### I forgot my backup password, can I recover it?
 
@@ -101,10 +101,10 @@ On Android 17+, apps need the Local Network Access permission to connect to loca
 
 ### Does Colota support mutual TLS (mTLS)?
 
-Yes. Import a PKCS12 (`.p12` / `.pfx`) bundle in **Settings → Connection → Authentication & Headers → Client Certificate (mTLS)**. The private key is stored in the OS keystore and the password isn't saved. For self-signed server certificates, import a CA in the same screen so trust is scoped to Colota only - no need to install a CA at the OS level. See the [mTLS guide](/docs/configuration/mtls) for details.
+Yes. Import a PKCS12 (`.p12` / `.pfx`) bundle in **Settings → Connection → Authentication & headers → Client Certificate (mTLS)**. The private key is stored in the OS keystore and the password isn't saved. For self-signed server certificates, import a CA in the same screen so trust is scoped to Colota only - no need to install a CA at the OS level. See the [mTLS guide](/docs/configuration/mtls) for details.
 
 ### I was using a CA installed in Android Settings for Colota - does it still work?
 
 No, not since 1.9.0. Colota only trusts system CAs and an optional CA you import in-app via mTLS Settings - user-installed device CAs are deliberately ignored. If sync starts failing with `Server certificate is not trusted...` after upgrading, you'll need to re-import your CA through the new in-app screen.
 
-The migration is one-time: open Colota → Settings → Connection → Authentication & Headers → Client Certificate (mTLS) → Trusted Server CA → Import CA. The same `.crt` / `.pem` you originally installed in Android Settings works. See [Migrating from earlier behavior](/docs/configuration/mtls#trusting-a-privateinternal-server-ca) for the full walkthrough.
+The migration is one-time: open Colota → Settings → Connection → Authentication & headers → Client Certificate (mTLS) → Trusted Server CA → Import CA. The same `.crt` / `.pem` you originally installed in Android Settings works. See [Migrating from earlier behavior](/docs/configuration/mtls#trusting-a-privateinternal-server-ca) for the full walkthrough.

--- a/apps/docs/docs/guides/backup-restore.md
+++ b/apps/docs/docs/guides/backup-restore.md
@@ -2,7 +2,7 @@
 sidebar_position: 3
 ---
 
-# Backup & Restore
+# Backup & restore
 
 Bundle your locations, settings and credentials into a single password-encrypted file you can store anywhere - cloud drive, USB stick, another device.
 
@@ -23,7 +23,7 @@ The auth credentials Colota uses to reach your tracking endpoint (Basic Auth, Be
 
 ## Creating a Backup
 
-1. Go to **Settings → Backup & Restore**
+1. Go to **Settings → Backup & restore**
 2. Enter a password (12 characters minimum) and confirm it
 3. Wait for the strength meter to reach at least **OK**
 4. Tap **Create backup**
@@ -54,7 +54,7 @@ Replaces all current data Restoring overwrites every location, setting, geofence
 
 :::
 
-1. Go to **Settings → Backup & Restore**
+1. Go to **Settings → Backup & restore**
 2. Tap **Choose backup file** and pick the `.colota` file
 3. Enter the backup password when prompted
 4. Confirm the replace warning
@@ -101,4 +101,4 @@ If a backup fails mid-encrypt, the app deletes the partial `.colota` file at the
 
 ## Storage Reference
 
-A backup is roughly the size of your SQLite database after deflate compression (typically 30-60% of the raw DB size). Use the [Data Management](data-management.md) screen to see the current database size before backing up.
+A backup is roughly the size of your SQLite database after deflate compression (typically 30-60% of the raw DB size). Use the [Data management](data-management.md) screen to see the current database size before backing up.

--- a/apps/docs/docs/guides/data-export.md
+++ b/apps/docs/docs/guides/data-export.md
@@ -8,7 +8,7 @@ Export your location history in multiple formats.
 
 :::tip[Looking for a full archive?]
 
-Data Export produces shareable, human-readable formats (CSV, GeoJSON, GPX, KML) of your location history. If you instead want a single password-encrypted archive of **everything** - locations, settings, geofences and credentials - for device migration or offsite storage, use [Backup & Restore](backup-restore.md).
+Data Export produces shareable, human-readable formats (CSV, GeoJSON, GPX, KML) of your location history. If you instead want a single password-encrypted archive of **everything** - locations, settings, geofences and credentials - for device migration or offsite storage, use [Backup & restore](backup-restore.md).
 
 :::
 
@@ -25,7 +25,7 @@ Data Export produces shareable, human-readable formats (CSV, GeoJSON, GPX, KML) 
 
 ### Bulk Export
 
-1. Go to **Settings → Export Locations**
+1. Go to **Settings → Export locations**
 2. Select a format
 3. Tap **Export** and share the file via Android's share menu
 
@@ -44,19 +44,19 @@ For a single trip you can also tap the card to open **Trip Detail**, then use th
 
 Trip exports include a `trip` column/property so each location is tagged with its trip number. Custom selections produce a single file containing only the chosen trips.
 
-To remove trips or single points instead of exporting them, see [Data Management](data-management.md#deleting-from-location-history).
+To remove trips or single points instead of exporting them, see [Data management](data-management.md#deleting-from-location-history).
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/ExportData.png", label: "Export Data" }, { src: "/img/screenshots/AutoExport.png", label: "Auto-Export" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/ExportData.png", label: "Export Data" }, { src: "/img/screenshots/AutoExport.png", label: "Auto-export" }, ]} />
 
-## Scheduled Export (Auto-Export)
+## Scheduled Export (Auto-export)
 
 Automatically export your location data on a schedule without opening the app.
 
 ### Setup
 
-1. Go to **Settings → Auto-Export**
+1. Go to **Settings → Auto-export**
 2. Select an export directory (files are saved there via Android's Storage Access Framework)
 3. Choose a format (CSV, GeoJSON, GPX, or KML)
 4. Set the frequency: **Daily**, **Weekly**, or **Monthly**
@@ -142,7 +142,7 @@ Other notes:
 - Templates longer than 100 characters are rejected, and `{device}` is shortened to 32 characters, so the result stays inside the filesystem's name limit.
 - If a file of the same name already exists, Android adds a counter (`… (1).gpx`). Colota still recognises those as its own.
 
-Manual **Export Locations** and trip exports are unaffected. Those go through the Android share sheet, where you name the file yourself.
+Manual **Export locations** and trip exports are unaffected. Those go through the Android share sheet, where you name the file yourself.
 
 ## Storage Reference
 

--- a/apps/docs/docs/guides/data-import.md
+++ b/apps/docs/docs/guides/data-import.md
@@ -39,7 +39,7 @@ The exported file is saved to your phone's `Downloads` folder.
 
 ## How to Import
 
-1. Go to **Settings → Import Locations**
+1. Go to **Settings → Import locations**
 2. Tap **Choose File** and pick the file you want to import
 3. Wait for the parse to finish (large Google Timeline files can take 10+ seconds)
 4. Review the preview: format, points found, duplicates that will be skipped, invalid rows, date range
@@ -47,7 +47,7 @@ The exported file is saved to your phone's `Downloads` folder.
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/ImportLocations.png", label: "Import Locations" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/ImportLocations.png", label: "Import locations" }, ]} />
 
 ### How duplicates are handled
 
@@ -96,7 +96,7 @@ Once queued, the rows are uploaded as soon as the next sync runs. Removing them 
 
 - Imported rows show up immediately on the **Dashboard** and **Location History** screens.
 - Trip detection re-runs on demand the next time you open a screen that uses it (the trip computation is derived from the locations table on the fly).
-- If you imported with **Import + Queue for Sync**, the queue counter in **Data Management** reflects the new pending rows; the next sync cycle replicates them to your configured backend.
+- If you imported with **Import + Queue for Sync**, the queue counter in **Data management** reflects the new pending rows; the next sync cycle replicates them to your configured backend.
 
 ## Edge Cases
 

--- a/apps/docs/docs/guides/data-management.md
+++ b/apps/docs/docs/guides/data-management.md
@@ -2,13 +2,13 @@
 sidebar_position: 3
 ---
 
-# Data Management
+# Data management
 
-Manage your location database from the Data Management screen.
+Manage your location database from the Data management screen.
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/DataManagement.png", label: "Data Management" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/DataManagement.png", label: "Data management" }, ]} />
 
 ## Actions
 
@@ -19,12 +19,12 @@ import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 | **Clear Queue**              | Remove unsent locations from the upload queue                              |
 | **Delete Older Than X Days** | Clean up old data past a specified age                                     |
 | **Vacuum Database**          | Reclaim disk space after deletions                                         |
-| **Export Locations**         | Export location history - see [Data Export](data-export.md)                |
-| **Import Locations**         | Merge external files into your history - see [Data Import](data-import.md) |
+| **Export locations**         | Export location history - see [Data Export](data-export.md)                |
+| **Import locations**         | Merge external files into your history - see [Data Import](data-import.md) |
 
 In [offline mode](/docs/configuration/server-settings#offline-mode), sync-related actions (Sync Now, Clear Sent History, Clear Queue) are hidden since no queue is used. A **Delete All Locations** action is available instead. Data export remains fully available - see [Data Export](data-export.md).
 
-For a full archive of locations, settings and credentials in a single password-encrypted file, use **Settings → Backup & Restore** - see [Backup & Restore](backup-restore.md).
+For a full archive of locations, settings and credentials in a single password-encrypted file, use **Settings → Backup & restore** - see [Backup & restore](backup-restore.md).
 
 ## Deleting from Location History
 

--- a/apps/docs/docs/guides/deep-link-setup.md
+++ b/apps/docs/docs/guides/deep-link-setup.md
@@ -16,11 +16,11 @@ Fill in the settings you want to configure. Only the fields you set will be incl
 
 ## Sharing From the App
 
-You can also generate a setup link straight from an existing installation, without the browser generator. Open **Settings → Share Setup**, tick which categories to include - Tracking, Sync, API, Geofences, Tracking profiles and Credentials - and tap **Share** to send the `colota://setup` link through any app.
+You can also generate a setup link straight from an existing installation, without the browser generator. Open **Settings → Share setup**, tick which categories to include - Tracking, Sync, API, Geofences, Tracking profiles and Credentials - and tap **Share** to send the `colota://setup` link through any app.
 
 Credentials are off by default. Enabling them puts your username, password, bearer token or custom headers into the link in plain text, so only share it over a trusted channel.
 
-Geofences and tracking profiles can also be shared on their own from the [Geofences](geofencing.md#sharing-zones) and Tracking Profiles screens.
+Geofences and tracking profiles can also be shared on their own from the [Geofences](geofencing.md#sharing-zones) and Tracking profiles screens.
 
 ## How It Works
 
@@ -63,7 +63,7 @@ The `config` parameter is a base64-encoded JSON object. Only include the setting
 | `auth.bearerToken` | string | Token for Bearer Auth |
 | `customHeaders` | object | Custom HTTP headers (e.g. Cloudflare Access) |
 | `geofences` | array | Pause zone definitions (see [Geofences](#geofences)) |
-| `profiles` | array | Tracking profile definitions (see [Tracking Profiles](#tracking-profiles)) |
+| `profiles` | array | Tracking profile definitions (see [Tracking profiles](#tracking-profiles)) |
 
 ### Geofences
 
@@ -87,7 +87,7 @@ Imported geofences are appended by default. The import confirmation screen has a
 
 You can build links with geofences using the in-browser generator above, the Node.js or Python snippets below, or by sharing zones directly from the Geofences screen in the app (see the [Geofencing](geofencing.md#sharing-zones) guide).
 
-### Tracking Profiles
+### Tracking profiles
 
 Each entry in the `profiles` array describes one [tracking profile](tracking-profiles.md). `name`, `interval`, `distance`, `syncInterval` and `condition` are required. Other fields fall back to safe defaults. `id` and `createdAt` are ignored on import - the receiving device always creates fresh rows.
 
@@ -106,7 +106,7 @@ Each entry in the `profiles` array describes one [tracking profile](tracking-pro
 
 Imported profiles are appended by default. When both profiles and geofences are present the same "Replace ... with the same name" toggle on the import screen also deletes existing profiles whose names match before creating the incoming ones.
 
-You can build links with profiles using the in-browser generator above, the Node.js or Python snippets below, or by sharing profiles directly from the Tracking Profiles screen in the app.
+You can build links with profiles using the in-browser generator above, the Node.js or Python snippets below, or by sharing profiles directly from the Tracking profiles screen in the app.
 
 ## Generating Links Programmatically
 

--- a/apps/docs/docs/guides/editing-trips.md
+++ b/apps/docs/docs/guides/editing-trips.md
@@ -65,6 +65,6 @@ Colota normally discards trips that never travel more than 100 m, which keeps st
 
 ## Related
 
-- [Data Management](data-management.md) - deleting trips and individual points
-- [Backup & Restore](backup-restore.md) - what a backup includes
+- [Data management](data-management.md) - deleting trips and individual points
+- [Backup & restore](backup-restore.md) - what a backup includes
 - [Troubleshooting](troubleshooting.md) - other history and tracking issues

--- a/apps/docs/docs/guides/geofencing.md
+++ b/apps/docs/docs/guides/geofencing.md
@@ -15,17 +15,19 @@ Create zones where location recording stops automatically. These "pause zones" s
 ## Setup
 
 1. Go to the **Geofences** tab
-2. Enter a name and radius
-3. Tap **Place Geofence**, then tap the map to place it
-4. Tap the **›** arrow on any geofence to open the editor and configure pause options
+2. Tap **Create geofence**
+3. Give the zone a name and a radius, then tap **Location** and pick a point on the map
+4. Set the pause options, then tap **Save geofence**
+
+Tap any zone in the list to reopen the editor. Every field can be changed there, **Location** included.
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/Geofences.png", label: "Geofences" }, { src: "/img/screenshots/GeofenceEditor.png", label: "Geofence Editor" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/Geofences.png", label: "Geofences" }, { src: "/img/screenshots/GeofenceEditor.png", label: "Geofence editor" }, ]} />
 
 ## GPS Pause Options
 
-Each geofence has independent pause settings, configured in the editor (tap **›**):
+Each geofence has independent pause settings, configured in the editor:
 
 ### Don't record in zone
 
@@ -64,7 +66,7 @@ Changes made in the editor take effect immediately, even when you are already in
 You can share all your geofences with another device or another user via a setup link instead of recreating zones by hand.
 
 1. Open the **Geofences** screen
-2. Tap the share icon next to "Active Geofences"
+2. Tap the share icon next to "Active geofences"
 3. The system share sheet opens with a `colota://setup?config=...` link
 4. Send the link through any messenger, email or as a QR code
 
@@ -72,7 +74,7 @@ When the recipient opens the link, Colota shows the import confirmation screen l
 
 The share button is all-or-nothing - every zone in the list is included. The `id`, `createdAt` and `enabled` fields are stripped, so imported zones always start enabled and get fresh database entries on the recipient's device.
 
-To share zones together with your tracking, sync and API settings in a single link, use **Settings -> Share Setup** instead (see [Deep Link Setup](deep-link-setup.md#sharing-from-the-app)).
+To share zones together with your tracking, sync and API settings in a single link, use **Settings -> Share setup** instead (see [Deep Link Setup](deep-link-setup.md#sharing-from-the-app)).
 
 See the [Deep Link Setup](deep-link-setup.md#geofences) guide for the full payload format.
 

--- a/apps/docs/docs/guides/offline-maps.md
+++ b/apps/docs/docs/guides/offline-maps.md
@@ -2,17 +2,17 @@
 sidebar_position: 5
 ---
 
-# Offline Maps
+# Offline maps
 
 Download map areas to your device so the map works without an internet connection. Useful when tracking in areas with poor cell coverage - remote trails, backcountry routes, etc.
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/OfflineMaps.png", label: "Offline Maps" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/OfflineMaps.png", label: "Offline maps" }, ]} />
 
 ## Downloading an Area
 
-1. Go to **Settings > Offline Maps**
+1. Go to **Settings > Offline maps**
 2. Pan and zoom the map to frame the area you want to download
 3. Tap the location button to center on your current position if needed
 4. Enter a **name** for the area
@@ -35,13 +35,13 @@ To avoid hitting the cap:
 
 ## Storage
 
-Downloaded areas are stored on the device by MapLibre's offline tile cache. They persist across app restarts. The **Offline Maps** screen shows the current size of each saved area.
+Downloaded areas are stored on the device by MapLibre's offline tile cache. They persist across app restarts. The **Offline maps** screen shows the current size of each saved area.
 
 To free up space, delete areas you no longer need. When the last area is deleted, the tile database is reset and the storage is reclaimed by the OS.
 
 ## Managing Areas
 
-From the **Offline Maps** screen you can:
+From the **Offline maps** screen you can:
 
 - See all downloaded areas with their size and status
 - Delete an area (removes all cached tiles for that area)

--- a/apps/docs/docs/guides/tracking-profiles.md
+++ b/apps/docs/docs/guides/tracking-profiles.md
@@ -2,13 +2,13 @@
 sidebar_position: 2
 ---
 
-# Tracking Profiles
+# Tracking profiles
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
 Tracking profiles automatically adjust GPS interval, distance filter, and sync settings when conditions like charging, car mode, or speed thresholds are met.
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/TrackingProfiles.png", label: "Tracking Profiles" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/TrackingProfiles.png", label: "Tracking profiles" }, ]} />
 
 ## Use Cases
 
@@ -19,7 +19,7 @@ Tracking profiles automatically adjust GPS interval, distance filter, and sync s
 
 ## Setup
 
-1. Go to **Settings** → **Tracking Profiles**
+1. Go to **Settings** → **Tracking profiles**
 2. Tap **Create Profile**
 3. Enter a name and select a condition trigger
 4. Configure the GPS interval, distance filter, and sync interval

--- a/apps/docs/docs/guides/troubleshooting.md
+++ b/apps/docs/docs/guides/troubleshooting.md
@@ -47,7 +47,7 @@ Colota starts a new trip after a 15-minute gap in fixes, so a long stop can brea
 2. Use the **Test Connection** button in settings
 3. Check server logs for incoming requests
 4. Verify network connectivity
-5. Check the queue count in **Data Management**
+5. Check the queue count in **Data management**
 
 **Common causes**: Wrong URL, HTTPS required for public endpoints, expired SSL certificate, incorrect authentication, mismatched field mapping, self-signed / private-CA server cert (see the [mTLS guide](/docs/configuration/mtls) for trust setup), **Sync Condition** restricting uploads to a specific network (Wi-Fi, SSID or VPN), missing local network permission on Android 16+.
 
@@ -136,7 +136,7 @@ To change: **Settings > Advanced Settings > Network Settings > Sync Only On**.
 
 ## Auto-export not working
 
-- Verify a directory is selected in **Settings > Auto-Export**
+- Verify a directory is selected in **Settings > Auto-export**
 - Check that the toggle is enabled
 - The first export fires at the configured time, not on enable. Tap **Export Now** to confirm the pipeline works without waiting
 - Doze mode can delay an alarm by up to ~15 minutes - if exports are running but a few minutes late, that's expected

--- a/apps/docs/docs/integrations/api-templates.md
+++ b/apps/docs/docs/integrations/api-templates.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 Colota includes built-in templates for popular backends. Select a template in **Settings > API Settings** to auto-configure field mappings and custom fields.
 
-| Template | HTTP Method | Bearing Field | Custom Fields | Notes |
+| Template | HTTP method | Bearing Field | Custom fields | Notes |
 | --- | --- | --- | --- | --- |
 | **Dawarich** | POST | `cog` | `_type: "location"` | OwnTracks single-point format. Optional Batch chip switches to Overland envelope (see [Dawarich integration](./dawarich.md)). |
 | **GeoPulse** | POST | `bear` | _(none)_ | Native Colota format |

--- a/apps/docs/docs/integrations/dawarich.md
+++ b/apps/docs/docs/integrations/dawarich.md
@@ -71,8 +71,8 @@ Bundles up to N queued points into a single request to `/api/v1/overland/batches
 
 **Endpoint URL**: change the saved endpoint to `https://dawarich.yourdomain.com/api/v1/overland/batches?api_key=YOUR_API_KEY`. The chip only updates the placeholder hint, not your saved endpoint.
 
-**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & Sync > Advanced > Network Settings > Batch Size** (only shown when batch mode is active).
+**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & sync > Advanced > Network Settings > Batch Size** (only shown when batch mode is active).
 
 **Requires non-zero sync interval**: batch mode is incompatible with instant sync. Pick a batched preset or set a custom sync interval before enabling. The chip is disabled when sync interval is 0.
 
-**Device identifier**: your Dawarich server sees this device as the value of the `device_id` custom field, defaulting to `"colota"`. Edit it under **Settings > API Settings > Custom Fields** if you run multiple devices.
+**Device identifier**: your Dawarich server sees this device as the value of the `device_id` custom field, defaulting to `"colota"`. Edit it under **Settings > API Settings > Custom fields** if you run multiple devices.

--- a/apps/docs/docs/integrations/overland.md
+++ b/apps/docs/docs/integrations/overland.md
@@ -49,7 +49,7 @@ Each upload is a single POST containing one or more locations as GeoJSON Feature
 
 ## Configuration
 
-**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & Sync > Advanced > Network Settings > Batch Size**. Larger bundles mean fewer round trips but bigger payloads on flaky networks.
+**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & sync > Advanced > Network Settings > Batch Size**. Larger bundles mean fewer round trips but bigger payloads on flaky networks.
 
 **HTTP method**: POST only. The Overland protocol does not support GET; the option is hidden when this template is selected.
 
@@ -57,7 +57,7 @@ Each upload is a single POST containing one or more locations as GeoJSON Feature
 
 ## Device Identifier
 
-Your server sees this device as the value of the `device_id` custom field, defaulting to `"colota"`. Edit it under **Settings > API Settings > Custom Fields** if you run multiple devices. If you previously set `tid` (OwnTracks) or `id` (Traccar) as a custom field, that value is reused so you don't have to reconfigure.
+Your server sees this device as the value of the `device_id` custom field, defaulting to `"colota"`. Edit it under **Settings > API Settings > Custom fields** if you run multiple devices. If you previously set `tid` (OwnTracks) or `id` (Traccar) as a custom field, that value is reused so you don't have to reconfigure.
 
 ## Dawarich Users
 

--- a/apps/docs/docs/integrations/owntracks.md
+++ b/apps/docs/docs/integrations/owntracks.md
@@ -13,7 +13,7 @@ sidebar_position: 3
    - Go to **Settings > API Settings**
    - Select the **OwnTracks** template
    - Set your endpoint URL, e.g. `https://owntracks.yourdomain.com/pub`
-   - If your Recorder uses HTTP Basic Auth, configure it in **Settings > Authentication & Headers**
+   - If your Recorder uses HTTP Basic Auth, configure it in **Settings > Authentication & headers**
 
 ## Payload Format
 

--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -12,14 +12,14 @@ Colota is a self-hosted GPS tracking app for Android. It sends your location to 
 - **Self-Hosted** - Send location data to your own server. Works with Dawarich, GeoPulse, Home Assistant, OwnTracks, Overland, PhoneTrack, Reitti, Traccar or any custom backend.
 - **Privacy First** - No analytics, no telemetry, no third-party SDKs. Open source (AGPL-3.0).
 - **Works Offline** - Fully functional without a server. Export as CSV, GeoJSON, GPX, or KML.
-- **Offline Maps** - Download map areas to your device for use without an internet connection.
+- **Offline maps** - Download map areas to your device for use without an internet connection.
 - **Scheduled Export** - Automatic daily, weekly or monthly exports to a local directory with file retention management.
 - **Encrypted Backup** - Single password-encrypted archive of locations, settings, geofences and credentials.
 - **Location History** - View daily summaries, trip segmentation with manual merge and split, calendar with activity dots, per-trip export and per-point notes or deletion.
 - **Import Your History** - Bring in existing tracks from GeoJSON, Google Timeline, GPX, KML or CSV.
 - **Reliable Tracking** - Foreground service, auto-start on boot and exponential backoff retry.
 - **Geofencing** - Pause zones that stop recording locations. Optionally stop GPS entirely when on WiFi or when the device is motionless.
-- **Tracking Profiles** - Automatically adjust GPS interval, distance filter and sync settings based on conditions like charging, Android Auto, speed or stationary detection.
+- **Tracking profiles** - Automatically adjust GPS interval, distance filter and sync settings based on conditions like charging, Android Auto, speed or stationary detection.
 - **Flexible Sync** - Instant, batch, Wi-Fi only or offline modes.
 - **Display Settings** - Choose between metric and imperial units, 12h or 24h time format. Auto-detected from device locale on first use.
 - **App Shortcuts** - Long-press the app icon to start or stop tracking from the home screen. Compatible with automation apps like Tasker and Samsung Routines.
@@ -34,28 +34,28 @@ Colota has twenty-five screens, each focused on a specific task:
 | Screen | Purpose |
 | --- | --- |
 | **Dashboard** | Live map with current coordinates, today's track overlay, tracking controls, database stats, and geofence status |
-| **Settings** | Hub linking to Connection, Tracking and Sync, API Field Mapping, Tracking Profiles, Appearance and data/about screens |
+| **Settings** | Hub linking to Connection, Tracking and Sync, API config, Tracking profiles, Appearance and data/about screens |
 | **Connection** | Server endpoint URL, offline mode toggle and connection test |
-| **Tracking & Sync** | GPS polling interval, distance filter, accuracy threshold and sync strategy preset |
+| **Tracking & sync** | GPS polling interval, distance filter, accuracy threshold and sync strategy preset |
 | **Appearance** | Light/dark theme, unit system, time format and custom map tile URLs |
 | **API Config** | Endpoint field mapping with templates for Dawarich, GeoPulse, Overland, OwnTracks, PhoneTrack, Reitti, Traccar or custom backends |
 | **Auth Settings** | Endpoint authentication (None, Basic Auth, Bearer Token) and custom HTTP headers |
 | **mTLS Settings** | Client certificate (mTLS) import or KeyChain selection and trusted server CA management |
 | **Geofences** | Create pause zones by tapping the map, view all zones with pause option indicators |
 | **Geofence Editor** | Configure a zone: name, radius, record pause, WiFi pause, motionless pause and timeout, stationary heartbeat |
-| **Offline Maps** | Download map areas to the device for use without an internet connection |
-| **Tracking Profiles** | Create and manage condition-based profiles that automatically adjust tracking settings |
+| **Offline maps** | Download map areas to the device for use without an internet connection |
+| **Tracking profiles** | Create and manage condition-based profiles that automatically adjust tracking settings |
 | **Profile Editor** | Configure profile name, condition trigger, GPS interval, distance filter, sync interval, priority, and deactivation delay |
 | **Location History** | Browse recorded locations on a track map with calendar day picker and trip-colored segments, view segmented trips with per-trip stats; tap a point to add a note or delete it |
 | **Trip Detail** | Full trip view with dedicated map, stats grid (distance, duration, avg speed, elevation), speed and elevation profile charts, export, and delete |
 | **Location Summary** | Aggregated stats (total distance, trips, active days, avg distance) for selectable periods with daily breakdown and tap-to-inspect navigation |
-| **Export Locations** | Export tracked locations as CSV, GeoJSON, GPX, or KML |
-| **Import Locations** | Import tracks from GeoJSON, Google Timeline, GPX, KML or CSV with a preview before committing |
-| **Auto-Export** | Configure scheduled exports: directory, format, frequency, time of day (with weekday or day-of-month for weekly/monthly), export range and file retention |
-| **Data Management** | Clear sent history, delete old data, vacuum the database |
-| **Backup & Restore** | Create or restore a single password-encrypted `.colota` archive of all data (locations, settings, geofences, credentials) |
+| **Export locations** | Export tracked locations as CSV, GeoJSON, GPX, or KML |
+| **Import locations** | Import tracks from GeoJSON, Google Timeline, GPX, KML or CSV with a preview before committing |
+| **Auto-export** | Configure scheduled exports: directory, format, frequency, time of day (with weekday or day-of-month for weekly/monthly), export range and file retention |
+| **Data management** | Clear sent history, delete old data, vacuum the database |
+| **Backup & restore** | Create or restore a single password-encrypted `.colota` archive of all data (locations, settings, geofences, credentials) |
 | **Setup Import** | Confirmation screen for deep link configuration imports (`colota://setup`) |
-| **Share Setup** | Build a `colota://setup` link or QR code from selected settings to configure another device |
+| **Share setup** | Build a `colota://setup` link or QR code from selected settings to configure another device |
 | **Logging** | In-app activity log viewer (level filtering, search, export) plus opt-in persistent file logging |
 | **About** | App version, device info, links to repository and privacy policy |
 
@@ -63,7 +63,7 @@ Colota has twenty-five screens, each focused on a specific task:
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/Dashboard.png", label: "Dashboard" }, { src: "/img/screenshots/Settings.png", label: "Settings" }, { src: "/img/screenshots/ApiFieldMapping.png", label: "API Config" }, { src: "/img/screenshots/Authentication.png", label: "Auth Settings" }, { src: "/img/screenshots/Geofences.png", label: "Geofences" }, { src: "/img/screenshots/GeofenceEditor.png", label: "Geofence Editor" }, { src: "/img/screenshots/OfflineMaps.png", label: "Offline Maps" }, { src: "/img/screenshots/TrackingProfiles.png", label: "Profile Editor" }, { src: "/img/screenshots/LocationHistory.png", label: "Location History" }, { src: "/img/screenshots/TripDetails.png", label: "Trip Detail" }, { src: "/img/screenshots/Trips.png", label: "Trips" }, { src: "/img/screenshots/ExportData.png", label: "Export" }, { src: "/img/screenshots/AutoExport.png", label: "Auto-Export" }, { src: "/img/screenshots/DataManagement.png", label: "Data Management" }, { src: "/img/screenshots/DarkMode.png", label: "Dark Mode" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/Dashboard.png", label: "Dashboard" }, { src: "/img/screenshots/Settings.png", label: "Settings" }, { src: "/img/screenshots/ApiFieldMapping.png", label: "API Config" }, { src: "/img/screenshots/Authentication.png", label: "Auth Settings" }, { src: "/img/screenshots/Geofences.png", label: "Geofences" }, { src: "/img/screenshots/GeofenceEditor.png", label: "Geofence Editor" }, { src: "/img/screenshots/OfflineMaps.png", label: "Offline maps" }, { src: "/img/screenshots/TrackingProfiles.png", label: "Profile Editor" }, { src: "/img/screenshots/LocationHistory.png", label: "Location History" }, { src: "/img/screenshots/TripDetails.png", label: "Trip Detail" }, { src: "/img/screenshots/Trips.png", label: "Trips" }, { src: "/img/screenshots/ExportData.png", label: "Export" }, { src: "/img/screenshots/AutoExport.png", label: "Auto-export" }, { src: "/img/screenshots/DataManagement.png", label: "Data management" }, { src: "/img/screenshots/DarkMode.png", label: "Dark Mode" }, ]} />
 
 ## Architecture
 

--- a/apps/docs/docs/security.md
+++ b/apps/docs/docs/security.md
@@ -15,7 +15,7 @@ HTTPS is enforced for all public server endpoints. HTTP is only allowed for priv
 Colota's HTTPS chain validation accepts two trust sources, either of which is sufficient:
 
 1. **System CAs** that ship with Android - the normal public web (Let's Encrypt, DigiCert, etc.)
-2. **In-app imported CA** added via Settings → Connection → Authentication & Headers → Client Certificate (mTLS) → Trusted Server CA. One slot, trusted only by Colota.
+2. **In-app imported CA** added via Settings → Connection → Authentication & headers → Client Certificate (mTLS) → Trusted Server CA. One slot, trusted only by Colota.
 
 User-installed device CAs (from Android Settings -> Encryption & credentials) are not honored, so malware or a coerced profile that plants a CA in the device store can't intercept Colota's sync. Self-hosted users running a private CA should import it via the in-app path.
 
@@ -37,7 +37,7 @@ The database is not accessible to other apps (standard Android sandboxing).
 
 ## Encrypted Backups
 
-Colota can produce a single password-encrypted archive of your full dataset (locations, settings, geofences, credentials) for off-device storage or device migration. See the [Backup & Restore guide](/docs/guides/backup-restore) for the user-facing flow. The relevant security properties:
+Colota can produce a single password-encrypted archive of your full dataset (locations, settings, geofences, credentials) for off-device storage or device migration. See the [Backup & restore guide](/docs/guides/backup-restore) for the user-facing flow. The relevant security properties:
 
 - **Cipher**: AES-256-GCM, chunked at 1 MiB of plaintext per chunk. Each chunk's GCM tag binds the file header as additional authenticated data, so any flip in the header (KDF parameters, salt, nonce prefix) invalidates the very first tag.
 - **Key derivation**: Argon2id with 64 MiB memory, 3 iterations and 1 lane on standard devices; 32 MiB on devices flagged as low-RAM by Android. The salt is 32 bytes from `SecureRandom`, fresh per backup.


### PR DESCRIPTION
One dead path and a lot of drift. sync-presets told readers to open Tracking and Sync, Advanced Settings, Network Settings, Sync Only On; #775 deleted that accordion, so a reader following it finds nothing. Sixteen labels were still title case across 25 files, from before the sentence-case sweep.

The geofencing guide still described entering a name and radius on the list and tapping Place Geofence. That form is gone; creation opens the editor, and a zone can now be moved without deleting it.

The architecture screen table listed LocationInspectorScreen, which is LocationHistoryScreen, and was missing PlaceZoneScreen and LegalScreen. It also described a Settings stats card removed in #772, creation living on the geofence list, and a stats grid on Trip Detail.

Two app-side inconsistencies turned up and are not fixed here: the Settings row reads API field mapping while the screen it opens is titled API config, and Client Certificate (mTLS) is title case in three places.