### PR TITLE
feat(sync): sync condition becomes radio rows

### DIFF
--- a/apps/docs/docs/configuration/server-settings.md
+++ b/apps/docs/docs/configuration/server-settings.md
@@ -70,7 +70,7 @@ The UI simplifies to remove sync-related elements that don't apply:
 - Server Endpoint and Test Connection
 - Authentication & headers
 - API Field Mapping
-- Sync Interval, Sync Condition (Any / Wi-Fi / SSID / VPN)
+- Sync Interval, Sync Condition (Any network / Wi-Fi / Specific Wi-Fi network / VPN)
 - Queue statistics (Queued / Sent counts)
 - Queue actions (Sync Now, Clear Sent History, Clear Queue)
 - Queue info in the tracking notification

--- a/apps/docs/docs/configuration/sync-presets.md
+++ b/apps/docs/docs/configuration/sync-presets.md
@@ -19,12 +19,12 @@ Select a preset in **Settings → Tracking & sync** or choose **Custom** to conf
 
 Controls when Colota uploads locations. Locations are always recorded and queued locally regardless of this setting.
 
-| Option            | Behavior                                               |
-| ----------------- | ------------------------------------------------------ |
-| **Any Network**   | Upload on any connection (default)                     |
-| **Wi-Fi Only**    | Upload only on unmetered networks (Wi-Fi, Ethernet)    |
-| **Specific SSID** | Upload only when connected to a specific Wi-Fi network |
-| **VPN**           | Upload only when a VPN connection is active            |
+| Option                     | Behavior                                             |
+| -------------------------- | ---------------------------------------------------- |
+| **Any network**            | Uploads over mobile data as well as Wi-Fi (default)  |
+| **Wi-Fi**                  | Uploads only on unmetered networks (Wi-Fi, Ethernet) |
+| **Specific Wi-Fi network** | Uploads only on one network you choose               |
+| **VPN**                    | Uploads only while a VPN is active                   |
 
 This is useful for:
 

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -30,6 +30,13 @@ interface SyncStrategySettingsProps {
   colors: ThemeColors
 }
 
+const SYNC_CONDITION_OPTIONS: { value: SyncCondition; label: string; sub: string }[] = [
+  { value: "any", label: "Any network", sub: "Uploads over mobile data as well as Wi-Fi" },
+  { value: "wifi_any", label: "Wi-Fi", sub: "Uploads only while connected to any Wi-Fi" },
+  { value: "wifi_ssid", label: "Specific Wi-Fi network", sub: "Uploads only on one network you choose" },
+  { value: "vpn", label: "VPN", sub: "Uploads only while a VPN is active" }
+]
+
 function presetSummary(preset: SelectablePreset, isOfflineMode: boolean): string {
   const config = TRACKING_PRESETS[preset]
   const base = isOfflineMode ? config.description.split(" • ")[0] : config.description
@@ -320,67 +327,61 @@ export function SyncStrategySettings({
             {/* Sync Condition */}
             <View style={styles.settingBlock}>
               <Text style={[styles.blockLabel, { color: colors.text }]}>Sync only on</Text>
-              <Text style={[styles.blockHint, { color: colors.textSecondary }]}>
-                {settings.syncCondition === "any" && "Upload on any network connection"}
-                {settings.syncCondition === "wifi_any" && "Upload only when connected to Wi-Fi"}
-                {settings.syncCondition === "wifi_ssid" && "Upload only on a specific Wi-Fi network"}
-                {settings.syncCondition === "vpn" && "Upload only when VPN is active"}
-              </Text>
-              <ChipGroup
-                options={[
-                  { value: "any", label: "Any" },
-                  { value: "wifi_any", label: "Wi-Fi" },
-                  { value: "wifi_ssid", label: "SSID" },
-                  { value: "vpn", label: "VPN" }
-                ]}
-                selected={settings.syncCondition}
-                onSelect={(value) => {
-                  const next = {
-                    ...settings,
-                    syncCondition: value as SyncCondition,
-                    syncPreset: "custom" as const
-                  }
-                  onSettingsChange(next)
-                  onImmediateSave(next)
-                }}
-              />
-              {settings.syncCondition === "wifi_ssid" && (
-                <View style={styles.ssidRow}>
-                  <TextField
-                    accessibilityLabel="Wi-Fi SSID"
-                    testID="sync-ssid-input"
-                    style={styles.ssidField}
-                    mono
-                    value={settings.syncSsid}
-                    onChangeText={(text) => {
-                      const next = { ...settings, syncSsid: text }
-                      onSettingsChange(next)
-                      onDebouncedSave(next)
-                    }}
-                    placeholder="Enter Wi-Fi SSID"
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                  />
-                  {currentSsid !== "" && currentSsid.toLowerCase() !== settings.syncSsid.toLowerCase() && (
-                    <Pressable
-                      hitSlop={HIT_SLOP_MD}
-                      accessibilityRole="button"
-                      style={({ pressed }) => [
-                        styles.ssidFillButton,
-                        { backgroundColor: colors.primary + "15" },
-                        pressed && { opacity: colors.pressedOpacity }
-                      ]}
+              <View accessibilityRole="radiogroup">
+                {SYNC_CONDITION_OPTIONS.map(({ value, label, sub }) => (
+                  <React.Fragment key={value}>
+                    <RadioRow
+                      testID={`sync-condition-${value}`}
+                      label={label}
+                      sub={sub}
+                      selected={settings.syncCondition === value}
                       onPress={() => {
-                        const next = { ...settings, syncSsid: currentSsid }
+                        const next = { ...settings, syncCondition: value, syncPreset: "custom" as const }
                         onSettingsChange(next)
                         onImmediateSave(next)
                       }}
-                    >
-                      <Text style={[styles.ssidFillText, { color: colors.primary }]}>Use current</Text>
-                    </Pressable>
-                  )}
-                </View>
-              )}
+                    />
+                    {/* Belongs to its own row, not to the end of the group: VPN sits below it. */}
+                    {value === "wifi_ssid" && settings.syncCondition === "wifi_ssid" && (
+                      <View style={styles.ssidRow}>
+                        <TextField
+                          accessibilityLabel="Wi-Fi SSID"
+                          testID="sync-ssid-input"
+                          style={styles.ssidField}
+                          mono
+                          value={settings.syncSsid}
+                          onChangeText={(text) => {
+                            const next = { ...settings, syncSsid: text }
+                            onSettingsChange(next)
+                            onDebouncedSave(next)
+                          }}
+                          placeholder="Enter Wi-Fi SSID"
+                          autoCapitalize="none"
+                          autoCorrect={false}
+                        />
+                        {currentSsid !== "" && currentSsid.toLowerCase() !== settings.syncSsid.toLowerCase() && (
+                          <Pressable
+                            hitSlop={HIT_SLOP_MD}
+                            accessibilityRole="button"
+                            style={({ pressed }) => [
+                              styles.ssidFillButton,
+                              { backgroundColor: colors.primary + "15" },
+                              pressed && { opacity: colors.pressedOpacity }
+                            ]}
+                            onPress={() => {
+                              const next = { ...settings, syncSsid: currentSsid }
+                              onSettingsChange(next)
+                              onImmediateSave(next)
+                            }}
+                          >
+                            <Text style={[styles.ssidFillText, { color: colors.primary }]}>Use current</Text>
+                          </Pressable>
+                        )}
+                      </View>
+                    )}
+                  </React.Fragment>
+                ))}
+              </View>
             </View>
           </Card>
         </>
@@ -463,10 +464,14 @@ const styles = StyleSheet.create({
   customSyncInput: {
     marginTop: space.md
   },
+  // Indents and spaces itself the way the custom preset parameters do. The row above already pays
+  // space.lg below it, so a top margin here would push the field nearer VPN than its own option.
   ssidRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginTop: space.sm,
+    paddingLeft: size.iconColumn,
+    marginTop: -space.xs,
+    paddingBottom: space.lg,
     gap: space.sm
   },
   ssidField: {

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -379,4 +379,49 @@ describe("SyncStrategySettings", () => {
       expect(mockOnImmediateSave).not.toHaveBeenCalled()
     })
   })
+
+  describe("sync condition", () => {
+    it("states what every option does without one being chosen, which the chips could not", () => {
+      const { getByText } = renderComponent({ syncCondition: "any" })
+
+      expect(getByText("Uploads over mobile data as well as Wi-Fi")).toBeTruthy()
+      expect(getByText("Uploads only while connected to any Wi-Fi")).toBeTruthy()
+      expect(getByText("Uploads only on one network you choose")).toBeTruthy()
+      expect(getByText("Uploads only while a VPN is active")).toBeTruthy()
+    })
+
+    it("saves the choice and drops the preset to custom, because a preset does not carry it", () => {
+      const { getByTestId } = renderComponent({ syncCondition: "any", syncPreset: "balanced" })
+
+      fireEvent.press(getByTestId("sync-condition-vpn"))
+
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(
+        expect.objectContaining({ syncCondition: "vpn", syncPreset: "custom" })
+      )
+    })
+
+    it("puts the SSID field under its own row, not at the end of the group below VPN", () => {
+      const { toJSON } = renderComponent({ syncCondition: "wifi_ssid" })
+
+      const ids: string[] = []
+      const walk = (node: any) => {
+        if (!node || typeof node !== "object") return
+        if (Array.isArray(node)) return node.forEach(walk)
+        if (node.props?.testID) ids.push(node.props.testID)
+        ;(node.children ?? []).forEach(walk)
+      }
+      walk(toJSON())
+
+      expect(ids.indexOf("sync-ssid-input")).toBeGreaterThan(ids.indexOf("sync-condition-wifi_ssid"))
+      expect(ids.indexOf("sync-ssid-input")).toBeLessThan(ids.indexOf("sync-condition-vpn"))
+    })
+
+    it("reveals the SSID field only for the one option that needs a network name", () => {
+      const { queryByTestId } = renderComponent({ syncCondition: "wifi_any" })
+      expect(queryByTestId("sync-ssid-input")).toBeNull()
+
+      const named = renderComponent({ syncCondition: "wifi_ssid" })
+      expect(named.queryByTestId("sync-ssid-input")).toBeTruthy()
+    })
+  })
 })


### PR DESCRIPTION
The four options were Any, Wi-Fi, SSID and VPN as chips, under one description line that swapped with the selection. A chip holds three words and no explanation, so the only way to find out what SSID did was to tap it, and tapping writes the setting and restarts the service. Each option carries its own sentence now, permanently, and SSID reads Specific Wi-Fi network because the jargon was standing in for the explanation that was missing.

The SSID field renders inside the radiogroup after its own row rather than after the group, where it appeared below VPN and read as belonging to it. It pulls up by space.xs against the row's space.lg bottom padding and pays space.lg below, so it sits 12 under its own option and 32 above the next.

sync-presets.md and server-settings.md both listed the old labels.
