### PR TITLE
refactor(settings): one sync interval picker for both screens

### DIFF
--- a/apps/mobile/src/components/features/settings/SyncIntervalPicker.tsx
+++ b/apps/mobile/src/components/features/settings/SyncIntervalPicker.tsx
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import React, { useEffect, useRef, useState } from "react"
+import { View, Text, StyleSheet } from "react-native"
+import { useTheme } from "../../../hooks/useTheme"
+import { fontSizes, fonts, lineHeights } from "../../../styles/typography"
+import { SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, size, space } from "../../../constants"
+import { NumericInput } from "../../ui/NumericInput"
+import { RadioRow } from "../../ui/RadioRow"
+
+type SyncIntervalPickerProps = {
+  label: string
+  hint: string
+  value: number
+  /** The floor a blurred value is clamped to. Settings takes 1, a profile takes 0. */
+  min?: number
+  /** A preset row was chosen. */
+  onSelect: (seconds: number) => void
+  /** A valid number was typed into the custom field. */
+  onChange: (seconds: number) => void
+  /** An invalid number was corrected on blur. */
+  onClamp: (seconds: number) => void
+  testIDPrefix?: string
+}
+
+/**
+ * The presets, Custom, and the field Custom reveals. Two screens draw this, and when it was
+ * copy-pasted both carried the same defect: Custom seeded a hardcoded 1800 and saved it, throwing
+ * away the interval you had.
+ *
+ * Custom mode cannot be derived from the value, because every number a user might start from is
+ * also a preset. It is state here, and opening Custom saves nothing at all - it only seeds the
+ * field from the current value and waits for a real one.
+ */
+export function SyncIntervalPicker({
+  label,
+  hint,
+  value,
+  min = 1,
+  onSelect,
+  onChange,
+  onClamp,
+  testIDPrefix = "sync-interval"
+}: SyncIntervalPickerProps) {
+  const { colors } = useTheme()
+  const [customOpen, setCustomOpen] = useState(false)
+  const [input, setInput] = useState(value.toString())
+  const isCustom = customOpen || !SYNC_INTERVAL_PRESETS.includes(value)
+
+  const emitted = useRef(value)
+  useEffect(() => {
+    if (value !== emitted.current) {
+      emitted.current = value
+      setInput(value.toString())
+    }
+  }, [value])
+
+  const report = (seconds: number, notify: (seconds: number) => void) => {
+    emitted.current = seconds
+    notify(seconds)
+  }
+
+  return (
+    <View>
+      <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+      <Text style={[styles.hint, { color: colors.textSecondary }]}>{hint}</Text>
+
+      <View accessibilityRole="radiogroup" style={styles.group}>
+        {SYNC_INTERVAL_PRESETS.map((seconds) => (
+          <RadioRow
+            key={seconds}
+            testID={`${testIDPrefix}-${seconds}`}
+            label={SYNC_INTERVAL_LABELS[seconds]}
+            sub={seconds === 0 ? "Uploads each fix as soon as it is recorded" : undefined}
+            selected={!isCustom && value === seconds}
+            onPress={() => {
+              setCustomOpen(false)
+              report(seconds, onSelect)
+            }}
+          />
+        ))}
+        <RadioRow
+          testID={`${testIDPrefix}-custom`}
+          label="Custom"
+          sub={isCustom ? `Every ${value} seconds` : "Set your own interval"}
+          selected={isCustom}
+          onPress={() => {
+            setInput(value.toString())
+            setCustomOpen(true)
+          }}
+        />
+
+        {isCustom && (
+          <View style={styles.customField}>
+            <NumericInput
+              label="Custom sync interval"
+              value={input}
+              onChange={(next) => {
+                setInput(next)
+                const parsed = Number(next)
+                if (!isNaN(parsed) && parsed >= min) report(parsed, onChange)
+              }}
+              onBlur={() => {
+                const parsed = Number(input)
+                if (isNaN(parsed) || parsed < min) {
+                  setInput(min.toString())
+                  report(min, onClamp)
+                }
+              }}
+              unit="seconds"
+              hint="Custom interval in seconds"
+            />
+          </View>
+        )}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: fontSizes.label,
+    ...fonts.semiBold,
+    marginBottom: space.xs
+  },
+  hint: {
+    fontSize: fontSizes.description,
+    ...fonts.regular,
+    lineHeight: lineHeights.description
+  },
+  group: {
+    marginTop: -space.sm
+  },
+  customField: {
+    paddingLeft: size.iconColumn,
+    marginTop: -space.xs,
+    paddingBottom: space.lg
+  }
+})

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -7,16 +7,9 @@ import React, { useState, useCallback, useEffect, useMemo } from "react"
 import { Text, StyleSheet, View, Pressable, AppState } from "react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
 import { fonts, fontSizes, lineHeights } from "../../../styles/typography"
-import {
-  HIT_SLOP_MD,
-  OVERLAND_BATCH_MAX,
-  OVERLAND_BATCH_MIN,
-  SYNC_INTERVAL_LABELS,
-  SYNC_INTERVAL_PRESETS,
-  size,
-  space
-} from "../../../constants"
+import { HIT_SLOP_MD, OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, size, space } from "../../../constants"
 import { Card, NumericInput, RadioRow, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
+import { SyncIntervalPicker } from "./SyncIntervalPicker"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
 import { isOverlandFormat } from "../../../utils/apiPayload"
 import NativeLocationService from "../../../services/NativeLocationService"
@@ -57,7 +50,6 @@ export function SyncStrategySettings({
   const [accuracyThresholdInput, setAccuracyThresholdInput] = useState(
     metersToInput(settings.accuracyThreshold).toString()
   )
-  const [syncIntervalInput, setSyncIntervalInput] = useState(settings.syncInterval.toString())
   const [overlandBatchSizeInput, setOverlandBatchSizeInput] = useState(settings.overlandBatchSize.toString())
   const showOverlandBatchSize = isOverlandFormat(settings.apiTemplate, settings.dawarichMode)
   const [currentSsid, setCurrentSsid] = useState("")
@@ -77,17 +69,11 @@ export function SyncStrategySettings({
     return () => sub.remove()
   }, [settings.syncCondition])
 
-  // Custom mode cannot be derived from the value alone: every number the user might pick first is
-  // also a preset, so deriving it forced the old code to invent one and save it on the spot.
-  const [customSyncOpen, setCustomSyncOpen] = useState(false)
-  const isCustomSyncInterval = customSyncOpen || !SYNC_INTERVAL_PRESETS.includes(settings.syncInterval)
-
   // Sync inputs with settings changes (e.g. preset selection)
   useEffect(() => {
     setIntervalInput(settings.interval.toString())
     setDistanceInput(metersToInput(settings.distance ?? 0).toString())
     setAccuracyThresholdInput(metersToInput(settings.accuracyThreshold).toString())
-    setSyncIntervalInput(settings.syncInterval.toString())
     setOverlandBatchSizeInput(settings.overlandBatchSize.toString())
   }, [
     settings.interval,
@@ -235,67 +221,19 @@ export function SyncStrategySettings({
         <>
           <SectionTitle style={styles.groupTop}>Network settings</SectionTitle>
           <Card rows>
-            {/* Sync Interval */}
             <View style={styles.settingBlock}>
-              <Text style={[styles.blockLabel, { color: colors.text }]}>Sync interval</Text>
-              <Text style={[styles.blockHint, { color: colors.textSecondary }]}>
-                How often to upload data to server
-              </Text>
-
-              <View accessibilityRole="radiogroup">
-                {SYNC_INTERVAL_PRESETS.map((seconds) => (
-                  <RadioRow
-                    key={seconds}
-                    testID={`sync-interval-${seconds}`}
-                    label={SYNC_INTERVAL_LABELS[seconds]}
-                    sub={seconds === 0 ? "Uploads each fix as soon as it is recorded" : undefined}
-                    selected={!isCustomSyncInterval && settings.syncInterval === seconds}
-                    onPress={() => {
-                      setCustomSyncOpen(false)
-                      handleGridSelect("syncInterval", seconds)
-                    }}
-                  />
-                ))}
-                <RadioRow
-                  testID="sync-interval-custom"
-                  label="Custom"
-                  sub={isCustomSyncInterval ? `Every ${settings.syncInterval} seconds` : "Set your own interval"}
-                  selected={isCustomSyncInterval}
-                  onPress={() => {
-                    setSyncIntervalInput(settings.syncInterval.toString())
-                    setCustomSyncOpen(true)
-                  }}
-                />
-
-                {isCustomSyncInterval && (
-                  <View style={styles.customSyncInput}>
-                    <NumericInput
-                      label="Custom sync interval"
-                      value={syncIntervalInput}
-                      onChange={(val) => {
-                        setSyncIntervalInput(val)
-                        const num = Number(val)
-                        if (!isNaN(num) && num >= 1) {
-                          const next = { ...settings, syncInterval: num, syncPreset: "custom" as const }
-                          onDebouncedSave(next)
-                        }
-                      }}
-                      onBlur={() => {
-                        let val = Number(syncIntervalInput)
-                        if (isNaN(val) || val < 1) {
-                          val = 1
-                          setSyncIntervalInput("1")
-                          const next = { ...settings, syncInterval: val, syncPreset: "custom" as const }
-                          onSettingsChange(next)
-                          onImmediateSave(next)
-                        }
-                      }}
-                      unit="seconds"
-                      hint="Custom interval in seconds"
-                    />
-                  </View>
-                )}
-              </View>
+              <SyncIntervalPicker
+                label="Sync interval"
+                hint="How often to upload data to server"
+                value={settings.syncInterval}
+                onSelect={(seconds) => handleGridSelect("syncInterval", seconds)}
+                onChange={(seconds) => onDebouncedSave({ ...settings, syncInterval: seconds, syncPreset: "custom" })}
+                onClamp={(seconds) => {
+                  const next = { ...settings, syncInterval: seconds, syncPreset: "custom" as const }
+                  onSettingsChange(next)
+                  onImmediateSave(next)
+                }}
+              />
             </View>
 
             {showOverlandBatchSize && (

--- a/apps/mobile/src/components/features/settings/__tests__/SyncIntervalPicker.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncIntervalPicker.test.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+jest.mock("../../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+import { SyncIntervalPicker } from "../SyncIntervalPicker"
+
+describe("SyncIntervalPicker", () => {
+  const onSelect = jest.fn()
+  const onChange = jest.fn()
+  const onClamp = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function renderPicker(value = 300, min?: number) {
+    return render(
+      <SyncIntervalPicker
+        label="Sync interval"
+        hint="How often to upload data to server"
+        value={value}
+        min={min}
+        onSelect={onSelect}
+        onChange={onChange}
+        onClamp={onClamp}
+      />
+    )
+  }
+
+  it("offers every preset plus Custom", () => {
+    const { getByTestId } = renderPicker()
+
+    expect(getByTestId("sync-interval-0")).toBeTruthy()
+    expect(getByTestId("sync-interval-60")).toBeTruthy()
+    expect(getByTestId("sync-interval-300")).toBeTruthy()
+    expect(getByTestId("sync-interval-900")).toBeTruthy()
+    expect(getByTestId("sync-interval-custom")).toBeTruthy()
+  })
+
+  it("reports a preset press without touching the custom field", () => {
+    const { getByTestId, queryByDisplayValue } = renderPicker()
+
+    fireEvent.press(getByTestId("sync-interval-60"))
+
+    expect(onSelect).toHaveBeenCalledWith(60)
+    expect(queryByDisplayValue("300")).toBeNull()
+  })
+
+  it("opens Custom on the interval you already had and reports nothing", () => {
+    const { getByTestId, getByDisplayValue } = renderPicker(300)
+
+    fireEvent.press(getByTestId("sync-interval-custom"))
+
+    // Both callers used to seed a hardcoded 1800 here and save it, discarding the interval.
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onClamp).not.toHaveBeenCalled()
+    expect(getByDisplayValue("300")).toBeTruthy()
+  })
+
+  it("leaves Custom for a preset even though the value it opened on was itself a preset", () => {
+    const { getByTestId, queryByDisplayValue } = renderPicker(300)
+
+    fireEvent.press(getByTestId("sync-interval-custom"))
+    expect(queryByDisplayValue("300")).toBeTruthy()
+
+    fireEvent.press(getByTestId("sync-interval-60"))
+
+    expect(queryByDisplayValue("300")).toBeNull()
+    expect(onSelect).toHaveBeenCalledWith(60)
+  })
+
+  it("stays in Custom when the value is off every preset", () => {
+    const { getByDisplayValue } = renderPicker(120)
+
+    expect(getByDisplayValue("120")).toBeTruthy()
+  })
+
+  it("reports a typed value only once it is valid", () => {
+    const { getByDisplayValue } = renderPicker(120)
+
+    fireEvent.changeText(getByDisplayValue("120"), "")
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.changeText(getByDisplayValue(""), "45")
+    expect(onChange).toHaveBeenCalledWith(45)
+  })
+
+  it("clamps to the floor its caller sets, which differs between settings and a profile", () => {
+    const { getByDisplayValue } = renderPicker(120, 0)
+
+    fireEvent.changeText(getByDisplayValue("120"), "-5")
+    fireEvent(getByDisplayValue("-5"), "blur")
+
+    expect(onClamp).toHaveBeenCalledWith(0)
+  })
+})

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -75,6 +75,33 @@ jest.mock("../../../index", () => {
   }
 })
 
+jest.mock("../SyncIntervalPicker", () => {
+  const R = require("react")
+  const { View, Text, Pressable } = require("react-native")
+  const { SYNC_INTERVAL_PRESETS } = require("../../../../constants")
+  return {
+    SyncIntervalPicker: ({ label, hint, value, onSelect }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        R.createElement(Text, null, hint),
+        SYNC_INTERVAL_PRESETS.map((seconds: number) =>
+          R.createElement(
+            Pressable,
+            {
+              key: seconds,
+              testID: `sync-interval-${seconds}`,
+              onPress: () => onSelect(seconds),
+              accessibilityState: { checked: value === seconds }
+            },
+            R.createElement(Text, null, String(seconds))
+          )
+        )
+      )
+  }
+})
+
 jest.mock("../../../../utils/geo", () => ({
   shortDistanceUnit: () => "m",
   inputToMeters: (value: number) => value,
@@ -214,14 +241,11 @@ describe("SyncStrategySettings", () => {
   })
 
   describe("sync interval", () => {
-    it("renders every option inline, Custom included", () => {
-      const { getByTestId } = renderComponent()
+    it("hands the picker its label and hint rather than drawing them itself", () => {
+      const { getByText } = renderComponent()
 
-      expect(getByTestId("sync-interval-0")).toBeTruthy()
-      expect(getByTestId("sync-interval-60")).toBeTruthy()
-      expect(getByTestId("sync-interval-300")).toBeTruthy()
-      expect(getByTestId("sync-interval-900")).toBeTruthy()
-      expect(getByTestId("sync-interval-custom")).toBeTruthy()
+      expect(getByText("Sync interval")).toBeTruthy()
+      expect(getByText("How often to upload data to server")).toBeTruthy()
     })
 
     it("selecting a sync interval sets preset to custom", () => {
@@ -241,30 +265,6 @@ describe("SyncStrategySettings", () => {
           syncPreset: "custom"
         })
       )
-    })
-
-    it("opening Custom saves nothing and keeps the interval you already had", () => {
-      const { getByTestId, getByDisplayValue } = renderComponent({ syncInterval: 300 })
-
-      fireEvent.press(getByTestId("sync-interval-custom"))
-
-      // The old code wrote a hardcoded 1800 here, discarding the interval and restarting tracking.
-      expect(mockOnSettingsChange).not.toHaveBeenCalled()
-      expect(mockOnDebouncedSave).not.toHaveBeenCalled()
-      expect(mockOnImmediateSave).not.toHaveBeenCalled()
-      expect(getByDisplayValue("300")).toBeTruthy()
-    })
-
-    it("leaves Custom when a preset is pressed, even though the value was never off-preset", () => {
-      const { getByTestId, queryByDisplayValue } = renderComponent({ syncInterval: 300 })
-
-      fireEvent.press(getByTestId("sync-interval-custom"))
-      expect(queryByDisplayValue("300")).toBeTruthy()
-
-      fireEvent.press(getByTestId("sync-interval-60"))
-
-      expect(queryByDisplayValue("300")).toBeNull()
-      expect(mockOnDebouncedSave).toHaveBeenCalledWith(expect.objectContaining({ syncInterval: 60 }))
     })
   })
 

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -11,14 +11,13 @@ import { ProfileService } from "../services/ProfileService"
 import { showAlert, showConfirm } from "../services/modalService"
 import { TrackingProfile, ProfileConditionType } from "../types/global"
 import { fontSizes, fonts, lineHeights } from "../styles/typography"
+import { SyncIntervalPicker } from "../components/features/settings/SyncIntervalPicker"
 import {
   Button,
   Card,
-  ChipGroup,
   Container,
   Divider,
   FieldMessage,
-  NumericInput,
   RadioRow,
   SectionTitle,
   SettingRow,
@@ -30,9 +29,8 @@ import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
 import {
   MS_TO_KMH,
   PROFILE_CONDITIONS,
-  STATIONARY_MAX_INTERVAL_SECONDS,
   SYNC_INTERVAL_LABELS,
-  SYNC_INTERVAL_PRESETS,
+  STATIONARY_MAX_INTERVAL_SECONDS,
   defaultProfileDelays,
   size,
   space
@@ -70,7 +68,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
   const [priorityStr, setPriorityStr] = useState("10")
   const [activationDelayStr, setActivationDelayStr] = useState("0")
   const [delayStr, setDelayStr] = useState("60")
-  const [syncIntervalStr, setSyncIntervalStr] = useState(String(settings.syncInterval))
 
   useLayoutEffect(() => {
     navigation.setOptions({ headerTitle: isEditing ? "Edit profile" : "New profile" })
@@ -99,7 +96,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
           setPriorityStr(String(existing.priority))
           setActivationDelayStr(String(existing.activationDelay))
           setDelayStr(String(existing.deactivationDelay))
-          setSyncIntervalStr(String(existing.syncInterval))
           if (existing.condition.speedThreshold) {
             setSpeedKmh((existing.condition.speedThreshold * MS_TO_KMH).toFixed(0))
           }
@@ -210,8 +206,6 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
   }, [profile, isEditing, profileId, navigation])
 
   const isSpeed = profile.condition.type === "speed_above" || profile.condition.type === "speed_below"
-  const [customSyncOpen, setCustomSyncOpen] = useState(false)
-  const isCustomSyncInterval = customSyncOpen || !SYNC_INTERVAL_PRESETS.includes(profile.syncInterval)
 
   return (
     <Container>
@@ -337,56 +331,15 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
             <>
               <Divider tight />
 
-              <View style={styles.syncLabelRow}>
-                <Text style={[styles.settingLabel, { color: colors.text }]}>Sync interval</Text>
-                <Text style={[styles.settingHint, { color: colors.textSecondary }]}>
-                  Default: {formatSyncDefault(settings.syncInterval)}
-                </Text>
-              </View>
-              <ChipGroup
-                options={[
-                  ...SYNC_INTERVAL_PRESETS.map((sec) => ({
-                    value: String(sec),
-                    label: SYNC_INTERVAL_LABELS[sec]
-                  })),
-                  { value: "custom", label: "Custom" }
-                ]}
-                selected={isCustomSyncInterval ? "custom" : String(profile.syncInterval)}
-                onSelect={(value) => {
-                  if (value === "custom") {
-                    setSyncIntervalStr(profile.syncInterval.toString())
-                    setCustomSyncOpen(true)
-                    return
-                  }
-                  setCustomSyncOpen(false)
-                  setProfile((prev) => ({ ...prev, syncInterval: Number(value) }))
-                }}
+              <SyncIntervalPicker
+                label="Sync interval"
+                hint={`Default: ${formatSyncDefault(settings.syncInterval)}`}
+                value={profile.syncInterval}
+                min={0}
+                onSelect={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
+                onChange={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
+                onClamp={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
               />
-
-              {isCustomSyncInterval && (
-                <View style={styles.customSyncInput}>
-                  <NumericInput
-                    label="Custom sync interval"
-                    value={syncIntervalStr}
-                    onChange={(val) => {
-                      setSyncIntervalStr(val)
-                      const num = Number(val)
-                      if (!isNaN(num) && num >= 0) {
-                        setProfile((prev) => ({ ...prev, syncInterval: num }))
-                      }
-                    }}
-                    onBlur={() => {
-                      const num = Number(syncIntervalStr)
-                      if (isNaN(num) || num < 0) {
-                        setSyncIntervalStr("0")
-                        setProfile((prev) => ({ ...prev, syncInterval: 0 }))
-                      }
-                    }}
-                    unit="seconds"
-                    hint="Custom interval in seconds"
-                  />
-                </View>
-              )}
             </>
           )}
         </Card>

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -59,6 +59,33 @@ jest.mock("../../contexts/TrackingProvider", () => ({
   })
 }))
 
+jest.mock("../../components/features/settings/SyncIntervalPicker", () => {
+  const R = require("react")
+  const { View, Text, Pressable } = require("react-native")
+  const { SYNC_INTERVAL_PRESETS, SYNC_INTERVAL_LABELS } = require("../../constants")
+  return {
+    SyncIntervalPicker: ({ label, hint, value, onSelect }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        R.createElement(Text, null, hint),
+        SYNC_INTERVAL_PRESETS.map((seconds: number) =>
+          R.createElement(
+            Pressable,
+            {
+              key: seconds,
+              testID: `sync-interval-${seconds}`,
+              onPress: () => onSelect(seconds),
+              accessibilityState: { checked: value === seconds }
+            },
+            R.createElement(Text, null, SYNC_INTERVAL_LABELS[seconds])
+          )
+        )
+      )
+  }
+})
+
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
     colors: {
@@ -194,13 +221,13 @@ describe("ProfileEditorScreen", () => {
     expect(getByText("Speed Below")).toBeTruthy()
   })
 
-  it("shows all sync interval options inline", () => {
-    const { getByText, getAllByText } = renderNewProfile()
+  it("hands the sync interval to the shared picker rather than drawing its own", () => {
+    const { getByTestId } = renderNewProfile()
 
-    expect(getAllByText("Instant").length).toBeGreaterThan(0)
-    expect(getByText("1 min")).toBeTruthy()
-    expect(getByText("5 min")).toBeTruthy()
-    expect(getByText("15 min")).toBeTruthy()
+    expect(getByTestId("sync-interval-0")).toBeTruthy()
+    expect(getByTestId("sync-interval-60")).toBeTruthy()
+    expect(getByTestId("sync-interval-300")).toBeTruthy()
+    expect(getByTestId("sync-interval-900")).toBeTruthy()
   })
 
   it("pre-fills fields with main settings values", () => {
@@ -523,18 +550,6 @@ describe("ProfileEditorScreen", () => {
       await waitFor(() => expect(mockShowConfirm).toHaveBeenCalled())
       expect(mockDeleteProfile).not.toHaveBeenCalled()
       expect(mockGoBack).not.toHaveBeenCalled()
-    })
-  })
-
-  describe("custom sync interval", () => {
-    it("opens Custom on the interval the profile already has, not on an invented one", async () => {
-      const { getByText, getByDisplayValue } = renderEditProfile(1)
-
-      await waitFor(() => expect(getByDisplayValue("Existing Profile")).toBeTruthy())
-      fireEvent.press(getByText("Custom"))
-
-      // The old code seeded a hardcoded 1800 here, throwing away the profile's 60.
-      expect(getByDisplayValue("60")).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
Tracking & sync and the profile editor drew the same control from copy-pasted code, and that is why both carried the same defect: Custom seeded a hardcoded 1800 and saved it, discarding the interval you had. Fixing it meant writing the same fix twice.

SyncIntervalPicker owns the presets, Custom, the field Custom reveals, and the custom-mode state that cannot be derived from the value. Callers keep their own persistence through three named callbacks: onSelect for a preset row, onChange for a valid typed value, onClamp for one corrected on blur. Tracking & sync maps them to its debounced and immediate saves, the profile editor maps all three to setProfile, and min carries the floor that differs between them.

The profile editor's chips become radio rows as a side effect, so the control now reads the same in both places.

The picker re-seeds its field when the value changes from outside, which is what the removed useEffect line did: a tracking preset writes a sync interval too, and without it the field would keep showing your number while the stored value had moved. It compares against what it last emitted, so the re-seed cannot land mid-keystroke.
