### PR TITLE
refactor(ui): the last press fades become ripples

### DIFF
--- a/apps/mobile/src/__tests__/designSystemGuard.test.ts
+++ b/apps/mobile/src/__tests__/designSystemGuard.test.ts
@@ -45,7 +45,10 @@ const RULES = [
   // letter spacing at all.
   { name: "elevation", pattern: /elevation:\s*\d/ },
   { name: "fontWeight", pattern: /fontWeight:\s*"?\d/ },
-  { name: "letterSpacing", pattern: /letterSpacing:/ }
+  { name: "letterSpacing", pattern: /letterSpacing:/ },
+  // Touch feedback is a ripple. A fade is the iOS idiom and dims the label with the surface,
+  // so it is banned outright rather than by value; the pressedOpacity token is gone with it.
+  { name: "pressOpacity", pattern: /pressed[^)]*&&[^}]*opacity/ }
 ] as const
 
 function sourceFiles(): string[] {
@@ -102,6 +105,13 @@ describe("design system guard", () => {
     expect(caught("{ paddingHorizontal: 0 }")).toEqual([])
     expect(caught("{ marginHorizontal: -space.lg }")).toEqual([])
     expect(caught("{ paddingHorizontal: FIELD_INSET - borderWidth }")).toEqual([])
+  })
+
+  it("flags a press that fades instead of rippling", () => {
+    const caught = (source: string) => RULES.filter((rule) => rule.pattern.test(source)).map((rule) => rule.name)
+
+    expect(caught("style={({ pressed }) => [s.btn, pressed && { opacity: 0.7 }]}")).toEqual(["pressOpacity"])
+    expect(caught("android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}")).toEqual([])
   })
 
   it("keeps screens out of the styling business", () => {

--- a/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
+++ b/apps/mobile/src/components/features/dashboard/ConnectionStatus.tsx
@@ -12,7 +12,7 @@ import { useTracking } from "../../../contexts/TrackingProvider"
 import { ServerStatus, ConnectionStatusProps } from "../../../types/global"
 import { fontSizes, fonts } from "../../../styles/typography"
 import NativeLocationService from "../../../services/NativeLocationService"
-import { size, space } from "../../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../../constants"
 import { radius } from "@colota/shared"
 
 export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps) {
@@ -88,11 +88,8 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
     <Pressable
       accessibilityRole="button"
       onPress={() => navigation.navigate("Connection")}
-      style={({ pressed }) => [
-        styles.container,
-        { backgroundColor: colors.card },
-        pressed && { opacity: colors.pressedOpacity }
-      ]}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+      style={[styles.container, { backgroundColor: colors.card }]}
     >
       <View style={[styles.dot, { backgroundColor: config.color }]} />
       <Text style={[styles.host, { color: colors.text }]} numberOfLines={1}>
@@ -106,6 +103,7 @@ export function ConnectionStatus({ endpoint, navigation }: ConnectionStatusProps
 
 const styles = StyleSheet.create({
   container: {
+    overflow: "hidden",
     flexDirection: "row",
     alignItems: "center",
     padding: space.lg,

--- a/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
+++ b/apps/mobile/src/components/features/dashboard/WelcomeCard.tsx
@@ -11,7 +11,7 @@ import { useTracking } from "../../../contexts/TrackingProvider"
 import { fontSizes, fonts, type } from "../../../styles/typography"
 import { Button } from "../../ui/Button"
 import { Card } from "../../ui/Card"
-import { size, space } from "../../../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../../../constants"
 import { radius } from "@colota/shared"
 
 interface WelcomeCardProps {
@@ -56,7 +56,7 @@ function ChecklistItem({ label, completed, colors, onPress }: ChecklistItemProps
       <Pressable
         accessibilityRole="button"
         onPress={onPress}
-        style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+        android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
       >
         {content}
       </Pressable>
@@ -104,7 +104,7 @@ export function WelcomeCard({
             <Pressable
               accessibilityRole="button"
               onPress={onNavigateToRequestFormat}
-              style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+              android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
             >
               <Text style={[styles.link, { color: colors.primaryDark }]}>Request format</Text>
             </Pressable>
@@ -112,7 +112,7 @@ export function WelcomeCard({
           <Pressable
             accessibilityRole="button"
             onPress={onNavigateToTrackingSync}
-            style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+            android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
           >
             <Text style={[styles.link, { color: colors.primaryDark }]}>Tracking presets</Text>
           </Pressable>

--- a/apps/mobile/src/components/features/dashboard/__tests__/ConnectionStatus.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/ConnectionStatus.test.tsx
@@ -12,8 +12,7 @@ jest.mock("../../../../hooks/useTheme", () => ({
       textLight: "#9ca3af",
       text: "#000",
       card: "#fff",
-      border: "#e5e7eb",
-      pressedOpacity: 0.6
+      border: "#e5e7eb"
     }
   })
 }))

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -89,8 +89,7 @@ const colors = {
   border: "#ccc",
   text: "#000",
   textSecondary: "#666",
-  borderRadius: 8,
-  pressedOpacity: 0.6
+  borderRadius: 8
 } as any
 
 const loc = (lat: number, lon: number) => ({

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -7,7 +7,7 @@ import React, { useState, useCallback, useEffect, useMemo } from "react"
 import { Text, StyleSheet, View, Pressable, AppState } from "react-native"
 import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
 import { fonts, fontSizes, lineHeights } from "../../../styles/typography"
-import { HIT_SLOP_MD, OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, size, space } from "../../../constants"
+import { HIT_SLOP_MD, OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, size, space, STATE_LAYER_ALPHA } from "../../../constants"
 import { Card, NumericInput, RadioRow, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
 import { SyncIntervalPicker } from "./SyncIntervalPicker"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
@@ -313,11 +313,8 @@ export function SyncStrategySettings({
                           <Pressable
                             hitSlop={HIT_SLOP_MD}
                             accessibilityRole="button"
-                            style={({ pressed }) => [
-                              styles.ssidFillButton,
-                              { backgroundColor: colors.primary + "15" },
-                              pressed && { opacity: colors.pressedOpacity }
-                            ]}
+                            android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA }}
+                            style={[styles.ssidFillButton, { backgroundColor: colors.primary + "15" }]}
                             onPress={() => {
                               const next = { ...settings, syncSsid: currentSsid }
                               onSettingsChange(next)
@@ -434,6 +431,7 @@ const styles = StyleSheet.create({
     flex: 1
   },
   ssidFillButton: {
+    overflow: "hidden",
     alignSelf: "flex-start",
     justifyContent: "center",
     minHeight: size.chip,

--- a/apps/mobile/src/components/features/settings/__tests__/MtlsSection.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/MtlsSection.test.tsx
@@ -39,8 +39,7 @@ jest.mock("../../../../hooks/useTheme", () => ({
       placeholder: "#999",
       error: "#f00",
       warning: "#f80",
-      success: "#0a0",
-      pressedOpacity: 0.7
+      success: "#0a0"
     }
   })
 }))

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -26,7 +26,7 @@ import { logger, LOG_LEVELS, DEFAULT_LOG_LEVELS, type LogLevel } from "../utils/
 import { getMergedLogs, exportLogs, MergedLogEntry } from "../utils/logExport"
 import NativeLocationService from "../services/NativeLocationService"
 import { ScreenProps } from "../types/global"
-import { HIT_SLOP_MD, size, space, elevation } from "../constants"
+import { HIT_SLOP_MD, size, space, elevation, STATE_LAYER_ALPHA } from "../constants"
 import { radius } from "@colota/shared"
 
 type FilterLevel = LogLevel
@@ -111,7 +111,8 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
           accessibilityState={{ disabled: exporting }}
           onPress={handleExport}
           disabled={exporting}
-          style={({ pressed }) => [styles.headerButton, pressed && { opacity: colors.pressedOpacity }]}
+          android_ripple={{ color: colors.text + STATE_LAYER_ALPHA, borderless: true }}
+          style={styles.headerButton}
         >
           {exporting ? (
             <ActivityIndicator size={size.icon.md} color={colors.primary} />

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -41,7 +41,7 @@ import {
   isTraccarJsonFormat,
   isOverlandFormat
 } from "../utils/apiPayload"
-import { HIT_SLOP_LG, space } from "../constants"
+import { HIT_SLOP_LG, space, STATE_LAYER_ALPHA } from "../constants"
 import { radius } from "@colota/shared"
 
 type LocalCustomField = CustomField & { id: number }
@@ -560,7 +560,8 @@ export function ApiSettingsScreen({ navigation, route }: RootScreenProps<"Reques
                 onPress={handleResetAll}
                 hitSlop={HIT_SLOP_LG}
                 accessibilityRole="button"
-                style={({ pressed }) => [styles.resetAllButton, pressed && { opacity: colors.pressedOpacity }]}
+                android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA, borderless: true }}
+                style={styles.resetAllButton}
               >
                 <Text style={[styles.resetAllText, { color: colors.primaryDark }]}>Reset all</Text>
               </Pressable>
@@ -711,7 +712,8 @@ export function ApiSettingsScreen({ navigation, route }: RootScreenProps<"Reques
               onPress={handleCopyPayload}
               hitSlop={HIT_SLOP_LG}
               accessibilityRole="button"
-              style={({ pressed }) => [styles.copyButton, pressed && { opacity: colors.pressedOpacity }]}
+              android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA, borderless: true }}
+              style={styles.copyButton}
             >
               <Text style={[styles.copyButtonText, { color: copied ? colors.success : colors.primaryDark }]}>
                 {copied ? "Copied!" : "Copy"}

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -15,7 +15,7 @@ import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
 import type { UnitSystem, TimeFormat } from "../utils/geo"
-import { space } from "../constants"
+import { space, STATE_LAYER_ALPHA } from "../constants"
 
 export function AppearanceScreen({}: ScreenProps) {
   const { preference, setPreference, colors } = useTheme()
@@ -178,7 +178,7 @@ export function AppearanceScreen({}: ScreenProps) {
                   <Pressable
                     accessibilityRole="button"
                     onPress={resetMapStyle}
-                    style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+                    android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA, borderless: true }}
                   >
                     <Text style={[styles.mapStyleHint, { color: colors.primary }]}>
                       {t("appearance.mapStyle.reset")}

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -40,7 +40,7 @@ import { fontSizes, fonts, lineHeights } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { formatExportDateTime, formatBytes } from "../utils/format"
 import { showAlert } from "../services/modalService"
-import { size, space } from "../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../constants"
 
 type ExportInterval = "daily" | "weekly" | "monthly"
 type ExportMode = "all" | "incremental"
@@ -413,7 +413,8 @@ export function AutoExportScreen(_props: ScreenProps) {
           <Card>
             <Pressable
               accessibilityRole="button"
-              style={({ pressed }) => [styles.directoryRow, pressed && { opacity: colors.pressedOpacity }]}
+              android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+              style={styles.directoryRow}
               onPress={handlePickDirectory}
             >
               <FolderOpen size={size.icon.md} color={colors.primary} />
@@ -647,7 +648,8 @@ export function AutoExportScreen(_props: ScreenProps) {
                     <Pressable
                       accessibilityRole="button"
                       accessibilityLabel={`Share ${file.name}`}
-                      style={({ pressed }) => [styles.shareButton, pressed && { opacity: colors.pressedOpacity }]}
+                      android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
+                      style={styles.shareButton}
                       onPress={() => handleShareFile(file)}
                     >
                       <Share2 size={size.icon.md} color={colors.primary} />

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -32,7 +32,7 @@ import {
   StatRow,
   TextField
 } from "../components"
-import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, size, space } from "../constants"
+import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, size, space, STATE_LAYER_ALPHA } from "../constants"
 import { useTimeout } from "../hooks/useTimeout"
 import { showConfirm } from "../services/modalService"
 import { logger } from "../utils/logger"
@@ -410,7 +410,8 @@ const ActionRow = ({
 
   return (
     <Pressable
-      style={({ pressed }) => [styles.actionRow, pressed && { opacity: colors.pressedOpacity }]}
+      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+      style={styles.actionRow}
       onPress={onPress}
       disabled={disabled}
       accessibilityRole="button"

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -30,7 +30,7 @@ import {
 import { EXPORT_FORMATS, type ExportFormat } from "../utils/exportConverters"
 import { showAlert, showConfirm } from "../services/modalService"
 import type { RootScreenProps } from "../types/navigation"
-import { size, space } from "../constants"
+import { size, space, STATE_LAYER_ALPHA } from "../constants"
 
 type TabType = "map" | "trips" | "data"
 
@@ -89,7 +89,8 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         accessibilityRole="button"
         accessibilityLabel="Location summary"
         onPress={() => navigation.navigate("Location Summary")}
-        style={({ pressed }) => [styles.headerBtn, pressed && { opacity: colors.pressedOpacity }]}
+        android_ripple={{ color: colors.text + STATE_LAYER_ALPHA, borderless: true }}
+        style={styles.headerBtn}
       >
         <ChartNoAxesColumn size={size.icon.md} color={colors.text} />
       </Pressable>

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -10,7 +10,6 @@ import {
   FlatList,
   StyleSheet,
   ActivityIndicator,
-  Pressable,
   Animated,
   RefreshControl,
   StyleProp,
@@ -151,30 +150,29 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
 
   const renderDailyStat = useCallback(
     ({ item }: { item: DailyStat }) => (
-      <Pressable
+      <Card
+        variant="interactive"
         accessibilityRole="button"
         onPress={() => handleDayPress(item.day)}
-        style={({ pressed }) => pressed && { opacity: colors.pressedOpacity }}
+        style={styles.dayCard}
       >
-        <Card style={styles.dayCard}>
-          <View style={styles.dayHeader}>
-            <Text style={[styles.dayLabel, { color: colors.text }]}>{formatDayLabel(item.day)}</Text>
-            <View style={styles.dayHeaderRight}>
-              <Text style={[styles.dayDistance, { color: colors.primary }]}>{formatDistance(item.distanceMeters)}</Text>
-              <ChevronRight size={size.icon.sm} color={colors.textDisabled} />
-            </View>
+        <View style={styles.dayHeader}>
+          <Text style={[styles.dayLabel, { color: colors.text }]}>{formatDayLabel(item.day)}</Text>
+          <View style={styles.dayHeaderRight}>
+            <Text style={[styles.dayDistance, { color: colors.primary }]}>{formatDistance(item.distanceMeters)}</Text>
+            <ChevronRight size={size.icon.sm} color={colors.textDisabled} />
           </View>
-          <View style={styles.dayStats}>
-            <Text style={[styles.dayStat, { color: colors.textSecondary }]}>
-              {item.tripCount} {item.tripCount === 1 ? "trip" : "trips"}
-            </Text>
-            <Text style={[styles.dayStat, { color: colors.textSecondary }]}>{item.count} points</Text>
-            <Text style={[styles.dayStat, { color: colors.textSecondary }]}>
-              {formatDuration(item.endTime - item.startTime)}
-            </Text>
-          </View>
-        </Card>
-      </Pressable>
+        </View>
+        <View style={styles.dayStats}>
+          <Text style={[styles.dayStat, { color: colors.textSecondary }]}>
+            {item.tripCount} {item.tripCount === 1 ? "trip" : "trips"}
+          </Text>
+          <Text style={[styles.dayStat, { color: colors.textSecondary }]}>{item.count} points</Text>
+          <Text style={[styles.dayStat, { color: colors.textSecondary }]}>
+            {formatDuration(item.endTime - item.startTime)}
+          </Text>
+        </View>
+      </Card>
     ),
     [colors, formatDayLabel, handleDayPress]
   )

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -23,7 +23,8 @@ import {
   WORLD_MAP_ZOOM,
   size,
   space,
-  elevation
+  elevation,
+  STATE_LAYER_ALPHA
 } from "../constants"
 import { MapCenterButton } from "../components/features/map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
@@ -157,11 +158,8 @@ const DownloadForm = memo(
                   onPress={onCancelDownload}
                   hitSlop={HIT_SLOP_MD}
                   accessibilityRole="button"
-                  style={({ pressed }) => [
-                    styles.cancelBtn,
-                    { backgroundColor: colors.error + "15" },
-                    pressed && { opacity: colors.pressedOpacity }
-                  ]}
+                  android_ripple={{ color: colors.error + STATE_LAYER_ALPHA }}
+                  style={[styles.cancelBtn, { backgroundColor: colors.error + "15" }]}
                 >
                   <Text style={[styles.cancelBtnText, { color: colors.error }]}>Cancel download</Text>
                 </Pressable>
@@ -693,7 +691,8 @@ export function OfflineMapsScreen({}: ScreenProps) {
             <Pressable
               accessibilityRole="button"
               accessibilityState={{ disabled: item.isActive }}
-              style={({ pressed }) => [styles.info, pressed && { opacity: colors.pressedOpacity }]}
+              android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+              style={styles.info}
               onPress={() => fitToArea(item.name)}
               disabled={item.isActive}
             >
@@ -723,11 +722,8 @@ export function OfflineMapsScreen({}: ScreenProps) {
                 disabled={isCanceling}
                 hitSlop={HIT_SLOP_MD}
                 accessibilityRole="button"
-                style={({ pressed }) => [
-                  styles.cancelAreaBtn,
-                  { backgroundColor: colors.error + "15" },
-                  pressed && { opacity: colors.pressedOpacity }
-                ]}
+                android_ripple={{ color: colors.error + STATE_LAYER_ALPHA }}
+                style={[styles.cancelAreaBtn, { backgroundColor: colors.error + "15" }]}
               >
                 {isCanceling ? (
                   <ActivityIndicator size="small" color={colors.error} />
@@ -890,6 +886,7 @@ const styles = StyleSheet.create({
   progressFill: { height: "100%", borderRadius: 3 },
   progressSub: { fontSize: fontSizes.caption, ...fonts.regular },
   cancelBtn: {
+    overflow: "hidden",
     padding: space.md,
     borderRadius: radius.sm,
     alignItems: "center",
@@ -913,6 +910,7 @@ const styles = StyleSheet.create({
   },
   actionBtns: { flexDirection: "row", gap: space.sm, alignItems: "center" },
   cancelAreaBtn: {
+    overflow: "hidden",
     justifyContent: "center",
     minHeight: size.chip,
     paddingHorizontal: space.md,

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -15,7 +15,7 @@ import { Button, Card, Container, EmptyState, IconButton, SectionTitle, Toggle }
 import { Plus, X, Zap, Share2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { buildProfilesLink } from "../utils/setupLink"
-import { HIT_SLOP_MD, MS_TO_KMH, PROFILE_CONDITIONS, size, space } from "../constants"
+import { HIT_SLOP_MD, MS_TO_KMH, PROFILE_CONDITIONS, size, space, STATE_LAYER_ALPHA } from "../constants"
 import { radius } from "@colota/shared"
 
 function formatCondition(profile: SavedTrackingProfile): string {
@@ -116,7 +116,8 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
         <Card style={[styles.card, isActive && { backgroundColor: colors.primaryContainer }]}>
           <Pressable
             accessibilityRole="button"
-            style={({ pressed }) => [styles.row, pressed && { opacity: colors.pressedOpacity }]}
+            android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
+            style={styles.row}
             onPress={() => navigation.navigate("Profile Editor", { profileId: item.id })}
           >
             <View style={[styles.iconWrap, { backgroundColor: colors.primary + "15" }]}>
@@ -191,7 +192,8 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
                   accessibilityLabel="Share all profiles"
                   onPress={handleShareProfiles}
                   hitSlop={HIT_SLOP_MD}
-                  style={({ pressed }) => [styles.shareBtn, pressed && { opacity: colors.pressedOpacity }]}
+                  android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
+                  style={styles.shareBtn}
                 >
                   <Share2 size={size.icon.md} color={colors.textSecondary} />
                 </Pressable>

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -229,12 +229,14 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
         onPress={handleDelete}
         disabled={deleting}
         hitSlop={HIT_SLOP_MD}
-        style={({ pressed }) => [styles.headerBtn, (pressed || deleting) && { opacity: colors.pressedOpacity }]}
+        android_ripple={deleting ? undefined : { color: colors.error + STATE_LAYER_ALPHA, borderless: true }}
+        style={styles.headerBtn}
       >
-        <Trash2 size={size.icon.md} color={colors.error} />
+        {/* Busy recedes to textDisabled the way every other disabled control does, rather than fading. */}
+        <Trash2 size={size.icon.md} color={deleting ? colors.textDisabled : colors.error} />
       </Pressable>
     ),
-    [handleDelete, deleting, colors.error, colors.pressedOpacity]
+    [handleDelete, deleting, colors.error, colors.textDisabled]
   )
 
   useLayoutEffect(() => {
@@ -286,7 +288,8 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               onPress={() => goToTrip(prevTrip)}
               disabled={!prevTrip}
               hitSlop={HIT_SLOP_LG}
-              style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
+              android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA, borderless: true }}
+              style={styles.navBtn}
             >
               <ChevronLeft size={size.icon.lg} color={prevTrip ? colors.primary : colors.textDisabled} />
             </Pressable>
@@ -306,7 +309,8 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
               onPress={() => goToTrip(nextTrip)}
               disabled={!nextTrip}
               hitSlop={HIT_SLOP_LG}
-              style={({ pressed }) => [styles.navBtn, pressed && { opacity: colors.pressedOpacity }]}
+              android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA, borderless: true }}
+              style={styles.navBtn}
             >
               <ChevronRight size={size.icon.lg} color={nextTrip ? colors.primary : colors.textDisabled} />
             </Pressable>

--- a/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
@@ -49,8 +49,7 @@ jest.mock("../../hooks/useTheme", () => ({
       warning: "#f59e0b",
       success: "#22c55e",
       placeholder: "#9ca3af",
-      borderRadius: 12,
-      pressedOpacity: 0.7
+      borderRadius: 12
     }
   })
 }))

--- a/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
@@ -102,7 +102,6 @@ jest.mock("../../hooks/useTheme", () => ({
       card: "#fff",
       background: "#fff",
       error: "#ef4444",
-      pressedOpacity: 0.7,
       borderRadius: 8
     }
   })

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -48,7 +48,6 @@ export interface ThemeColors {
 
   // Utility
   overlay: string
-  pressedOpacity: number
   borderRadius: number
   textOnPrimary: string
 }
@@ -91,7 +90,6 @@ export const lightColors: ThemeColors = {
   overlay: "rgba(0, 0, 0, 0.5)",
 
   // Special
-  pressedOpacity: 0.7,
   borderRadius: 8,
   textOnPrimary: "#FFFFFF"
 }
@@ -134,7 +132,6 @@ export const darkColors: ThemeColors = {
   overlay: "rgba(0, 0, 0, 0.7)",
 
   // Special
-  pressedOpacity: 0.7,
   borderRadius: 8,
   textOnPrimary: "#121212"
 }


### PR DESCRIPTION
The twenty-one sites #808 left, across thirteen screens, plus the token that expressed them. A fade is the iOS idiom and dims the label along with the surface; Android draws a state layer from the touch point.

Two were the wrong shape rather than the wrong feedback. The location summary day row wrapped a Card in a Pressable, where a ripple squares off around the card's corners, so it takes Card interactive which already clips one. Every tinted control with its own corner gained overflow hidden for the same reason.

TripDetail's delete button spent one opacity on two meanings, pressed and deleting. Press ripples now and the busy state recedes the glyph to textDisabled, which is where every other disabled control goes.

pressedOpacity is gone from @colota/shared. Nothing referenced it but five hand-written test palettes, so tsc enforces this now rather than a guard, and a deleted token cannot come back by accident. The guard rule covers the technique instead, so a literal opacity behind a pressed check still fails.
