### PR TITLE
feat(api): API config becomes Request format

### DIFF
--- a/apps/docs/docs/api-reference.md
+++ b/apps/docs/docs/api-reference.md
@@ -10,7 +10,7 @@ Reference for the HTTP requests Colota sends to your server.
 
 **Method:** `POST` (default) or `GET`
 
-Configure the HTTP method in **Settings → API field mapping → HTTP method**.
+Configure the HTTP method in **Settings → Request format → HTTP method**.
 
 ### POST (default)
 

--- a/apps/docs/docs/configuration/field-mapping.md
+++ b/apps/docs/docs/configuration/field-mapping.md
@@ -45,12 +45,12 @@ You can rename any field to match your backend. For example:
 }
 ```
 
-Configure field names in **Settings → API field mapping → Field mappings**.
+Configure field names in **Settings → Request format → Field mappings**.
 
 ## Custom Static Fields
 
 Add arbitrary key-value pairs that are included in every API payload. For example, adding `_type: "location"` for OwnTracks-compatible backends.
 
-Configure in **Settings → API field mapping → Custom fields**.
+Configure in **Settings → Request format → Custom fields**.
 
 **Note:** Custom field values are always sent as strings. Custom fields are added to the payload before location fields - if a custom field key matches a location field key, the location field takes precedence.

--- a/apps/docs/docs/configuration/server-settings.md
+++ b/apps/docs/docs/configuration/server-settings.md
@@ -69,7 +69,7 @@ The UI simplifies to remove sync-related elements that don't apply:
 
 - Server Endpoint and Test Connection
 - Authentication & headers
-- API Field Mapping
+- Request format
 - Sync Interval, Sync Condition (Any network / Wi-Fi / Specific Wi-Fi network / VPN)
 - Queue statistics (Queued / Sent counts)
 - Queue actions (Sync Now, Clear Sent History, Clear Queue)

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -298,11 +298,11 @@ For backups, two `internal` methods support the export/import flow without expos
 | Screen | Purpose |
 | --- | --- |
 | `DashboardScreen` | Live map with tracking controls, coordinates, database stats, geofence and profile status |
-| `SettingsScreen` | Hub navigating to Connection, Tracking & sync, API field mapping, Tracking profiles, Appearance and the data, Colota and about screens. Each row's sub line carries live state rather than a description |
+| `SettingsScreen` | Hub navigating to Connection, Tracking & sync, Request format, Tracking profiles, Appearance and the data, Colota and about screens. Each row's sub line carries live state rather than a description |
 | `ConnectionScreen` | Server endpoint URL, offline mode toggle and connection test |
 | `TrackingSyncScreen` | GPS interval, distance filter, accuracy threshold and sync strategy preset |
 | `AppearanceScreen` | Light/dark theme, unit system, time format and custom map tile URLs (light and dark) |
-| `ApiSettingsScreen` | Backend template as a row opening the picker, HTTP method and Dawarich mode as radio rows, and the field mapping |
+| `ApiSettingsScreen` | Route **Request Format**. Backend template as a row opening the picker, HTTP method and Dawarich mode as radio rows, and the field mapping |
 | `BackendTemplateScreen` | The eight backend templates as radio rows, each stating what it sends, returning the choice with `popTo` and `merge`. Eight options that each need a sentence do not fit inline on a form screen |
 | `AuthSettingsScreen` | Authentication method (None, Basic Auth, Bearer Token) and custom HTTP headers, with a link row to mTLS Settings |
 | `MtlsSettingsScreen` | Client certificate (PKCS12 import + Android Keystore storage) and Trusted Server CA management |

--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -34,11 +34,11 @@ Colota has twenty-eight screens, each focused on a specific task:
 | Screen | Purpose |
 | --- | --- |
 | **Dashboard** | Live map with current coordinates, today's track overlay, tracking controls, database stats, and geofence status |
-| **Settings** | Hub linking to Connection, Tracking and Sync, API config, Tracking profiles, Appearance and data/about screens |
+| **Settings** | Hub linking to Connection, Tracking and Sync, Request format, Tracking profiles, Appearance and data/about screens |
 | **Connection** | Server endpoint URL, offline mode toggle and connection test |
 | **Tracking & sync** | GPS polling interval, distance filter, accuracy threshold and sync strategy preset |
 | **Appearance** | Light/dark theme, unit system, time format and custom map tile URLs |
-| **API Config** | Endpoint field mapping with templates for Dawarich, GeoPulse, Overland, OwnTracks, PhoneTrack, Reitti, Traccar or custom backends |
+| **Request format** | How the request is shaped: the backend template, the HTTP method, the field names and any custom fields |
 | **Backend template** | Pick the backend Colota formats its payload for, each option describing what it sends |
 | **Auth Settings** | Endpoint authentication (None, Basic Auth, Bearer Token) and custom HTTP headers |
 | **mTLS Settings** | Client certificate (mTLS) import or KeyChain selection and trusted server CA management |
@@ -66,7 +66,7 @@ Colota has twenty-eight screens, each focused on a specific task:
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-<ScreenshotGallery screenshots={[ { src: "/img/screenshots/Dashboard.png", label: "Dashboard" }, { src: "/img/screenshots/Settings.png", label: "Settings" }, { src: "/img/screenshots/ApiFieldMapping.png", label: "API Config" }, { src: "/img/screenshots/Authentication.png", label: "Auth Settings" }, { src: "/img/screenshots/Geofences.png", label: "Geofences" }, { src: "/img/screenshots/GeofenceEditor.png", label: "Geofence Editor" }, { src: "/img/screenshots/OfflineMaps.png", label: "Offline maps" }, { src: "/img/screenshots/TrackingProfiles.png", label: "Profile Editor" }, { src: "/img/screenshots/LocationHistory.png", label: "Location History" }, { src: "/img/screenshots/TripDetails.png", label: "Trip Detail" }, { src: "/img/screenshots/Trips.png", label: "Trips" }, { src: "/img/screenshots/ExportData.png", label: "Export" }, { src: "/img/screenshots/AutoExport.png", label: "Auto-export" }, { src: "/img/screenshots/DataManagement.png", label: "Data management" }, { src: "/img/screenshots/DarkMode.png", label: "Dark Mode" }, ]} />
+<ScreenshotGallery screenshots={[ { src: "/img/screenshots/Dashboard.png", label: "Dashboard" }, { src: "/img/screenshots/Settings.png", label: "Settings" }, { src: "/img/screenshots/ApiFieldMapping.png", label: "Request format" }, { src: "/img/screenshots/Authentication.png", label: "Auth Settings" }, { src: "/img/screenshots/Geofences.png", label: "Geofences" }, { src: "/img/screenshots/GeofenceEditor.png", label: "Geofence Editor" }, { src: "/img/screenshots/OfflineMaps.png", label: "Offline maps" }, { src: "/img/screenshots/TrackingProfiles.png", label: "Profile Editor" }, { src: "/img/screenshots/LocationHistory.png", label: "Location History" }, { src: "/img/screenshots/TripDetails.png", label: "Trip Detail" }, { src: "/img/screenshots/Trips.png", label: "Trips" }, { src: "/img/screenshots/ExportData.png", label: "Export" }, { src: "/img/screenshots/AutoExport.png", label: "Auto-export" }, { src: "/img/screenshots/DataManagement.png", label: "Data management" }, { src: "/img/screenshots/DarkMode.png", label: "Dark Mode" }, ]} />
 
 ## Architecture
 

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -70,9 +70,9 @@ const SCREEN_CONFIG: readonly ScreenConfig[] = [
     title: "Settings"
   },
   {
-    name: "API Config",
+    name: "Request Format",
     component: ApiSettingsScreen,
-    title: "API config"
+    title: "Request format"
   },
   {
     name: "Backend Template",

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -22,7 +22,7 @@ interface WelcomeCardProps {
   onStartTracking: () => void
   onNavigateToConnection: () => void
   onNavigateToTrackingSync: () => void
-  onNavigateToApiConfig: () => void
+  onNavigateToRequestFormat: () => void
 }
 
 interface ChecklistItemProps {
@@ -74,7 +74,7 @@ export function WelcomeCard({
   onStartTracking,
   onNavigateToConnection,
   onNavigateToTrackingSync,
-  onNavigateToApiConfig
+  onNavigateToRequestFormat
 }: WelcomeCardProps) {
   const {
     settings: { isOfflineMode }
@@ -103,10 +103,10 @@ export function WelcomeCard({
           {!isOfflineMode && (
             <Pressable
               accessibilityRole="button"
-              onPress={onNavigateToApiConfig}
+              onPress={onNavigateToRequestFormat}
               style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
             >
-              <Text style={[styles.link, { color: colors.primaryDark }]}>API field mapping</Text>
+              <Text style={[styles.link, { color: colors.primaryDark }]}>Request format</Text>
             </Pressable>
           )}
           <Pressable

--- a/apps/mobile/src/components/features/dashboard/__tests__/WelcomeCard.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/WelcomeCard.test.tsx
@@ -52,7 +52,7 @@ const defaultProps = {
   onStartTracking: jest.fn(),
   onNavigateToConnection: jest.fn(),
   onNavigateToTrackingSync: jest.fn(),
-  onNavigateToApiConfig: jest.fn()
+  onNavigateToRequestFormat: jest.fn()
 }
 
 describe("WelcomeCard", () => {
@@ -81,10 +81,10 @@ describe("WelcomeCard", () => {
       expect(getByText("2. Configure your server endpoint")).toBeTruthy()
     })
 
-    it("shows API field mapping link", () => {
+    it("shows the request format link", () => {
       const { getByText } = render(<WelcomeCard {...defaultProps} />)
 
-      expect(getByText("API field mapping")).toBeTruthy()
+      expect(getByText("Request format")).toBeTruthy()
     })
 
     it("shows Tracking presets link", () => {
@@ -105,10 +105,10 @@ describe("WelcomeCard", () => {
       expect(queryByText("2. Configure your server endpoint")).toBeNull()
     })
 
-    it("hides API field mapping link", () => {
+    it("hides the request format link", () => {
       const { queryByText } = render(<WelcomeCard {...defaultProps} />)
 
-      expect(queryByText("API field mapping")).toBeNull()
+      expect(queryByText("Request format")).toBeNull()
     })
 
     it("still shows Tracking presets link", () => {
@@ -148,12 +148,12 @@ describe("WelcomeCard", () => {
     expect(defaultProps.onNavigateToConnection).toHaveBeenCalledTimes(1)
   })
 
-  it("calls onNavigateToApiConfig when API field mapping is pressed", () => {
+  it("calls onNavigateToRequestFormat when the request format link is pressed", () => {
     const { getByText } = render(<WelcomeCard {...defaultProps} />)
 
-    fireEvent.press(getByText("API field mapping"))
+    fireEvent.press(getByText("Request format"))
 
-    expect(defaultProps.onNavigateToApiConfig).toHaveBeenCalledTimes(1)
+    expect(defaultProps.onNavigateToRequestFormat).toHaveBeenCalledTimes(1)
   })
 
   it("marks Start tracking as completed when tracking is active", () => {

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -82,7 +82,7 @@ function getReferenceCustomFields(template: ApiTemplateName): CustomField[] {
  * Screen for configuring API field name mappings, backend templates,
  * and custom static fields.
  */
-export function ApiSettingsScreen({ navigation, route }: RootScreenProps<"API Config">) {
+export function ApiSettingsScreen({ navigation, route }: RootScreenProps<"Request Format">) {
   const { settings, setSettings, restartTracking } = useTracking()
   const { colors } = useTheme()
 
@@ -696,7 +696,7 @@ export function ApiSettingsScreen({ navigation, route }: RootScreenProps<"API Co
 
         {/* Example payload preview */}
         <View style={styles.exampleSection}>
-          <SectionTitle>{localHttpMethod === "GET" ? "EXAMPLE REQUEST" : "EXAMPLE PAYLOAD"}</SectionTitle>
+          <SectionTitle>{localHttpMethod === "GET" ? "Example request" : "Example payload"}</SectionTitle>
           <View
             style={[
               styles.exampleCard,

--- a/apps/mobile/src/screens/BackendTemplateScreen.tsx
+++ b/apps/mobile/src/screens/BackendTemplateScreen.tsx
@@ -31,7 +31,7 @@ export function BackendTemplateScreen({ navigation, route }: RootScreenProps<"Ba
 
   const choose = useCallback(
     (value: ApiTemplateName) => {
-      navigation.popTo("API Config", { template: value }, { merge: true })
+      navigation.popTo("Request Format", { template: value }, { merge: true })
     },
     [navigation]
   )

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -255,7 +255,7 @@ export function DashboardScreen({ navigation }: ScreenProps) {
               onStartTracking={handleStart}
               onNavigateToConnection={() => navigation.navigate("Connection")}
               onNavigateToTrackingSync={() => navigation.navigate("Tracking & Sync")}
-              onNavigateToApiConfig={() => navigation.navigate("API Config")}
+              onNavigateToRequestFormat={() => navigation.navigate("Request Format")}
             />
           )}
 

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -182,9 +182,9 @@ export function SettingsScreen({ navigation }: Props) {
                 <ListItem
                   testID="nav-api-config"
                   icon={Braces}
-                  label="API field mapping"
+                  label="Request format"
                   sub={apiSummary}
-                  onPress={() => navigation.navigate("API Config")}
+                  onPress={() => navigation.navigate("Request Format")}
                 />
               </>
             )}

--- a/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ApiSettingsScreen.test.tsx
@@ -251,12 +251,14 @@ describe("ApiSettingsScreen", () => {
       expect(mockImmediateSaveAndRestart).toHaveBeenCalled()
     })
 
-    it("example payload changes format for GET method", () => {
-      const { getByText } = renderScreen()
+    it("calls the example a request under GET, because a GET carries no payload", () => {
+      const { getByText, getByTestId } = renderScreen()
 
-      fireEvent.press(getByText(/^GET$/))
+      expect(getByText("Example payload")).toBeTruthy()
 
-      expect(getByText("EXAMPLE REQUEST")).toBeTruthy()
+      fireEvent.press(getByTestId("http-method-get"))
+
+      expect(getByText("Example request")).toBeTruthy()
     })
   })
 

--- a/apps/mobile/src/screens/__tests__/BackendTemplateScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/BackendTemplateScreen.test.tsx
@@ -60,6 +60,6 @@ describe("BackendTemplateScreen", () => {
 
     fireEvent.press(getByTestId("template-dawarich"))
 
-    expect(mockPopTo).toHaveBeenCalledWith("API Config", { template: "dawarich" }, { merge: true })
+    expect(mockPopTo).toHaveBeenCalledWith("Request Format", { template: "dawarich" }, { merge: true })
   })
 })

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -298,22 +298,22 @@ describe("SettingsScreen", () => {
     expect(mockNavigate).toHaveBeenCalledWith("Data Management")
   })
 
-  it("navigates to API Config", () => {
+  it("navigates to Request Format", () => {
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    fireEvent.press(getByText("API field mapping"))
+    fireEvent.press(getByText("Request format"))
 
-    expect(mockNavigate).toHaveBeenCalledWith("API Config")
+    expect(mockNavigate).toHaveBeenCalledWith("Request Format")
   })
 
   // --- Offline mode ---
 
-  it("hides the API field mapping link when offline mode is enabled", () => {
+  it("hides the request format link when offline mode is enabled", () => {
     mockSettings = { ...DEFAULT_SETTINGS, isOfflineMode: true }
 
     const { queryByText } = render(<SettingsScreen {...mockProps} />)
 
-    expect(queryByText("API field mapping")).toBeNull()
+    expect(queryByText("Request format")).toBeNull()
   })
 
   it("still shows Connection, Tracking Profiles and Data Management in offline mode", () => {

--- a/apps/mobile/src/types/navigation.ts
+++ b/apps/mobile/src/types/navigation.ts
@@ -15,7 +15,7 @@ export type RootStackParamList = {
   Connection: undefined
   "Tracking & Sync": undefined
   Appearance: undefined
-  "API Config": { template?: ApiTemplateName } | undefined
+  "Request Format": { template?: ApiTemplateName } | undefined
   "Backend Template": { selected: ApiTemplateName }
   "Auth Settings": undefined
   "mTLS Settings": undefined


### PR DESCRIPTION
The screen was labelled API field mapping on the Settings row and the welcome card while its header read API config, and neither described it: there is no endpoint on it, and field mapping is one of five sections beside the backend template, the HTTP method, the Dawarich mode and custom fields.

Request format names what the screen decides, and separates it from its siblings: Connection is where, Auth is credentials, this is what the request looks like. It also survives GET, which has no payload, and the screen already switched its own example heading for that reason.

The route key moves with the title. Leaving it as API Config would keep the code saying one name while every string said another, which is the mismatch being fixed.

Two things fixed alongside: the example heading rendered in caps, missed by the sentence-case sweep and pinned by a test asserting the caps string, and introduction.md described the screen as endpoint field mapping with templates.

The screenshot still shows the old chip layout and needs a device.
