### PR TITLE
feat(sync): tracking and sync says when a profile is overriding it

### DIFF
--- a/apps/docs/docs/guides/tracking-profiles.md
+++ b/apps/docs/docs/guides/tracking-profiles.md
@@ -103,6 +103,7 @@ Note that Stationary has the highest priority so it takes over from Walking when
 - If the condition matches again before the delay expires, the timer is cancelled
 - After the delay expires, settings revert to the defaults configured in the Settings screen
 - Profile changes made in the editor take effect immediately on the running service
+- **Tracking & sync** names the active profile at the top. The values on that screen are the defaults the profile is overriding, not the ones in force
 
 ## Active Profile Indicators
 

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -20,6 +20,7 @@ interface SyncStrategySettingsProps {
   onSettingsChange: (newSettings: Settings) => void
   onDebouncedSave: (newSettings: Settings) => void
   onImmediateSave: (newSettings: Settings) => void
+  activeProfileName?: string | null
   colors: ThemeColors
 }
 
@@ -43,6 +44,7 @@ export function SyncStrategySettings({
   onSettingsChange,
   onDebouncedSave,
   onImmediateSave,
+  activeProfileName,
   colors
 }: SyncStrategySettingsProps) {
   const [intervalInput, setIntervalInput] = useState(settings.interval.toString())
@@ -170,6 +172,11 @@ export function SyncStrategySettings({
       <Text style={[styles.intro, { color: colors.textSecondary }]}>
         How often a fix is recorded, and when it uploads
       </Text>
+      {activeProfileName ? (
+        <Text testID="profile-override-notice" style={[styles.override, { color: colors.warning }]}>
+          {activeProfileName} is active and is overriding these values while its condition holds.
+        </Text>
+      ) : null}
       <SectionTitle>Tracking configuration</SectionTitle>
       <Card rows>
         <View accessibilityRole="radiogroup">
@@ -370,6 +377,13 @@ const styles = StyleSheet.create({
     lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
+  override: {
+    fontSize: fontSizes.description,
+    ...fonts.medium,
+    lineHeight: lineHeights.description,
+    marginTop: -space.sm,
+    marginBottom: space.lg
+  },
   section: {
     marginBottom: space.xl
   },
@@ -381,7 +395,6 @@ const styles = StyleSheet.create({
   groupTop: {
     marginTop: space.xl
   },
-  // The last child is a nested field, not a row, so the bottom inset comes back.
   cardTail: {
     paddingBottom: space.lg
   },

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -403,6 +403,30 @@ describe("SyncStrategySettings", () => {
     })
   })
 
+  describe("profile override", () => {
+    it("says a profile is overriding these values, because the screen otherwise reads as authoritative", () => {
+      const { getByTestId, getByText } = render(
+        <SyncStrategySettings
+          settings={baseSettings}
+          onSettingsChange={mockOnSettingsChange}
+          onDebouncedSave={mockOnDebouncedSave}
+          onImmediateSave={mockOnImmediateSave}
+          activeProfileName="Charging"
+          colors={mockColors}
+        />
+      )
+
+      expect(getByTestId("profile-override-notice")).toBeTruthy()
+      expect(getByText(/Charging is active/)).toBeTruthy()
+    })
+
+    it("stays quiet when no profile is active, so the notice means something when it appears", () => {
+      const { queryByTestId } = renderComponent()
+
+      expect(queryByTestId("profile-override-notice")).toBeNull()
+    })
+  })
+
   describe("sync condition", () => {
     it("states what every option does without one being chosen, which the chips could not", () => {
       const { getByText } = renderComponent({ syncCondition: "any" })

--- a/apps/mobile/src/screens/TrackingSyncScreen.tsx
+++ b/apps/mobile/src/screens/TrackingSyncScreen.tsx
@@ -15,7 +15,7 @@ import { SyncStrategySettings } from "../components/features/settings/SyncStrate
 import { space } from "../constants"
 
 export function TrackingSyncScreen({}: ScreenProps) {
-  const { settings, setSettings, updateSettingsLocal, restartTracking } = useTracking()
+  const { settings, setSettings, updateSettingsLocal, restartTracking, activeProfileName } = useTracking()
   const { colors } = useTheme()
   const {
     saving,
@@ -57,6 +57,7 @@ export function TrackingSyncScreen({}: ScreenProps) {
           onSettingsChange={updateSettingsLocal}
           onDebouncedSave={handleDebouncedSave}
           onImmediateSave={handleImmediateSave}
+          activeProfileName={activeProfileName}
           colors={colors}
         />
       </ScrollView>


### PR DESCRIPTION
A profile overrides the interval, the distance and the sync interval together, so the screen could read 5 min while the service synced every 15 and give no sign of it. The profile editor already showed the reverse relationship in its Default hint; this is the missing half.

The notice sits above the first card because the override covers every value on the screen, and it renders only while a profile is active. activeProfileName comes down as a prop rather than the component reaching for the context, which is why it takes settings by prop too.

sync-presets.md never mentioned profiles even though a profile supplies the sync interval, while tracking-settings.md already warned about its own two values. It gets the matching note, including the limit that the sync condition is not overridden.
