### PR TITLE
refactor(ui): the map and inspector controls ripple instead of fading

### DIFF
--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -237,7 +237,8 @@ export function CalendarPicker({
           accessibilityLabel="Previous day"
           onPress={goBack}
           hitSlop={HIT_SLOP_LG}
-          style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
+          android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
+          style={styles.navBtn}
         >
           <ChevronLeft size={size.icon.md} color={colors.primary} />
         </Pressable>
@@ -247,7 +248,8 @@ export function CalendarPicker({
           onPress={toggleExpanded}
           accessibilityRole="button"
           accessibilityState={{ expanded: isExpanded }}
-          style={({ pressed }) => [styles.dateContainer, pressed && { opacity: colors.pressedOpacity }]}
+          android_ripple={{ color: colors.text + STATE_LAYER_ALPHA, borderless: true }}
+          style={styles.dateContainer}
         >
           <View style={styles.dateLabelRow}>
             <Text style={[styles.dateText, { color: colors.text }]}>{formatted}</Text>
@@ -270,7 +272,8 @@ export function CalendarPicker({
           accessibilityState={{ disabled: isToday }}
           onPress={goForward}
           hitSlop={HIT_SLOP_LG}
-          style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
+          android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
+          style={styles.navBtn}
           disabled={isToday}
         >
           <ChevronRight size={size.icon.md} color={isToday ? colors.textDisabled : colors.primary} />
@@ -282,11 +285,8 @@ export function CalendarPicker({
           accessibilityRole="button"
           onPress={goToToday}
           hitSlop={HIT_SLOP_LG}
-          style={({ pressed }) => [
-            styles.todayBtn,
-            { backgroundColor: colors.primary + "15" },
-            pressed && { opacity: colors.pressedOpacity }
-          ]}
+          android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA }}
+          style={[styles.todayBtn, { backgroundColor: colors.primary + "15" }]}
         >
           <Text style={[styles.todayText, { color: colors.primary }]}>Today</Text>
         </Pressable>
@@ -304,7 +304,8 @@ export function CalendarPicker({
                 hitSlop={HIT_SLOP_LG}
                 accessibilityRole="button"
                 accessibilityLabel="Previous month"
-                style={({ pressed }) => [styles.monthNav, pressed && { opacity: colors.pressedOpacity }]}
+                android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
+                style={styles.monthNav}
               >
                 <ChevronLeft size={size.icon.md} color={colors.primary} />
               </Pressable>
@@ -334,7 +335,8 @@ export function CalendarPicker({
                 hitSlop={HIT_SLOP_LG}
                 accessibilityRole="button"
                 accessibilityLabel="Next month"
-                style={({ pressed }) => [styles.monthNav, pressed && { opacity: colors.pressedOpacity }]}
+                android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
+                style={styles.monthNav}
                 disabled={isFutureMonth}
               >
                 <ChevronRight size={size.icon.md} color={isFutureMonth ? colors.textDisabled : colors.primary} />
@@ -521,6 +523,8 @@ const styles = StyleSheet.create({
     marginTop: space.xxs
   },
   todayBtn: {
+    // A bounded ripple squares off the corner unless the control clips it.
+    overflow: "hidden",
     alignSelf: "center",
     marginTop: space.sm,
     paddingHorizontal: space.lg,

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -22,7 +22,15 @@ import {
   type TrackLocation
 } from "../map/mapUtils"
 import { getSpeedUnit } from "../../../utils/geo"
-import { DEFAULT_MAP_ZOOM, HIT_SLOP_MD, MAP_ANIMATION_DURATION_MS, size, space, elevation } from "../../../constants"
+import {
+  DEFAULT_MAP_ZOOM,
+  HIT_SLOP_MD,
+  MAP_ANIMATION_DURATION_MS,
+  size,
+  space,
+  elevation,
+  STATE_LAYER_ALPHA
+} from "../../../constants"
 import { radius } from "@colota/shared"
 
 const HAS_NOTE = ["!=", ["get", "note"], ""]
@@ -314,7 +322,7 @@ export function TrackMap({
                   testID="popup-split-point"
                   onPress={() => onPointSplit(popup.id)}
                   hitSlop={HIT_SLOP_MD}
-                  style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+                  android_ripple={{ color: colors.textSecondary + STATE_LAYER_ALPHA, borderless: true }}
                   accessibilityRole="button"
                   accessibilityLabel="Start a new trip at this point"
                 >
@@ -326,7 +334,7 @@ export function TrackMap({
                   testID="popup-delete-point"
                   onPress={() => onPointDelete(popup.id)}
                   hitSlop={HIT_SLOP_MD}
-                  style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+                  android_ripple={{ color: colors.textSecondary + STATE_LAYER_ALPHA, borderless: true }}
                   accessibilityRole="button"
                   accessibilityLabel="Delete this point"
                 >
@@ -341,7 +349,7 @@ export function TrackMap({
                   setSelectedPoint(null)
                 }}
                 hitSlop={HIT_SLOP_MD}
-                style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+                android_ripple={{ color: colors.textSecondary + STATE_LAYER_ALPHA, borderless: true }}
               >
                 <X size={size.icon.sm} color={colors.textSecondary} />
               </Pressable>
@@ -385,7 +393,8 @@ export function TrackMap({
                       accessibilityLabel="Save note"
                       onPress={handleSaveNote}
                       hitSlop={HIT_SLOP_MD}
-                      style={({ pressed }) => [styles.noteSaveBtn, pressed && { opacity: colors.pressedOpacity }]}
+                      android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
+                      style={styles.noteSaveBtn}
                     >
                       <Check size={size.icon.md} color={colors.primary} />
                     </Pressable>

--- a/apps/mobile/src/components/features/inspector/TripList.tsx
+++ b/apps/mobile/src/components/features/inspector/TripList.tsx
@@ -236,7 +236,8 @@ export function TripList({ trips, colors, onTripSelect, onExport, onDelete, onMe
             <Pressable
               onPress={handleSelectAllToggle}
               hitSlop={HIT_SLOP_SM}
-              style={({ pressed }) => [styles.cabTextBtn, pressed && { opacity: colors.pressedOpacity }]}
+              android_ripple={{ color: colors.text + STATE_LAYER_ALPHA, borderless: true }}
+              style={styles.cabTextBtn}
               accessibilityRole="button"
               accessibilityLabel={allSelected ? "Clear selection" : "Select all trips"}
             >
@@ -278,7 +279,8 @@ export function TripList({ trips, colors, onTripSelect, onExport, onDelete, onMe
           {onExport && (
             <Pressable
               onPress={() => setShowExport((prev) => !prev)}
-              style={({ pressed }) => [styles.exportAllBtn, pressed && { opacity: colors.pressedOpacity }]}
+              android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA, borderless: true }}
+              style={styles.exportAllBtn}
               accessibilityRole="button"
               accessibilityLabel="Export all trips"
               accessibilityState={{ expanded: showExport }}

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -11,7 +11,15 @@ import type { NativeSyntheticEvent } from "react-native"
 import { Compass, Info, X } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
-import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_DARK, MAP_STYLE_URL_LIGHT, size, space, elevation } from "../../../constants"
+import {
+  DEFAULT_MAP_ZOOM,
+  MAP_STYLE_URL_DARK,
+  MAP_STYLE_URL_LIGHT,
+  size,
+  space,
+  elevation,
+  STATE_LAYER_ALPHA
+} from "../../../constants"
 import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
@@ -235,7 +243,8 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
                   hitSlop={8}
                   accessibilityRole="button"
                   accessibilityLabel="Close"
-                  style={({ pressed }) => [styles.attributionClose, pressed && { opacity: colors.pressedOpacity }]}
+                  android_ripple={{ color: colors.textLight + STATE_LAYER_ALPHA, borderless: true }}
+                  style={styles.attributionClose}
                 >
                   <X size={size.icon.md} color={colors.textLight} />
                 </Pressable>
@@ -244,7 +253,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
                     key={link.url}
                     accessibilityRole="link"
                     onPress={() => Linking.openURL(link.url)}
-                    style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+                    android_ripple={{ color: colors.link + STATE_LAYER_ALPHA, borderless: true }}
                   >
                     <Text style={[styles.attributionPopupText, { color: colors.link }, fonts.regular]}>
                       {link.label}

--- a/apps/mobile/src/components/features/map/MapActionButton.tsx
+++ b/apps/mobile/src/components/features/map/MapActionButton.tsx
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import { elevation } from "../../../constants"
+import { elevation, STATE_LAYER_ALPHA } from "../../../constants"
 import React from "react"
 import { Pressable, StyleSheet, ViewStyle, StyleProp, PressableProps } from "react-native"
 import { useTheme } from "../../../hooks/useTheme"
@@ -23,12 +23,8 @@ export function MapActionButton({ onPress, style, children, hitSlop, accessibili
 
   return (
     <Pressable
-      style={({ pressed }) => [
-        styles.button,
-        { backgroundColor: colors.card },
-        style,
-        pressed && { opacity: colors.pressedOpacity }
-      ]}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+      style={[styles.button, { backgroundColor: colors.card }, style]}
       onPress={onPress}
       hitSlop={hitSlop}
       accessibilityLabel={accessibilityLabel}
@@ -41,6 +37,8 @@ export function MapActionButton({ onPress, style, children, hitSlop, accessibili
 
 const styles = StyleSheet.create({
   button: {
+    // Bounded ripple, so the disc has to clip it to its own corner.
+    overflow: "hidden",
     position: "absolute",
     bottom: 30,
     width: 40,


### PR DESCRIPTION
#711 moved every ui/ primitive to a Material state layer and left the hand-rolled controls on an opacity fade, which is the iOS idiom and dims the label along with the surface. This takes the fifteen sites in the calendar, the trip map, the trip list and the map controls; twenty-one remain across thirteen screens.

Each ripple takes the colour of the content it sits under, and is borderless for an icon control so it fills the slop rather than a padding box. The two shaped controls are the exception: a bounded ripple squares off a rounded corner unless the control clips, so the Today pill and the map action disc gained overflow hidden.

No test asserts any of this, because Pressable consumes android_ripple and a render test never sees it. That is what a guard is for, and it can only land when the last fade is gone.
