### PR TITLE
feat(api): dawarich mode becomes radio rows, and a blocked option says why

### DIFF
--- a/apps/mobile/src/components/ui/RadioDot.tsx
+++ b/apps/mobile/src/components/ui/RadioDot.tsx
@@ -8,15 +8,16 @@ import { View, StyleSheet } from "react-native"
 import { useTheme } from "../../hooks/useTheme"
 import { radius } from "@colota/shared"
 
-export function RadioDot({ selected }: { selected: boolean }) {
+export function RadioDot({ selected, disabled = false }: { selected: boolean; disabled?: boolean }) {
   const { colors } = useTheme()
+  const tint = disabled ? colors.textDisabled : colors.primary
   return (
     <View
-      style={[styles.radio, { borderColor: selected ? colors.primary : colors.border }]}
+      style={[styles.radio, { borderColor: selected ? tint : colors.border }]}
       importantForAccessibility="no"
       accessibilityElementsHidden
     >
-      {selected && <View style={[styles.inner, { backgroundColor: colors.primary }]} />}
+      {selected && <View style={[styles.inner, { backgroundColor: tint }]} />}
     </View>
   )
 }

--- a/apps/mobile/src/components/ui/RadioRow.tsx
+++ b/apps/mobile/src/components/ui/RadioRow.tsx
@@ -17,6 +17,7 @@ type RadioRowProps = {
   onPress: () => void
   sub?: string
   icon?: LucideIcon
+  disabled?: boolean
   testID?: string
 }
 
@@ -24,7 +25,7 @@ type RadioRowProps = {
  * The whole row is the radio; RadioDot is decoration, which is why it is hidden from
  * accessibility and the state lives here.
  */
-export function RadioRow({ label, selected, onPress, sub, icon: Icon, testID }: RadioRowProps) {
+export function RadioRow({ label, selected, onPress, sub, icon: Icon, disabled = false, testID }: RadioRowProps) {
   const { colors } = useTheme()
 
   return (
@@ -32,16 +33,19 @@ export function RadioRow({ label, selected, onPress, sub, icon: Icon, testID }: 
       testID={testID}
       onPress={onPress}
       accessibilityRole="radio"
-      accessibilityState={{ checked: selected }}
+      accessibilityState={{ checked: selected, disabled }}
       accessibilityLabel={sub ? `${label}, ${sub}` : label}
-      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+      android_ripple={disabled ? undefined : { color: colors.text + STATE_LAYER_ALPHA }}
+      disabled={disabled}
       style={styles.row}
     >
-      <RadioDot selected={selected} />
-      {Icon ? <Icon size={size.icon.md} color={colors.textSecondary} /> : null}
+      <RadioDot selected={selected} disabled={disabled} />
+      {Icon ? <Icon size={size.icon.md} color={disabled ? colors.textDisabled : colors.textSecondary} /> : null}
       <View style={styles.text}>
-        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
-        {sub ? <Text style={[styles.sub, { color: colors.textSecondary }]}>{sub}</Text> : null}
+        <Text style={[styles.label, { color: disabled ? colors.textDisabled : colors.text }]}>{label}</Text>
+        {sub ? (
+          <Text style={[styles.sub, { color: disabled ? colors.textDisabled : colors.textSecondary }]}>{sub}</Text>
+        ) : null}
       </View>
     </Pressable>
   )

--- a/apps/mobile/src/components/ui/__tests__/RadioRow.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/RadioRow.test.tsx
@@ -33,4 +33,24 @@ describe("RadioRow", () => {
 
     expect(getByTestId("r").props.accessibilityLabel).toBe("Stationary")
   })
+
+  it("keeps a disabled option on screen with its sub, so it can say why it is unavailable", () => {
+    const onPress = jest.fn()
+    const { getByTestId, getByText } = render(
+      <RadioRow
+        testID="r"
+        label="Batch"
+        sub="Needs the POST method, not GET"
+        selected={false}
+        disabled
+        onPress={onPress}
+      />
+    )
+
+    fireEvent.press(getByTestId("r"))
+
+    expect(onPress).not.toHaveBeenCalled()
+    expect(getByTestId("r").props.accessibilityState).toEqual({ checked: false, disabled: true })
+    expect(getByText("Needs the POST method, not GET")).toBeTruthy()
+  })
 })

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -28,6 +28,7 @@ import {
   Container,
   Divider,
   ChipGroup,
+  RadioRow,
   Button,
   TextField,
   IconButton
@@ -70,11 +71,6 @@ const HTTP_METHOD_OPTIONS: { value: HttpMethod; label: string }[] = [
   { value: "GET", label: "GET" }
 ]
 
-const DAWARICH_MODE_OPTIONS: { value: DawarichMode; label: string }[] = [
-  { value: "single", label: "Single point" },
-  { value: "batch", label: "Batch" }
-]
-
 /**
  * Returns the reference field map for the current template.
  * Used for "Modified" badge comparison and "Reset" actions.
@@ -112,6 +108,7 @@ export function ApiSettingsScreen({}: ScreenProps) {
   const isGetMethod = localHttpMethod === "GET"
   const showDawarichChip = localTemplate === "dawarich"
   const batchDisabled = isInstantSync || isGetMethod
+  const batchDisabledReason = isInstantSync ? "Needs a sync interval above Instant" : "Needs the POST method, not GET"
   const copiedTimeout = useTimeout()
   const {
     saving,
@@ -525,28 +522,28 @@ export function ApiSettingsScreen({}: ScreenProps) {
         {showDawarichChip && (
           <View style={styles.section}>
             <SectionTitle>Dawarich mode</SectionTitle>
-            <ChipGroup
-              options={DAWARICH_MODE_OPTIONS}
-              selected={localDawarichMode}
-              onSelect={handleDawarichModeChange}
-              colors={colors}
-              disabled={batchDisabled ? new Set<DawarichMode>(["batch"]) : undefined}
-            />
+            <View accessibilityRole="radiogroup" style={styles.radioGroup}>
+              <RadioRow
+                testID="dawarich-mode-single"
+                label="Single point"
+                sub="Sends one request per location"
+                selected={localDawarichMode === "single"}
+                onPress={() => handleDawarichModeChange("single")}
+              />
+              <RadioRow
+                testID="dawarich-mode-batch"
+                label="Batch"
+                sub={batchDisabled ? batchDisabledReason : "Sends queued locations in one request"}
+                disabled={batchDisabled}
+                selected={localDawarichMode === "batch"}
+                onPress={() => handleDawarichModeChange("batch")}
+              />
+            </View>
             <Text style={[styles.templateHint, { color: colors.textSecondary }]}>
               {localDawarichMode === "batch"
                 ? "Endpoint: /api/v1/overland/batches?api_key=YOUR_API_KEY"
                 : "Endpoint: /api/v1/owntracks/points?api_key=YOUR_API_KEY"}
             </Text>
-            {isInstantSync && (
-              <Text style={[styles.templateHint, { color: colors.textSecondary }]}>
-                Batch mode requires a non-zero sync interval. Switch to a batched preset to enable it.
-              </Text>
-            )}
-            {isGetMethod && !isInstantSync && (
-              <Text style={[styles.templateHint, { color: colors.textSecondary }]}>
-                Batch mode requires POST. Switch HTTP method to POST to enable batch.
-              </Text>
-            )}
           </View>
         )}
 
@@ -748,6 +745,12 @@ const styles = StyleSheet.create({
   },
   section: {
     marginBottom: space.xl
+  },
+  // Every control pays its own top padding, so the gap under a SectionTitle has to be measured to the
+  // text rather than to the box. A chip pays space.sm and lands at 20; a row pays space.lg and would
+  // land at 28. Pulling up space.sm puts the row text at 20 too, with the ripple still clear of the title.
+  radioGroup: {
+    marginTop: -space.sm
   },
   templateHint: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -83,6 +83,19 @@ jest.mock("../../components", () => {
     FloatingSaveIndicator: () => null,
     Container: ({ children }: any) => R.createElement(View, null, children),
     Divider: () => R.createElement(View, null),
+    RadioRow: ({ testID, label, sub, selected, disabled, onPress }: any) =>
+      R.createElement(
+        Pressable,
+        {
+          testID,
+          onPress,
+          disabled,
+          accessibilityRole: "radio",
+          accessibilityState: { checked: selected, disabled }
+        },
+        R.createElement(Text, null, label),
+        sub ? R.createElement(Text, null, sub) : null
+      ),
     ChipGroup: ({ options, selected, onSelect }: any) =>
       R.createElement(
         View,
@@ -290,6 +303,36 @@ describe("ApiSettingsScreen", () => {
       const { getByRole } = renderScreen()
 
       expect(getByRole("button", { name: "Copy" })).toBeTruthy()
+    })
+  })
+
+  describe("dawarich mode", () => {
+    it("says on the row itself why batch cannot be picked, rather than in a line under the group", () => {
+      mockSettings = { ...DEFAULT_SETTINGS, syncInterval: 0 }
+      const { getByText } = renderScreen()
+
+      fireEvent.press(getByText("Dawarich"))
+
+      expect(getByText("Needs a sync interval above Instant")).toBeTruthy()
+    })
+
+    it("names the other blocker when the method is the thing in the way", () => {
+      mockSettings = { ...DEFAULT_SETTINGS, syncInterval: 300 }
+      const { getByText } = renderScreen()
+
+      fireEvent.press(getByText("Dawarich"))
+      fireEvent.press(getByText(/^GET/))
+
+      expect(getByText("Needs the POST method, not GET")).toBeTruthy()
+    })
+
+    it("marks the blocked option disabled instead of only dimming it", () => {
+      mockSettings = { ...DEFAULT_SETTINGS, syncInterval: 0 }
+      const { getByText, getByTestId } = renderScreen()
+
+      fireEvent.press(getByText("Dawarich"))
+
+      expect(getByTestId("dawarich-mode-batch").props.accessibilityState.disabled).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Batch could be unavailable for two different reasons, and both were explained by a line under the whole group while the chip itself only looked dim. The reason sits on the row now, as its sub, which is the thing a chip has no room for.

RadioRow gains disabled, matching what SettingRow and ListItem already had: the press is refused, the accessibility state carries it, and RadioDot recedes to textDisabled rather than fading. Single point and Batch each state what they send.

The gap under a SectionTitle is measured to the text, not to the box, because every control pays its own top padding. A chip pays space.sm and lands at 20, a row pays space.lg and would land at 28, so the group pulls up space.sm to land at 20 as well.
