### PR TITLE
refactor(ui): section spacing takes the scale

### DIFF
--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     padding: 14,
     borderRadius: radius.md,
-    marginBottom: 22
+    marginBottom: space.xl
   },
   dot: {
     width: 8,

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -272,7 +272,7 @@ const styles = StyleSheet.create({
     marginBottom: space.lg
   },
   stateTitle: { ...type.heading, textAlign: "center" },
-  stateTitleSpaced: { marginTop: 20 },
+  stateTitleSpaced: { marginTop: space.lg },
   stateSubtext: {
     fontSize: fontSizes.body,
     textAlign: "center",

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -451,7 +451,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     // Both icons carry HIT_SLOP_MD, so a smaller gap overlaps delete with close
-    gap: 20
+    gap: space.xl
   },
   popupTime: {
     ...fonts.semiBold,

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -275,7 +275,8 @@ const styles = StyleSheet.create({
     maxWidth: 320,
     width: "100%",
     paddingStart: space.lg,
-    paddingEnd: 36,
+    // Clears the close control: space.xs inset plus space.xs padding either side of a 20 icon
+    paddingEnd: space.xxl,
     paddingVertical: 14,
     borderRadius: 10,
     gap: space.sm,
@@ -286,8 +287,8 @@ const styles = StyleSheet.create({
   },
   attributionClose: {
     position: "absolute",
-    top: 6,
-    right: 6,
+    top: space.xs,
+    right: space.xs,
     padding: space.xs
   }
 })

--- a/apps/mobile/src/components/ui/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ui/ErrorBoundary.tsx
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
   errorMessage: {
     fontSize: fontSizes.label,
     textAlign: "center",
-    marginBottom: 20,
-    paddingHorizontal: 20
+    marginBottom: space.lg,
+    paddingHorizontal: space.lg
   }
 })

--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: space.sm,
-    paddingHorizontal: 20,
+    paddingHorizontal: space.xl,
     paddingVertical: space.md,
     borderRadius: radius.pill,
     elevation: elevation.overlay

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -222,7 +222,7 @@ const styles = StyleSheet.create({
     paddingTop: space.sm
   },
   header: {
-    marginTop: 20,
+    marginTop: space.xl,
     marginBottom: space.xl,
     alignItems: "center"
   },

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -739,8 +739,8 @@ const styles = StyleSheet.create({
     paddingBottom: space.xxl
   },
   header: {
-    marginTop: 20,
-    marginBottom: 20
+    marginTop: space.xl,
+    marginBottom: space.xl
   },
   subtitle: {
     fontSize: fontSizes.body,
@@ -754,7 +754,7 @@ const styles = StyleSheet.create({
     marginTop: space.sm
   },
   fieldsSection: {
-    marginBottom: 20
+    marginBottom: space.xl
   },
   sectionHeader: {
     flexDirection: "row",
@@ -835,14 +835,14 @@ const styles = StyleSheet.create({
     padding: space.md,
     borderRadius: radius.sm,
     borderWidth: 1,
-    marginBottom: 20
+    marginBottom: space.xl
   },
   warningText: {
     fontSize: fontSizes.caption,
     lineHeight: lineHeights.caption
   },
   exampleSection: {
-    marginBottom: 20
+    marginBottom: space.xl
   },
   copyButton: {
     alignSelf: "flex-end",

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -346,7 +346,7 @@ const styles = StyleSheet.create({
     ...fonts.regular
   },
   header: {
-    marginBottom: 20
+    marginBottom: space.xl
   },
   subtitle: {
     fontSize: fontSizes.body,
@@ -384,7 +384,7 @@ const styles = StyleSheet.create({
     padding: space.md,
     borderRadius: radius.sm,
     borderWidth: 1,
-    marginBottom: 20
+    marginBottom: space.xl
   },
   warningText: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -685,8 +685,8 @@ const styles = StyleSheet.create({
     paddingBottom: space.xxl
   },
   header: {
-    marginTop: 20,
-    marginBottom: 20
+    marginTop: space.xl,
+    marginBottom: space.xl
   },
   subtitle: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -305,11 +305,11 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    paddingTop: 20,
+    paddingTop: space.lg,
     paddingHorizontal: space.lg,
     paddingBottom: space.sm
   },
   metricsSection: {
-    marginBottom: 20
+    marginBottom: space.lg
   }
 })

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -276,7 +276,7 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingHorizontal: space.md,
-    paddingBottom: 20
+    paddingBottom: space.xxl
   },
   summaryGrid: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/MtlsSettingsScreen.tsx
+++ b/apps/mobile/src/screens/MtlsSettingsScreen.tsx
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
     paddingBottom: space.xxl
   },
   header: {
-    marginBottom: 20
+    marginBottom: space.xl
   },
   subtitle: {
     fontSize: fontSizes.body,

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -213,7 +213,7 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
 
 const styles = StyleSheet.create({
   list: { padding: space.lg, paddingBottom: space.xxl },
-  header: { marginBottom: 20 },
+  header: { marginBottom: space.xl },
   subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: lineHeights.body },
   card: { marginBottom: space.md },
   row: { flexDirection: "row", alignItems: "center" },


### PR DESCRIPTION
Twenty-two spacing values sat off the space scale: twenty at 20, one at 22 and one at 36. designSystemGuard fires only on the values a scale holds, so none of them was visible to it.

space is 4, 8, 12, 16, 24, 32, a 4dp grid with 20 and 28 left out, so every stray sits exactly between two steps and there is no nearest step to snap to. Each takes the step its own block already names: header and section margins go to space.xl beside siblings that were already 24, the Dashboard content and metrics go to space.lg to match their own horizontal padding, and the location summary list ends at space.xxl like every other scroll skeleton.

Two are load-bearing and keep their measurement rather than their number. The trip popup gap clears two HIT_SLOP_MD icons, so it goes up to 24 and not down to 16. The attribution popup pads its end to clear the close control, which now sits on the scale as well: space.xs inset plus space.xs padding either side of a 20 icon is exactly space.xxl.

This is not value-preserving, unlike the earlier token sweeps. All twenty-two sites move, fourteen by +4, five by -4, and one each by +12, +2 and -4.