### PR TITLE
refactor(ui): one label treatment for every field

### DIFF
--- a/apps/mobile/src/components/ui/NumericInput.tsx
+++ b/apps/mobile/src/components/ui/NumericInput.tsx
@@ -40,7 +40,7 @@ export function NumericInput({
 
   return (
     <View style={styles.container}>
-      <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+      <Text style={[styles.label, { color: colors.textSecondary }]}>{label}</Text>
       {hint && <Text style={[styles.hint, { color: colors.textSecondary }]}>{hint}</Text>}
 
       <View style={styles.inputRow}>
@@ -66,8 +66,8 @@ const styles = StyleSheet.create({
     marginBottom: space.lg
   },
   label: {
-    fontSize: fontSizes.body,
-    ...fonts.semiBold,
+    fontSize: fontSizes.description,
+    ...fonts.medium,
     marginBottom: space.sm
   },
   hint: {

--- a/apps/mobile/src/components/ui/TimePicker.tsx
+++ b/apps/mobile/src/components/ui/TimePicker.tsx
@@ -12,6 +12,7 @@ import { space } from "../../constants"
 import { TextField } from "./TextField"
 
 interface TimePickerProps {
+  label: string
   value: string
   onChange: (value: string) => void
 }
@@ -31,7 +32,7 @@ function format(h: number, m: number): string {
   return `${pad2(h)}:${pad2(m)}`
 }
 
-export function TimePicker({ value, onChange }: TimePickerProps) {
+export function TimePicker({ label, value, onChange }: TimePickerProps) {
   const { colors } = useTheme()
   const { h, m } = useMemo(() => parse(value), [value])
 
@@ -63,37 +64,45 @@ export function TimePicker({ value, onChange }: TimePickerProps) {
   }, [minuteText, h, m, onChange])
 
   return (
-    <View style={styles.row}>
-      <TextField
-        testID="timepicker-hour-value"
-        accessibilityLabel="Hours"
-        figure
-        style={styles.field}
-        value={hourText}
-        onChangeText={onHourChange}
-        onBlur={commitHour}
-        keyboardType="number-pad"
-        maxLength={2}
-        selectTextOnFocus
-      />
-      <Text style={[styles.separator, { color: colors.text }]}>:</Text>
-      <TextField
-        testID="timepicker-minute-value"
-        accessibilityLabel="Minutes"
-        figure
-        style={styles.field}
-        value={minuteText}
-        onChangeText={onMinuteChange}
-        onBlur={commitMinute}
-        keyboardType="number-pad"
-        maxLength={2}
-        selectTextOnFocus
-      />
+    <View>
+      <Text style={[styles.label, { color: colors.textSecondary }]}>{label}</Text>
+      <View style={styles.row}>
+        <TextField
+          testID="timepicker-hour-value"
+          accessibilityLabel={`${label}, hours`}
+          figure
+          style={styles.field}
+          value={hourText}
+          onChangeText={onHourChange}
+          onBlur={commitHour}
+          keyboardType="number-pad"
+          maxLength={2}
+          selectTextOnFocus
+        />
+        <Text style={[styles.separator, { color: colors.text }]}>:</Text>
+        <TextField
+          testID="timepicker-minute-value"
+          accessibilityLabel={`${label}, minutes`}
+          figure
+          style={styles.field}
+          value={minuteText}
+          onChangeText={onMinuteChange}
+          onBlur={commitMinute}
+          keyboardType="number-pad"
+          maxLength={2}
+          selectTextOnFocus
+        />
+      </View>
     </View>
   )
 }
 
 const styles = StyleSheet.create({
+  label: {
+    fontSize: fontSizes.description,
+    ...fonts.medium,
+    marginBottom: space.sm
+  },
   row: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/src/components/ui/__tests__/TimePicker.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/TimePicker.test.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { TimePicker } from "../TimePicker"
+
+describe("TimePicker", () => {
+  const onChange = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function renderPicker(value = "14:05") {
+    return render(<TimePicker label="Time (24h)" value={value} onChange={onChange} />)
+  }
+
+  it("draws the label itself, so a caller does not hand-roll one beside it", () => {
+    const { getByText } = renderPicker()
+
+    expect(getByText("Time (24h)")).toBeTruthy()
+  })
+
+  it("names both fields with the label, because Hours alone does not say which time", () => {
+    const { getByLabelText } = renderPicker()
+
+    expect(getByLabelText("Time (24h), hours")).toBeTruthy()
+    expect(getByLabelText("Time (24h), minutes")).toBeTruthy()
+  })
+
+  it("pads a single digit on blur, so the value always round-trips as HH:mm", () => {
+    const { getByTestId } = renderPicker()
+
+    fireEvent.changeText(getByTestId("timepicker-hour-value"), "7")
+    fireEvent(getByTestId("timepicker-hour-value"), "blur")
+
+    expect(onChange).toHaveBeenCalledWith("07:05")
+  })
+
+  it("clamps an hour past 23 rather than storing an unparseable time", () => {
+    const { getByTestId } = renderPicker()
+
+    fireEvent.changeText(getByTestId("timepicker-hour-value"), "99")
+    fireEvent(getByTestId("timepicker-hour-value"), "blur")
+
+    expect(onChange).toHaveBeenCalledWith("23:05")
+  })
+
+  it("clamps a minute past 59 the same way", () => {
+    const { getByTestId } = renderPicker()
+
+    fireEvent.changeText(getByTestId("timepicker-minute-value"), "70")
+    fireEvent(getByTestId("timepicker-minute-value"), "blur")
+
+    expect(onChange).toHaveBeenCalledWith("14:59")
+  })
+})

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -458,7 +458,7 @@ export function AutoExportScreen(_props: ScreenProps) {
             {FILENAME_TOKENS.map((token) => (
               <View key={token} style={styles.templateTokenRow}>
                 <Text style={[styles.templateToken, { color: colors.text }]}>{`{${token}}`}</Text>
-                <Text style={[styles.templateHint, { color: colors.textSecondary }]}>{tokenValues[token]}</Text>
+                <Text style={[styles.templateTokenValue, { color: colors.textSecondary }]}>{tokenValues[token]}</Text>
               </View>
             ))}
             <Text style={[styles.templateHint, { color: colors.textSecondary }]}>
@@ -508,8 +508,7 @@ export function AutoExportScreen(_props: ScreenProps) {
               </>
             )}
             <Divider />
-            <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Time (24h)</Text>
-            <TimePicker value={timeOfDay} onChange={handleTimeChange} />
+            <TimePicker label="Time (24h)" value={timeOfDay} onChange={handleTimeChange} />
           </Card>
         </View>
 
@@ -763,9 +762,8 @@ const styles = StyleSheet.create({
     padding: space.sm
   },
   fieldLabel: {
-    fontSize: fontSizes.caption,
-    ...fonts.semiBold,
-    marginTop: space.md,
+    fontSize: fontSizes.description,
+    ...fonts.medium,
     marginBottom: space.sm
   },
   templateHint: {
@@ -776,13 +774,17 @@ const styles = StyleSheet.create({
   templateTokenRow: {
     flexDirection: "row",
     alignItems: "baseline",
-    gap: space.sm
+    gap: space.sm,
+    marginTop: space.sm
   },
   templateToken: {
     fontSize: fontSizes.description,
     ...fonts.semiBold,
-    marginTop: space.sm,
     minWidth: 72
+  },
+  templateTokenValue: {
+    fontSize: fontSizes.description,
+    ...fonts.regular
   },
   templatePreview: {
     fontSize: fontSizes.description,


### PR DESCRIPTION
A field label was drawn three ways, all visible on Auto-export at once: TextField's own at description/medium/textSecondary, NumericInput's at body/semiBold/text, and a hand-rolled caption/semiBold above the time picker. TextField's is what 33 of the app's 35 fields already use, so the other two converge on it.

TimePicker takes a required label and draws it, which is what forced the hand-rolled one: it was the only field primitive without the prop its siblings require. Its inputs now name themselves "Time (24h), hours" instead of a bare "Hours", which never said which time. It had no test at all and has five now.

The gap between the frequency chips and the time field drops from 45 to 33. The Divider above already pays space.lg on both sides, and the label was adding space.md for the same separation.

templateTokenRow pays its own top margin instead of both children paying one each, which only aligned by coincidence.

ChipGroup gets no label prop: one of its thirteen call sites hand-rolls a label, so it would serve a single caller.
