### PR TITLE
refactor(setup): setup import adopts the primitives

### DIFF
--- a/apps/mobile/src/components/ui/StatRow.tsx
+++ b/apps/mobile/src/components/ui/StatRow.tsx
@@ -34,7 +34,9 @@ export function StatRow({ icon: Icon, label, value, children, testID }: StatRowP
         <Text style={[styles.label, { color: colors.textSecondary }]}>{label}</Text>
       </View>
       <View style={styles.trailing}>
-        <Text style={[styles.value, { color: colors.text }]}>{value}</Text>
+        <Text numberOfLines={1} style={[styles.value, { color: colors.text }]}>
+          {value}
+        </Text>
         {children}
       </View>
     </View>
@@ -60,11 +62,15 @@ const styles = StyleSheet.create({
   trailing: {
     flexDirection: "row",
     alignItems: "center",
-    gap: space.sm
+    gap: space.sm,
+    flexShrink: 1,
+    minWidth: 0
   },
   value: {
     fontSize: fontSizes.label,
     ...fonts.medium,
-    fontVariant: ["tabular-nums"]
+    fontVariant: ["tabular-nums"],
+    flexShrink: 1,
+    textAlign: "right"
   }
 })

--- a/apps/mobile/src/screens/SetupImportScreen.tsx
+++ b/apps/mobile/src/screens/SetupImportScreen.tsx
@@ -7,9 +7,20 @@ import React, { useState, useMemo } from "react"
 import { View, Text, ScrollView, StyleSheet } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
-import { Button, Card, Container, SectionTitle, Toggle } from "../components"
-import { fontSizes, fonts, type } from "../styles/typography"
-import { CircleAlert, CircleCheckBig, Import } from "lucide-react-native"
+import {
+  Button,
+  Card,
+  Container,
+  Divider,
+  EmptyState,
+  FieldMessage,
+  SectionTitle,
+  SettingRow,
+  StatRow,
+  Toggle
+} from "../components"
+import { fontSizes, fonts, lineHeights } from "../styles/typography"
+import { Check, CircleAlert } from "lucide-react-native"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -130,29 +141,24 @@ export function SetupImportScreen({ route, navigation }: any) {
         <SectionTitle>{title}</SectionTitle>
         <Card>
           {entries.map((entry, i) => (
-            <View
-              key={entry.label}
-              style={[
-                styles.settingRow,
-                i < entries.length - 1 && styles.settingRowBorder,
-                i < entries.length - 1 && { borderBottomColor: colors.border }
-              ]}
-            >
-              <Text style={[styles.settingLabel, { color: entry.rejected ? colors.error : colors.textSecondary }]}>
-                {entry.label}
-              </Text>
-              <Text
-                style={[styles.settingValue, { color: entry.rejected ? colors.error : colors.text }]}
-                numberOfLines={1}
-              >
-                {entry.value}
-              </Text>
-            </View>
+            <React.Fragment key={entry.label}>
+              {i > 0 && <Divider tight />}
+              {/* A rejected entry carries a reason where a value would be, so it gets both. */}
+              <StatRow label={entry.label} value={entry.rejected ? "Not applied" : entry.value} />
+              {entry.rejected && <FieldMessage variant="error">{entry.value}</FieldMessage>}
+            </React.Fragment>
           ))}
         </Card>
       </View>
     )
   }
+
+  const replaceLabel =
+    geofenceEntries.length > 0 && profileEntries.length > 0
+      ? "Replace zones and profiles with the same name"
+      : profileEntries.length > 0
+        ? "Replace profiles with the same name"
+        : "Replace zones with the same name"
 
   const handleCancel = () => {
     navigation.navigate("Dashboard")
@@ -163,15 +169,7 @@ export function SetupImportScreen({ route, navigation }: any) {
     return (
       <Container>
         <ScrollView contentContainerStyle={styles.content}>
-          <Card style={styles.headerCard}>
-            <View style={styles.headerRow}>
-              <CircleAlert size={28} color={colors.error} />
-              <View style={styles.headerText}>
-                <Text style={[styles.title, { color: colors.text }]}>Invalid configuration</Text>
-                <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{result.error}</Text>
-              </View>
-            </View>
-          </Card>
+          <EmptyState icon={CircleAlert} title="Invalid configuration" hint={result.error} />
           <Button title="Go back" onPress={handleCancel} variant="primary" />
         </ScrollView>
       </Container>
@@ -182,46 +180,27 @@ export function SetupImportScreen({ route, navigation }: any) {
   return (
     <Container>
       <ScrollView contentContainerStyle={styles.content}>
-        <Card style={styles.headerCard}>
-          <View style={styles.headerRow}>
-            <Import size={28} color={colors.primary} />
-            <View style={styles.headerText}>
-              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                A setup link wants to apply {result.entries.length} setting{result.entries.length !== 1 ? "s" : ""}
-              </Text>
-            </View>
-          </View>
-        </Card>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          A setup link wants to apply {result.entries.length} setting{result.entries.length !== 1 ? "s" : ""}
+        </Text>
 
-        {renderSection("TRACKING", trackingEntries)}
+        {renderSection("Tracking", trackingEntries)}
         {renderSection("API", apiEntries)}
-        {renderSection("AUTHENTICATION", authEntries)}
-        {renderSection("GEOFENCES", geofenceEntries)}
-        {renderSection("TRACKING PROFILES", profileEntries)}
+        {renderSection("Authentication", authEntries)}
+        {renderSection("Geofences", geofenceEntries)}
+        {renderSection("Tracking profiles", profileEntries)}
 
         {(geofenceEntries.length > 0 || profileEntries.length > 0) && (
           <View style={styles.section}>
-            <Card>
-              <View style={styles.toggleRow}>
-                <View style={styles.toggleText}>
-                  <Text style={[styles.toggleLabel, { color: colors.text }]}>
-                    {geofenceEntries.length > 0 && profileEntries.length > 0
-                      ? "Replace zones and profiles with the same name"
-                      : profileEntries.length > 0
-                        ? "Replace profiles with the same name"
-                        : "Replace zones with the same name"}
-                  </Text>
-                  <Text style={[styles.toggleHint, { color: colors.textSecondary }]}>
-                    Off: imports are added as new entries
-                  </Text>
-                </View>
+            <Card rows>
+              <SettingRow label={replaceLabel} hint="Off: imports are added as new entries">
                 <Toggle
-                  accessibilityLabel="Replace entries with the same name"
+                  accessibilityLabel={replaceLabel}
                   testID="replace-imports-switch"
                   value={replaceByName}
                   onValueChange={setReplaceByName}
                 />
-              </View>
+              </SettingRow>
             </Card>
           </View>
         )}
@@ -231,7 +210,7 @@ export function SetupImportScreen({ route, navigation }: any) {
             title="Apply configuration"
             onPress={handleApply}
             variant="primary"
-            icon={CircleCheckBig}
+            icon={Check}
             loading={applying}
             disabled={applying}
           />
@@ -244,67 +223,18 @@ export function SetupImportScreen({ route, navigation }: any) {
 
 const styles = StyleSheet.create({
   content: {
-    padding: space.lg,
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
     paddingBottom: space.xxl
   },
-  headerCard: {
+  subtitle: {
+    fontSize: fontSizes.body,
+    ...fonts.regular,
+    lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
-  headerRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: space.md
-  },
-  headerText: {
-    flex: 1
-  },
-  title: {
-    ...type.heading
-  },
-  subtitle: {
-    fontSize: fontSizes.description,
-    ...fonts.regular,
-    marginTop: space.xxs
-  },
   section: {
-    marginTop: space.sm
-  },
-  settingRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: space.md
-  },
-  settingRowBorder: {
-    borderBottomWidth: StyleSheet.hairlineWidth
-  },
-  settingLabel: {
-    fontSize: fontSizes.description,
-    ...fonts.semiBold
-  },
-  toggleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: space.sm,
-    gap: space.md
-  },
-  toggleText: {
-    flex: 1
-  },
-  toggleLabel: {
-    fontSize: fontSizes.description,
-    ...fonts.semiBold
-  },
-  toggleHint: {
-    fontSize: fontSizes.caption,
-    ...fonts.regular,
-    marginTop: space.xxs
-  },
-  settingValue: {
-    fontSize: fontSizes.description,
-    ...fonts.regular,
-    maxWidth: "60%",
-    textAlign: "right"
+    marginTop: space.xl
   },
   actions: {
     marginTop: space.xl

--- a/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
@@ -80,6 +80,20 @@ jest.mock("../../components", () => {
     Container: ({ children }: any) => R.createElement(View, null, children),
     Card: ({ children }: any) => R.createElement(View, null, children),
     SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
+    Divider: () => R.createElement(View, null),
+    StatRow: ({ label, value }: any) =>
+      R.createElement(View, null, R.createElement(Text, null, label), R.createElement(Text, null, value)),
+    FieldMessage: ({ children }: any) => R.createElement(Text, null, children),
+    EmptyState: ({ title, hint }: any) =>
+      R.createElement(View, null, R.createElement(Text, null, title), hint ? R.createElement(Text, null, hint) : null),
+    SettingRow: ({ label, hint, children }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        hint ? R.createElement(Text, null, hint) : null,
+        children
+      ),
     Button: ({ title, onPress, disabled }: any) =>
       R.createElement(Pressable, { onPress, disabled, accessibilityRole: "button" }, R.createElement(Text, null, title))
   }
@@ -296,9 +310,9 @@ describe("SetupImportScreen", () => {
   describe("geofences", () => {
     const validGeofence = { name: "Home", lat: 52.5, lon: 13.4, radius: 100 }
 
-    it("parses a valid geofence and shows it under GEOFENCES", () => {
+    it("parses a valid geofence and shows it under Geofences", () => {
       const { getByText } = renderScreen(encode({ geofences: [validGeofence] }))
-      expect(getByText("GEOFENCES")).toBeTruthy()
+      expect(getByText("Geofences")).toBeTruthy()
       expect(getByText("Home")).toBeTruthy()
       expect(getByText("100m")).toBeTruthy()
     })
@@ -519,9 +533,9 @@ describe("SetupImportScreen", () => {
       mockCreateProfile.mockResolvedValue(1)
     })
 
-    it("parses a valid profile and shows it under TRACKING PROFILES", () => {
+    it("parses a valid profile and shows it under Tracking profiles", () => {
       const { getByText } = renderScreen(encode({ profiles: [validProfile] }))
-      expect(getByText("TRACKING PROFILES")).toBeTruthy()
+      expect(getByText("Tracking profiles")).toBeTruthy()
       expect(getByText("Driving")).toBeTruthy()
     })
 
@@ -733,6 +747,16 @@ describe("SetupImportScreen", () => {
       })
       expect(mockGetProfiles).not.toHaveBeenCalled()
       expect(mockDeleteProfile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("rejected entries", () => {
+    it("says the setting was not applied and why, instead of only turning the row red", () => {
+      const { getByText } = renderScreen(encode({ endpoint: "notaurl", interval: 10 }))
+
+      // The value column carries a reason for a rejected entry, so it cannot double as the value.
+      expect(getByText("Not applied")).toBeTruthy()
+      expect(getByText("HTTP not allowed for public hosts")).toBeTruthy()
     })
   })
 })

--- a/apps/mobile/src/utils/__tests__/trips.test.ts
+++ b/apps/mobile/src/utils/__tests__/trips.test.ts
@@ -439,22 +439,22 @@ describe("boundarySplits", () => {
 
 describe("formatDuration", () => {
   it("formats minutes only", () => {
-    expect(formatDuration(300)).toBe("5m")
-    expect(formatDuration(0)).toBe("0m")
-    expect(formatDuration(59)).toBe("0m")
-    expect(formatDuration(60)).toBe("1m")
+    expect(formatDuration(300)).toBe("5min")
+    expect(formatDuration(0)).toBe("0min")
+    expect(formatDuration(59)).toBe("0min")
+    expect(formatDuration(60)).toBe("1min")
   })
 
   it("formats hours and minutes", () => {
-    expect(formatDuration(3600)).toBe("1h 0m")
-    expect(formatDuration(3660)).toBe("1h 1m")
-    expect(formatDuration(7200)).toBe("2h 0m")
-    expect(formatDuration(5400)).toBe("1h 30m")
+    expect(formatDuration(3600)).toBe("1h 0min")
+    expect(formatDuration(3660)).toBe("1h 1min")
+    expect(formatDuration(7200)).toBe("2h 0min")
+    expect(formatDuration(5400)).toBe("1h 30min")
   })
 
   it("clamps negative values to 0", () => {
-    expect(formatDuration(-1)).toBe("0m")
-    expect(formatDuration(-3600)).toBe("0m")
+    expect(formatDuration(-1)).toBe("0min")
+    expect(formatDuration(-3600)).toBe("0min")
   })
 })
 


### PR DESCRIPTION
The confirmation rows were built by hand with a borderBottomWidth between them, which breaks two rules at once: rows do not draw their own borders, and Divider is the only hairline. They are StatRow with Divider tight now. A rejected entry carries a reason where a value would be, so it reads Not applied with the reason under it as a FieldMessage rather than turning the whole row red and leaving you to infer why.

The rest of the screen went with it: two boxed header cards become an EmptyState and a caption, the toggle block becomes a SettingRow, four section titles drop out of caps, and two icons at 28 take the size ladder. designSystemGuard fires on 16, 20 and 24 only, so 28 was invisible to it.

The toggle named itself with a fixed string while its visible label has three variants; both read from one now. The button carried CircleCheckBig, which is the status glyph the success modal and the connection dot use, where Check is the action mark.

Section spacing was space.sm against space.xl everywhere else, the subtitle was a size below the app's intro caption with no line height, and twelve styles were left dead by the conversion.

StatRow's value could not truncate, so a long endpoint squashed the label beside it. It shrinks and clips to one line, which is a no-op for the three adopters showing numbers.

trips.test.ts still asserted the m abbreviation that #790 replaced with min. It holds a second copy of those cases and was missed, so the branch has been red since.
