### PR TITLE
chore(format): run prettier across the tree

### DIFF
--- a/apps/docs/docs/api-reference.md
+++ b/apps/docs/docs/api-reference.md
@@ -25,10 +25,7 @@ Additional headers may be included based on your [authentication](/docs/configur
 
 **Body:**
 
-This is the body for the default field-mapped format. The Traccar POST and Overland templates and
-Dawarich in batch mode, send a different shape entirely. Those formats use fixed field names, so the
-[field mapping](/docs/configuration/field-mapping) does not apply to them and both add a `device_id`
-key. See [API templates](/docs/integrations/api-templates) for the exact bodies.
+This is the body for the default field-mapped format. The Traccar POST and Overland templates and Dawarich in batch mode, send a different shape entirely. Those formats use fixed field names, so the [field mapping](/docs/configuration/field-mapping) does not apply to them and both add a `device_id` key. See [API templates](/docs/integrations/api-templates) for the exact bodies.
 
 ```json
 {
@@ -82,9 +79,7 @@ When exiting a [pause zone](/docs/guides/geofencing#anchor-points), Colota sends
 - `alt`, `vel`, and `bear` are not included
 - `batt` and `bs` reflect the current battery state
 
-A zone [heartbeat](/docs/guides/geofencing) produces the same kind of synthetic point while you are
-still inside the zone: the zone centre, `acc` 0, timestamped when the heartbeat fired. Filter on both
-if you want to tell app-generated points from real fixes.
+A zone [heartbeat](/docs/guides/geofencing) produces the same kind of synthetic point while you are still inside the zone: the zone centre, `acc` 0, timestamped when the heartbeat fired. Filter on both if you want to tell app-generated points from real fixes.
 
 ### Custom fields
 
@@ -94,12 +89,9 @@ Custom field values are always sent as strings.
 
 ## Batch Sync Behavior
 
-In the default field-mapped format Colota sends **one location per HTTP request**. During batch sync
-up to 10 requests are sent concurrently, processing up to 500 queued locations per sync cycle.
+In the default field-mapped format Colota sends **one location per HTTP request**. During batch sync up to 10 requests are sent concurrently, processing up to 500 queued locations per sync cycle.
 
-The Overland format, and Dawarich in batch mode, instead send **an array of locations in a single
-request**. Batch size is configurable (1 to 500, default 50) and up to 10 batches are sent per cycle,
-so one cycle can move considerably more than 500 points.
+The Overland format, and Dawarich in batch mode, instead send **an array of locations in a single request**. Batch size is configurable (1 to 500, default 50) and up to 10 batches are sent per cycle, so one cycle can move considerably more than 500 points.
 
 Your server should handle multiple simultaneous POST requests. If you have rate limiting, some requests may fail and be retried.
 
@@ -147,11 +139,9 @@ Your server only needs to return a 2xx status code. The response body is not rea
 | **Any non-2xx response** | Queued for retry                           |
 | **Network timeout**      | Retried (10s connection, 10s read timeout) |
 
-There is no distinction between 4xx and 5xx in retry behavior - all failures are retried indefinitely,
-and failed items stay in the queue until they succeed.
+There is no distinction between 4xx and 5xx in retry behavior - all failures are retried indefinitely, and failed items stay in the queue until they succeed.
 
-Clearing the queue in **Settings > Data management** deletes those locations outright, not just their
-place in the queue, so anything not yet sent is lost.
+Clearing the queue in **Settings > Data management** deletes those locations outright, not just their place in the queue, so anything not yet sent is lost.
 
 ## Retry Strategy
 

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -155,18 +155,9 @@ An Android foreground service that runs continuously for GPS tracking. Manages:
 - Stationary detection - slows GPS to the profile's interval after 60s of fixes without movement; resume is driven by the shared `MotionStateDetector` (accelerometer variance, with SIG_MOTION as a fast-path for sharp wake events). It keeps working inside a pause zone and during an entry delay, since fixes reach `ProfileManager` before the in-zone drop; only a hold that stops the stream can prevent a verdict.
 - Queuing data for server sync
 
-**Alarms go through a receiver, not the service.** Each scheduler targets a `BroadcastReceiver`
-that then starts the service. That keeps the PendingIntent a plain explicit broadcast, and the
-foreground-service start runs inside the alarm's temporary allowlist window.
+**Alarms go through a receiver, not the service.** Each scheduler targets a `BroadcastReceiver` that then starts the service. That keeps the PendingIntent a plain explicit broadcast, and the foreground-service start runs inside the alarm's temporary allowlist window.
 
-**Intent vs liveness.** The `tracking_enabled` setting records that the user wants tracking and
-deliberately survives process death and reboot. Whether a service exists right now is
-`LocationForegroundService.isRunning`. Anything asking "is tracking alive" must read `isRunning`,
-because a service the system killed leaves the flag true. Recovery is layered: the app reconciles
-the two whenever it reaches the foreground, and `TrackingWatchdogScheduler` covers the window while
-the app stays closed. Reconciling can also drop the intent rather than honour it: a revoked location
-permission means no service can be started again, so the foreground reconciler clears the flag and
-the watchdog stops re-arming itself.
+**Intent vs liveness.** The `tracking_enabled` setting records that the user wants tracking and deliberately survives process death and reboot. Whether a service exists right now is `LocationForegroundService.isRunning`. Anything asking "is tracking alive" must read `isRunning`, because a service the system killed leaves the flag true. Recovery is layered: the app reconciles the two whenever it reaches the foreground, and `TrackingWatchdogScheduler` covers the window while the app stays closed. Reconciling can also drop the intent rather than honour it: a revoked location permission means no service can be started again, so the foreground reconciler clears the flag and the watchdog stops re-arming itself.
 
 ### NotificationHelper
 
@@ -398,12 +389,12 @@ Supporting utilities in `mapUtils.ts`:
 
 ### Hooks
 
-| Hook                  | Purpose                                                                                  |
-| --------------------- | ---------------------------------------------------------------------------------------- |
+| Hook | Purpose |
+| --- | --- |
 | `useLocationTracking` | Manages the foreground service lifecycle, native event subscriptions, and location state. On app foreground it reconciles the user's intent against real service liveness and restarts a service that died |
-| `useTheme`            | Provides theme colors, mode, and toggle from ThemeProvider context                       |
-| `useAutoSave`         | Debounced auto-save pattern for settings screens                                         |
-| `useTimeout`          | Managed timeout with automatic cleanup on unmount                                        |
+| `useTheme` | Provides theme colors, mode, and toggle from ThemeProvider context |
+| `useAutoSave` | Debounced auto-save pattern for settings screens |
+| `useTimeout` | Managed timeout with automatic cleanup on unmount |
 
 ### State Management
 

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -195,7 +195,6 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
   }
 ]
 
-
 function AppNavigator() {
   const { colors, isDark } = useTheme()
   const [currentRoute, setCurrentRoute] = useState<string | undefined>("Dashboard")
@@ -276,7 +275,12 @@ function AppNavigator() {
       {/* One provider so a 16 badge and a 24 tab glyph carry the same painted weight. */}
       <LucideProvider strokeWidth={1.5} absoluteStrokeWidth>
         <StatusBar {...statusBarConfig} />
-        <NavigationContainer theme={navigationTheme} linking={linking} ref={navigationRef} onStateChange={handleStateChange}>
+        <NavigationContainer
+          theme={navigationTheme}
+          linking={linking}
+          ref={navigationRef}
+          onStateChange={handleStateChange}
+        >
           <View style={styles.flex}>
             <Stack.Navigator initialRouteName="Dashboard" screenOptions={screenOptions}>
               {SCREEN_CONFIG.map((screen) => (

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -35,9 +35,7 @@ interface ChecklistItemProps {
 function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps) {
   const content = (
     <View style={styles.checklistItem}>
-      <View
-        style={[styles.checkCircle, { borderColor: colors.border }]}
-      >
+      <View style={[styles.checkCircle, { borderColor: colors.border }]}>
         {completed && <Check size={size.icon.sm} color={colors.success} />}
       </View>
       <Text
@@ -172,5 +170,5 @@ const styles = StyleSheet.create({
   link: {
     fontSize: fontSizes.body,
     ...fonts.semiBold
-  },
+  }
 })

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -161,8 +161,6 @@ describe("ConnectionSettings", () => {
 
       expect(getByText("Authentication & headers")).toBeTruthy()
     })
-
-
   })
 
   describe("offline mode", () => {

--- a/apps/mobile/src/components/ui/Divider.tsx
+++ b/apps/mobile/src/components/ui/Divider.tsx
@@ -22,14 +22,7 @@ export const Divider = ({ tight = false, inset = false }: DividerProps) => {
   const { colors } = useTheme()
 
   return (
-    <View
-      style={[
-        styles.divider,
-        tight && styles.tight,
-        inset && styles.inset,
-        { backgroundColor: colors.divider }
-      ]}
-    />
+    <View style={[styles.divider, tight && styles.tight, inset && styles.inset, { backgroundColor: colors.divider }]} />
   )
 }
 

--- a/apps/mobile/src/components/ui/IconButton.tsx
+++ b/apps/mobile/src/components/ui/IconButton.tsx
@@ -59,11 +59,7 @@ export function IconButton({
       }
       style={[styles.button, { backgroundColor: fill }, style]}
     >
-      {loading ? (
-        <ActivityIndicator size="small" color={content} />
-      ) : (
-        <Icon size={size.icon.sm} color={content} />
-      )}
+      {loading ? <ActivityIndicator size="small" color={content} /> : <Icon size={size.icon.sm} color={content} />}
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -58,7 +58,10 @@ export function ListItem({
       <View style={styles.content}>
         <Text style={[styles.label, { color: disabled ? colors.textDisabled : colors.text }]}>{label}</Text>
         {sub ? (
-          <Text style={[styles.sub, { color: disabled ? colors.textDisabled : colors.textSecondary }]} numberOfLines={1}>
+          <Text
+            style={[styles.sub, { color: disabled ? colors.textDisabled : colors.textSecondary }]}
+            numberOfLines={1}
+          >
             {sub}
           </Text>
         ) : null}

--- a/apps/mobile/src/components/ui/TextField.tsx
+++ b/apps/mobile/src/components/ui/TextField.tsx
@@ -39,18 +39,18 @@ type TextFieldProps = BaseProps &
 
 export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function TextFieldInput(
   {
-  label,
-  accessibilityLabel,
-  error,
-  disabled = false,
-  secure = false,
-  mono = false,
-  border = false,
-  figure = false,
-  style,
-  testID,
-  onFocus,
-  onBlur,
+    label,
+    accessibilityLabel,
+    error,
+    disabled = false,
+    secure = false,
+    mono = false,
+    border = false,
+    figure = false,
+    style,
+    testID,
+    onFocus,
+    onBlur,
     multiline = false,
     ...inputProps
   },
@@ -121,7 +121,12 @@ export const TextField = forwardRef<TextInputInstance, TextFieldProps>(function 
             <RevealIcon size={size.icon.md} color={disabled ? colors.textDisabled : colors.textSecondary} />
           </Pressable>
         ) : error ? (
-          <CircleAlert size={size.icon.md} color={colors.error} accessibilityElementsHidden importantForAccessibility="no" />
+          <CircleAlert
+            size={size.icon.md}
+            color={colors.error}
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+          />
         ) : null}
       </View>
       {typeof error === "string" ? <FieldMessage variant="error">{error}</FieldMessage> : null}

--- a/apps/mobile/src/components/ui/__tests__/Button.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/Button.test.tsx
@@ -27,9 +27,7 @@ describe("Button variants", () => {
   it("recedes when disabled instead of wearing an enabled label", () => {
     // The fill itself went to textDisabled while the label stayed textOnPrimary, so Offline maps'
     // disabled download button was white on grey and still read as a filled button you could press.
-    const { getByTestId } = render(
-      <Button title="Download area" onPress={jest.fn()} disabled testID="download-btn" />
-    )
+    const { getByTestId } = render(<Button title="Download area" onPress={jest.fn()} disabled testID="download-btn" />)
 
     expect(flat(getByTestId("download-btn")).backgroundColor).toBe(lightColors.well)
     expect(StyleSheet.flatten(getByTestId("download-btn").findByType(Text).props.style).color).toBe(

--- a/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
@@ -55,5 +55,4 @@ describe("ChipGroup", () => {
     expect(style.minHeight).toBe(size.chip)
     expect(style.minHeight + slop.top + slop.bottom).toBeGreaterThanOrEqual(size.touch)
   })
-
 })

--- a/apps/mobile/src/hooks/useLocationTracking.ts
+++ b/apps/mobile/src/hooks/useLocationTracking.ts
@@ -297,36 +297,39 @@ export function useLocationTracking(settings: Settings, settingsHydrated: boolea
    * Used after app restart when tracking_enabled is true in the DB.
    * Does NOT request permissions, but does restart the service if it died.
    */
-  const reconnect = useCallback(async (startSettings?: Settings) => {
-    if (isTrackingRef.current) {
-      logger.debug("[useLocationTracking] Already tracking, skip reconnect")
-      return
-    }
-
-    logger.debug("[useLocationTracking] Reconnecting to active service")
-    setTracking(true)
-
-    await reviveIfDead(startSettings ?? settingsRef.current)
-
-    try {
-      const latest = await NativeLocationService.getMostRecentLocation()
-      if (latest) {
-        setCoords({
-          latitude: latest.latitude,
-          longitude: latest.longitude,
-          accuracy: latest.accuracy,
-          altitude: latest.altitude ?? 0,
-          speed: latest.speed ?? 0,
-          bearing: latest.bearing ?? 0,
-          timestamp: latest.timestamp ?? Date.now(),
-          battery: latest.battery,
-          battery_status: latest.batteryStatus
-        })
+  const reconnect = useCallback(
+    async (startSettings?: Settings) => {
+      if (isTrackingRef.current) {
+        logger.debug("[useLocationTracking] Already tracking, skip reconnect")
+        return
       }
-    } catch (err) {
-      logger.error("[useLocationTracking] Failed to fetch location on reconnect:", err)
-    }
-  }, [reviveIfDead])
+
+      logger.debug("[useLocationTracking] Reconnecting to active service")
+      setTracking(true)
+
+      await reviveIfDead(startSettings ?? settingsRef.current)
+
+      try {
+        const latest = await NativeLocationService.getMostRecentLocation()
+        if (latest) {
+          setCoords({
+            latitude: latest.latitude,
+            longitude: latest.longitude,
+            accuracy: latest.accuracy,
+            altitude: latest.altitude ?? 0,
+            speed: latest.speed ?? 0,
+            bearing: latest.bearing ?? 0,
+            timestamp: latest.timestamp ?? Date.now(),
+            battery: latest.battery,
+            battery_status: latest.batteryStatus
+          })
+        }
+      } catch (err) {
+        logger.error("[useLocationTracking] Failed to fetch location on reconnect:", err)
+      }
+    },
+    [reviveIfDead]
+  )
 
   /**
    * Syncs tracking state and coords when app returns to foreground.

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -246,7 +246,13 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
                   }
                 ]}
               >
-                <Text style={[styles.chipText, active && styles.chipTextActive, { color: active ? colors.textOnPrimary : colors.textLight }]}>
+                <Text
+                  style={[
+                    styles.chipText,
+                    active && styles.chipTextActive,
+                    { color: active ? colors.textOnPrimary : colors.textLight }
+                  ]}
+                >
                   {level}
                   {count > 0 ? ` ${count}` : ""}
                 </Text>

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -22,7 +22,16 @@ import { useTheme } from "../hooks/useTheme"
 import { fonts, fontSizes, lineHeights } from "../styles/typography"
 import NativeLocationService from "../services/NativeLocationService"
 import { useTracking } from "../contexts/TrackingProvider"
-import { Button, Card, Container, Divider, FloatingSaveIndicator, SectionTitle, StatRow, TextField } from "../components"
+import {
+  Button,
+  Card,
+  Container,
+  Divider,
+  FloatingSaveIndicator,
+  SectionTitle,
+  StatRow,
+  TextField
+} from "../components"
 import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, size, space } from "../constants"
 import { useTimeout } from "../hooks/useTimeout"
 import { showConfirm } from "../services/modalService"

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -48,9 +48,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
   const [saving, setSaving] = useState(false)
   const placedOnEntry = useRef(route?.params?.lat != null)
   const [coord, setCoord] = useState<{ lat: number; lon: number } | null>(
-    route?.params?.lat != null && route?.params?.lon != null
-      ? { lat: route.params.lat, lon: route.params.lon }
-      : null
+    route?.params?.lat != null && route?.params?.lon != null ? { lat: route.params.lat, lon: route.params.lon } : null
   )
 
   const savedState = useRef({

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -12,12 +12,7 @@ import { Geofence, ScreenProps } from "../types/global"
 import { useTracking, useCoords } from "../contexts/TrackingProvider"
 import { MapPinHouse, Share2, Plus } from "lucide-react-native"
 import { Button, Card, Container, Divider, EmptyState, IconButton, ListItem, SectionTitle } from "../components"
-import {
-  DEFAULT_MAP_ZOOM,
-  MAP_ANIMATION_DURATION_MS,
-  WORLD_MAP_ZOOM,
-  space
-} from "../constants"
+import { DEFAULT_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, WORLD_MAP_ZOOM, space } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { buildGeofencesGeoJSON } from "../components/features/map/mapUtils"
@@ -71,7 +66,6 @@ const GeofenceMap = React.memo(function GeofenceMapView({
     })
   }, [coords, tracking])
 
-
   const handleCenterMe = useCallback(() => {
     if (coords && mapRef.current?.camera) {
       mapRef.current.camera.flyTo({
@@ -124,7 +118,6 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
   const [geofences, setGeofences] = useState<Geofence[]>([])
   const [currentPauseZone, setCurrentPauseZone] = useState<string | null>(null)
 
-
   const loadGeofences = useCallback(async () => {
     try {
       const data = await NativeLocationService.getGeofences()
@@ -155,8 +148,6 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
     })
     return () => listener.remove()
   }, [loadGeofences])
-
-
 
   const handleShareGeofences = useCallback(async () => {
     if (geofences.length === 0) return
@@ -189,11 +180,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
   return (
     <Container>
       <View style={{ height: mapHeight }}>
-        <GeofenceMap
-          tracking={tracking}
-          geofenceData={geofenceData}
-          currentPauseZone={currentPauseZone}
-        />
+        <GeofenceMap tracking={tracking} geofenceData={geofenceData} currentPauseZone={currentPauseZone} />
       </View>
 
       <View style={styles.listWrap}>
@@ -226,10 +213,7 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
           />
         </Card>
         {geofences.length === 0 && (
-          <EmptyState
-            title="No geofences yet"
-            hint="Create a geofence to stop recording locations in specific areas"
-          />
+          <EmptyState title="No geofences yet" hint="Create a geofence to stop recording locations in specific areas" />
         )}
       </View>
     </Container>

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -251,9 +251,7 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
             />
           }
           ListHeaderComponent={summaryHeader}
-          ListEmptyComponent={
-            <EmptyState style={styles.emptyInset} title="No data for this period" />
-          }
+          ListEmptyComponent={<EmptyState style={styles.emptyInset} title="No data for this period" />}
         />
       )}
     </Container>
@@ -329,5 +327,5 @@ const styles = StyleSheet.create({
   dayStat: {
     fontSize: fontSizes.caption,
     ...fonts.regular
-  },
+  }
 })

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -15,7 +15,16 @@ import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { X, CircleCheckBig, RefreshCw, TriangleAlert } from "lucide-react-native"
 import { Button, Card, Container, EmptyState, IconButton, SectionTitle, TextField } from "../components"
 import { useFocusEffect } from "@react-navigation/native"
-import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, MAP_STYLE_URL_LIGHT, WORLD_MAP_ZOOM, size, space, elevation } from "../constants"
+import {
+  DEFAULT_MAP_ZOOM,
+  HIT_SLOP_MD,
+  MAP_ANIMATION_DURATION_MS,
+  MAP_STYLE_URL_LIGHT,
+  WORLD_MAP_ZOOM,
+  size,
+  space,
+  elevation
+} from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
 import { logger } from "../utils/logger"

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -5,7 +5,18 @@
 
 import React, { useMemo, useState, useCallback, useLayoutEffect, useEffect, useRef } from "react"
 import { View, Text, StyleSheet, ScrollView, Pressable, useWindowDimensions } from "react-native"
-import { Share, Trash2, ChevronLeft, ChevronRight, Route, Clock, Gauge, MapPin, TrendingUp, TrendingDown } from "lucide-react-native"
+import {
+  Share,
+  Trash2,
+  ChevronLeft,
+  ChevronRight,
+  Route,
+  Clock,
+  Gauge,
+  MapPin,
+  TrendingUp,
+  TrendingDown
+} from "lucide-react-native"
 import { useTheme } from "../hooks/useTheme"
 import { fontSizes, fonts, type } from "../styles/typography"
 // Deep paths on purpose: the components barrel re-exports DashboardMap, which reaches
@@ -427,7 +438,6 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
     </Container>
   )
 }
-
 
 const styles = StyleSheet.create({
   content: {

--- a/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AboutScreen.test.tsx
@@ -144,9 +144,6 @@ describe("AboutScreen", () => {
     expect(getByText("Version 1.3.0")).toBeTruthy()
   })
 
-
-
-
   it("shows the build details", async () => {
     const { getByText } = renderScreen()
 

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -271,8 +271,6 @@ describe("DataManagementScreen", () => {
     })
   })
 
-
-
   it("Clear Sent History shows confirmation dialog", async () => {
     const { getByText, getAllByText } = renderScreen()
 

--- a/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
@@ -147,10 +147,7 @@ describe("GeofenceEditorScreen", () => {
 
   function renderEditAt(lat: number, lon: number) {
     return render(
-      <GeofenceEditorScreen
-        navigation={mockNavigation as any}
-        route={{ params: { geofenceId: 1, lat, lon } } as any}
-      />
+      <GeofenceEditorScreen navigation={mockNavigation as any} route={{ params: { geofenceId: 1, lat, lon } } as any} />
     )
   }
 

--- a/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
@@ -278,7 +278,9 @@ describe("GeofenceScreen", () => {
     mockGetGeofences.mockResolvedValue(mockGeofences)
     const mockNavigate = jest.fn()
 
-    const { getByTestId } = render(<GeofenceScreen navigation={{ navigate: mockNavigate, setOptions: jest.fn() } as any} />)
+    const { getByTestId } = render(
+      <GeofenceScreen navigation={{ navigate: mockNavigate, setOptions: jest.fn() } as any} />
+    )
 
     await waitFor(() => expect(getByTestId("edit-geofence-1")).toBeTruthy())
 

--- a/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/OfflineMapsScreen.test.tsx
@@ -205,7 +205,9 @@ async function waitForMapReady(findByText: ReturnType<typeof render>["findByText
 
 describe("OfflineMapsScreen", () => {
   it("names the delete disc, which the hand-built Pressable beside its IconButton sibling never did", async () => {
-    mockLoadOfflineAreas.mockResolvedValue([{ name: "my park", sizeBytes: 2_000_000, isComplete: true, isActive: false }])
+    mockLoadOfflineAreas.mockResolvedValue([
+      { name: "my park", sizeBytes: 2_000_000, isComplete: true, isActive: false }
+    ])
     const { getByTestId } = renderScreen()
 
     await waitFor(() => expect(getByTestId("delete-btn-my park")).toBeTruthy())


### PR DESCRIPTION
Twenty-four files had drifted out of prettier style. CI runs eslint but not the prettier check, and pre-commit only formats for someone who has run pre-commit install, so nothing caught them.

Formatting only: import lists and JSX rejoined, blank-line pairs collapsed, one useCallback re-indented, two trailing commas dropped, and api-reference.md and architecture.md unwrapped to one line per paragraph under proseWrap never. tsc, eslint, the jest suites and the docs build all pass unchanged.
