### PR TITLE
feat(sync): sync interval becomes radio rows

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -16,7 +16,7 @@ import {
   size,
   space
 } from "../../../constants"
-import { Card, ChipGroup, NumericInput, RadioRow, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
+import { Card, NumericInput, RadioRow, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
 import { isOverlandFormat } from "../../../utils/apiPayload"
 import NativeLocationService from "../../../services/NativeLocationService"
@@ -77,7 +77,10 @@ export function SyncStrategySettings({
     return () => sub.remove()
   }, [settings.syncCondition])
 
-  const isCustomSyncInterval = !SYNC_INTERVAL_PRESETS.includes(settings.syncInterval)
+  // Custom mode cannot be derived from the value alone: every number the user might pick first is
+  // also a preset, so deriving it forced the old code to invent one and save it on the spot.
+  const [customSyncOpen, setCustomSyncOpen] = useState(false)
+  const isCustomSyncInterval = customSyncOpen || !SYNC_INTERVAL_PRESETS.includes(settings.syncInterval)
 
   // Sync inputs with settings changes (e.g. preset selection)
   useEffect(() => {
@@ -239,59 +242,61 @@ export function SyncStrategySettings({
                 How often to upload data to server
               </Text>
 
-              <ChipGroup
-                options={[
-                  ...SYNC_INTERVAL_PRESETS.map((sec) => ({
-                    value: String(sec),
-                    label: SYNC_INTERVAL_LABELS[sec]
-                  })),
-                  { value: "custom", label: "Custom" }
-                ]}
-                selected={isCustomSyncInterval ? "custom" : String(settings.syncInterval)}
-                onSelect={(value) => {
-                  if (value === "custom") {
-                    // Seeding a value is what makes the mode custom; the field takes over.
-                    if (!isCustomSyncInterval) {
-                      const customValue = 1800
-                      setSyncIntervalInput(customValue.toString())
-                      handleGridSelect("syncInterval", customValue)
-                    }
-                    return
-                  }
-                  handleGridSelect("syncInterval", Number(value))
-                }}
-              />
-            </View>
-
-            {isCustomSyncInterval && (
-              <View style={styles.customSyncInput}>
-                <NumericInput
-                  label="Custom sync interval"
-                  value={syncIntervalInput}
-                  onChange={(val) => {
-                    setSyncIntervalInput(val)
-                    const num = Number(val)
-                    if (!isNaN(num) && num >= 1) {
-                      const next = { ...settings, syncInterval: num, syncPreset: "custom" as const }
-                      onDebouncedSave(next)
-                    }
+              <View accessibilityRole="radiogroup">
+                {SYNC_INTERVAL_PRESETS.map((seconds) => (
+                  <RadioRow
+                    key={seconds}
+                    testID={`sync-interval-${seconds}`}
+                    label={SYNC_INTERVAL_LABELS[seconds]}
+                    sub={seconds === 0 ? "Uploads each fix as soon as it is recorded" : undefined}
+                    selected={!isCustomSyncInterval && settings.syncInterval === seconds}
+                    onPress={() => {
+                      setCustomSyncOpen(false)
+                      handleGridSelect("syncInterval", seconds)
+                    }}
+                  />
+                ))}
+                <RadioRow
+                  testID="sync-interval-custom"
+                  label="Custom"
+                  sub={isCustomSyncInterval ? `Every ${settings.syncInterval} seconds` : "Set your own interval"}
+                  selected={isCustomSyncInterval}
+                  onPress={() => {
+                    setSyncIntervalInput(settings.syncInterval.toString())
+                    setCustomSyncOpen(true)
                   }}
-                  onBlur={() => {
-                    let val = Number(syncIntervalInput)
-                    if (isNaN(val) || val < 1) {
-                      val = 1
-                      setSyncIntervalInput("1")
-                      const next = { ...settings, syncInterval: val, syncPreset: "custom" as const }
-                      onSettingsChange(next)
-                      onImmediateSave(next)
-                    }
-                  }}
-                  unit="seconds"
-                  placeholder="1800"
-                  hint="Custom interval in seconds"
                 />
+
+                {isCustomSyncInterval && (
+                  <View style={styles.customSyncInput}>
+                    <NumericInput
+                      label="Custom sync interval"
+                      value={syncIntervalInput}
+                      onChange={(val) => {
+                        setSyncIntervalInput(val)
+                        const num = Number(val)
+                        if (!isNaN(num) && num >= 1) {
+                          const next = { ...settings, syncInterval: num, syncPreset: "custom" as const }
+                          onDebouncedSave(next)
+                        }
+                      }}
+                      onBlur={() => {
+                        let val = Number(syncIntervalInput)
+                        if (isNaN(val) || val < 1) {
+                          val = 1
+                          setSyncIntervalInput("1")
+                          const next = { ...settings, syncInterval: val, syncPreset: "custom" as const }
+                          onSettingsChange(next)
+                          onImmediateSave(next)
+                        }
+                      }}
+                      unit="seconds"
+                      hint="Custom interval in seconds"
+                    />
+                  </View>
+                )}
               </View>
-            )}
+            </View>
 
             {showOverlandBatchSize && (
               <View style={styles.customSyncInput}>

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -213,22 +213,21 @@ describe("SyncStrategySettings", () => {
     })
   })
 
-  describe("sync interval chips", () => {
-    it("renders all sync interval options inline", () => {
-      const { getByText, getAllByText } = renderComponent()
+  describe("sync interval", () => {
+    it("renders every option inline, Custom included", () => {
+      const { getByTestId } = renderComponent()
 
-      expect(getAllByText("Instant").length).toBeGreaterThan(0)
-      expect(getByText("1 min")).toBeTruthy()
-      expect(getByText("5 min")).toBeTruthy()
-      expect(getByText("15 min")).toBeTruthy()
-      // "Custom" labels both the preset row and this chip.
-      expect(getAllByText("Custom").length).toBeGreaterThan(0)
+      expect(getByTestId("sync-interval-0")).toBeTruthy()
+      expect(getByTestId("sync-interval-60")).toBeTruthy()
+      expect(getByTestId("sync-interval-300")).toBeTruthy()
+      expect(getByTestId("sync-interval-900")).toBeTruthy()
+      expect(getByTestId("sync-interval-custom")).toBeTruthy()
     })
 
     it("selecting a sync interval sets preset to custom", () => {
-      const { getByText } = renderComponent()
+      const { getByTestId } = renderComponent()
 
-      fireEvent.press(getByText("5 min"))
+      fireEvent.press(getByTestId("sync-interval-300"))
 
       expect(mockOnSettingsChange).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -242,6 +241,30 @@ describe("SyncStrategySettings", () => {
           syncPreset: "custom"
         })
       )
+    })
+
+    it("opening Custom saves nothing and keeps the interval you already had", () => {
+      const { getByTestId, getByDisplayValue } = renderComponent({ syncInterval: 300 })
+
+      fireEvent.press(getByTestId("sync-interval-custom"))
+
+      // The old code wrote a hardcoded 1800 here, discarding the interval and restarting tracking.
+      expect(mockOnSettingsChange).not.toHaveBeenCalled()
+      expect(mockOnDebouncedSave).not.toHaveBeenCalled()
+      expect(mockOnImmediateSave).not.toHaveBeenCalled()
+      expect(getByDisplayValue("300")).toBeTruthy()
+    })
+
+    it("leaves Custom when a preset is pressed, even though the value was never off-preset", () => {
+      const { getByTestId, queryByDisplayValue } = renderComponent({ syncInterval: 300 })
+
+      fireEvent.press(getByTestId("sync-interval-custom"))
+      expect(queryByDisplayValue("300")).toBeTruthy()
+
+      fireEvent.press(getByTestId("sync-interval-60"))
+
+      expect(queryByDisplayValue("300")).toBeNull()
+      expect(mockOnDebouncedSave).toHaveBeenCalledWith(expect.objectContaining({ syncInterval: 60 }))
     })
   })
 

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -210,7 +210,8 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
   }, [profile, isEditing, profileId, navigation])
 
   const isSpeed = profile.condition.type === "speed_above" || profile.condition.type === "speed_below"
-  const isCustomSyncInterval = !SYNC_INTERVAL_PRESETS.includes(profile.syncInterval)
+  const [customSyncOpen, setCustomSyncOpen] = useState(false)
+  const isCustomSyncInterval = customSyncOpen || !SYNC_INTERVAL_PRESETS.includes(profile.syncInterval)
 
   return (
     <Container>
@@ -353,14 +354,11 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                 selected={isCustomSyncInterval ? "custom" : String(profile.syncInterval)}
                 onSelect={(value) => {
                   if (value === "custom") {
-                    // Seeding a value is what makes the mode custom; the field takes over from here.
-                    if (!isCustomSyncInterval) {
-                      const customValue = 1800
-                      setSyncIntervalStr(customValue.toString())
-                      setProfile((prev) => ({ ...prev, syncInterval: customValue }))
-                    }
+                    setSyncIntervalStr(profile.syncInterval.toString())
+                    setCustomSyncOpen(true)
                     return
                   }
+                  setCustomSyncOpen(false)
                   setProfile((prev) => ({ ...prev, syncInterval: Number(value) }))
                 }}
               />
@@ -385,7 +383,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                       }
                     }}
                     unit="seconds"
-                    placeholder="1800"
                     hint="Custom interval in seconds"
                   />
                 </View>

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -126,6 +126,15 @@ jest.mock("../../components", () => {
     Container: ({ children }: any) => R.createElement(View, null, children),
     SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
     Card: ({ children }: any) => R.createElement(View, null, children),
+    NumericInput: ({ label, value, onChange, onBlur, unit, hint }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        hint ? R.createElement(Text, null, hint) : null,
+        R.createElement(require("react-native").TextInput, { value, onChangeText: onChange, onBlur }),
+        unit ? R.createElement(Text, null, unit) : null
+      ),
     Divider: () => R.createElement(View, null),
     SettingRow: ({ label, hint, children }: any) =>
       R.createElement(
@@ -514,6 +523,18 @@ describe("ProfileEditorScreen", () => {
       await waitFor(() => expect(mockShowConfirm).toHaveBeenCalled())
       expect(mockDeleteProfile).not.toHaveBeenCalled()
       expect(mockGoBack).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("custom sync interval", () => {
+    it("opens Custom on the interval the profile already has, not on an invented one", async () => {
+      const { getByText, getByDisplayValue } = renderEditProfile(1)
+
+      await waitFor(() => expect(getByDisplayValue("Existing Profile")).toBeTruthy())
+      fireEvent.press(getByText("Custom"))
+
+      // The old code seeded a hardcoded 1800 here, throwing away the profile's 60.
+      expect(getByDisplayValue("60")).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
The last chip group in a card whose other two controls are radio rows. Instant carries a sub saying it uploads each fix as it is recorded, the numeric presets need none, and Custom states the interval it holds, which is what the tracking preset list above already does.

The custom field renders inside the radiogroup under its own row rather than after the block. SyncStrategySettings no longer imports ChipGroup at all.
