### PR TITLE
refactor(theme): every corner comes from the radius scale

### DIFF
--- a/apps/mobile/src/__tests__/circleRadiusGuard.test.ts
+++ b/apps/mobile/src/__tests__/circleRadiusGuard.test.ts
@@ -41,15 +41,19 @@ function circlesWrittenAsArithmetic(source: string): string[] {
     const body = style[2]
     const width = body.match(/\bwidth:\s*([\d.]+)/)
     const height = body.match(/\bheight:\s*([\d.]+)/)
-    if (!width || !height || width[1] !== height[1]) continue
+    // A square is a circle and a bar is a pill: both write their corner as half a stated dimension,
+    // so checking only squares missed every rounded bar in the app.
+    const sides = [width, height].filter(Boolean).map((m) => parseFloat(m![1]))
+    if (sides.length === 0) continue
+    if (width && height && width[1] !== height[1]) continue
 
     const literal = body.match(/borderRadius:\s*([\d.]+)/)
     const token = body.match(/borderRadius:\s*radius\.(\w+)/)
     const drawn = literal ? parseFloat(literal[1]) : token ? SCALE[token[1]] : null
     if (drawn === null || drawn === undefined) continue
 
-    if (Math.abs(drawn - parseFloat(width[1]) / 2) < 0.01) {
-      found.push(`${style[1]}: ${width[1]}px with borderRadius ${literal ? literal[1] : `radius.${token![1]}`}`)
+    if (sides.some((side) => Math.abs(drawn - side / 2) < 0.01)) {
+      found.push(`${style[1]}: ${sides[0]}px with borderRadius ${literal ? literal[1] : `radius.${token![1]}`}`)
     }
   }
 

--- a/apps/mobile/src/__tests__/designSystemGuard.test.ts
+++ b/apps/mobile/src/__tests__/designSystemGuard.test.ts
@@ -37,7 +37,9 @@ const RULES = [
   { name: "spacing", pattern: /(?:padding|margin|gap|rowGap|columnGap)[A-Za-z]*:\s*-?(?!0\b)\d/ },
   // A literal hides just as well behind an operator: `insets.bottom + 8` is the same drift.
   { name: "spacingExpression", pattern: /(?:padding|margin|gap|rowGap|columnGap)[A-Za-z]*:[^,\n}]*[-+*/]\s*\d/ },
-  { name: "radius", pattern: /borderRadius:\s*(?:4|8|12|16)\b/ },
+  // Inverted like spacing: radius names every corner the app draws, pill included, so any number
+  // here is a literal. 0 squares a corner off rather than setting one, and stays legal.
+  { name: "radius", pattern: /borderRadius:\s*-?(?!0\b)\d/ },
   { name: "fontSize", pattern: /fontSize:\s*(?:10|11|12|13|14|15|16|18|20|24|28)\b/ },
   { name: "iconSize", pattern: /size=\{(?:16|20|24)\}/ },
   // These three ban a property outright rather than a value, because the scale covers every case:
@@ -90,7 +92,7 @@ describe("design system guard", () => {
     expect(caught("<Icon size={20} />")).toEqual(["iconSize"])
     expect(caught("<Icon size={size.icon.md} />")).toEqual([])
     // No constant names these, so they are not drift and rounding them would move the design.
-    expect(caught("{ borderRadius: 10 }")).toEqual([])
+    expect(caught("{ borderRadius: radius.md }")).toEqual([])
     expect(caught("<Icon size={28} />")).toEqual([])
   })
 
@@ -99,6 +101,8 @@ describe("design system guard", () => {
 
     // The three the value list could never see: between two steps, below the grid, and behind a plus.
     expect(caught("{ marginTop: 20 }")).toEqual(["spacing"])
+    expect(caught("{ borderRadius: 10 }")).toEqual(["radius"])
+    expect(caught("{ borderRadius: 0 }")).toEqual([])
     expect(caught("{ gap: 3 }")).toEqual(["spacing"])
     expect(caught("{ paddingBottom: insets.bottom + 8 }")).toEqual(["spacingExpression"])
     // 0 cancels a spacing value rather than setting one, and a token composes freely.

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -128,7 +128,7 @@ export function DashboardMap({
   const locationOff = tracking && !locationEnabled
 
   return (
-    <View style={[styles.container, { borderRadius: colors.borderRadius }]}>
+    <View style={[styles.container, { borderRadius: radius.sm }]}>
       {/* Keep map mounted to avoid MapLibre/Fabric unmount race condition.
           Hide it behind the placeholder when not tracking. */}
       {hasInitialCoords && initialCoords.current ? (
@@ -155,11 +155,7 @@ export function DashboardMap({
 
       {!tracking && (
         <View
-          style={[
-            styles.stateContainer,
-            styles.overlay,
-            { backgroundColor: colors.card, borderRadius: colors.borderRadius }
-          ]}
+          style={[styles.stateContainer, styles.overlay, { backgroundColor: colors.card, borderRadius: radius.sm }]}
         >
           <View style={[styles.iconCircle, { backgroundColor: colors.border }]}>
             <Image source={icon} style={styles.icon} />
@@ -179,11 +175,7 @@ export function DashboardMap({
         <Pressable
           accessibilityRole="button"
           onPress={() => NativeLocationService.openLocationSettings()}
-          style={[
-            styles.stateContainer,
-            styles.overlay,
-            { backgroundColor: colors.card, borderRadius: colors.borderRadius }
-          ]}
+          style={[styles.stateContainer, styles.overlay, { backgroundColor: colors.card, borderRadius: radius.sm }]}
         >
           <View style={[styles.iconCircle, { backgroundColor: colors.warning + "20" }]}>
             <TriangleAlert size={32} color={colors.warning} />
@@ -197,11 +189,7 @@ export function DashboardMap({
 
       {waitingForFix && !locationOff && (
         <View
-          style={[
-            styles.stateContainer,
-            styles.overlay,
-            { backgroundColor: colors.card, borderRadius: colors.borderRadius }
-          ]}
+          style={[styles.stateContainer, styles.overlay, { backgroundColor: colors.card, borderRadius: radius.sm }]}
         >
           <ActivityIndicator size="large" color={colors.primary} />
           <Text style={[styles.stateTitle, styles.stateTitleSpaced, { color: colors.text }]}>Searching GPS...</Text>

--- a/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
+++ b/apps/mobile/src/components/features/dashboard/__tests__/DashboardMap.test.tsx
@@ -33,7 +33,6 @@ jest.mock("../../../../hooks/useTheme", () => ({
       info: "#3b82f6",
       background: "#fff",
       border: "#e5e7eb",
-      borderRadius: 12,
       success: "#22c55e",
       error: "#ef4444",
       link: "#0d9488",

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -511,7 +511,7 @@ const styles = StyleSheet.create({
   todayBadge: {
     paddingHorizontal: space.sm,
     paddingVertical: space.xxs,
-    borderRadius: 6
+    borderRadius: radius.xs
   },
   todayBadgeText: {
     fontSize: fontSizes.micro,
@@ -529,7 +529,7 @@ const styles = StyleSheet.create({
     marginTop: space.sm,
     paddingHorizontal: space.lg,
     paddingVertical: space.sm,
-    borderRadius: 14
+    borderRadius: radius.sm
   },
   todayText: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -494,7 +494,7 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.description,
     paddingVertical: space.xxs,
     paddingHorizontal: space.sm,
-    borderRadius: 6,
+    borderRadius: radius.sm,
     minHeight: 32,
     maxHeight: 80
   },

--- a/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
+++ b/apps/mobile/src/components/features/inspector/__tests__/TrackMap.test.tsx
@@ -88,8 +88,7 @@ const colors = {
   card: "#fff",
   border: "#ccc",
   text: "#000",
-  textSecondary: "#666",
-  borderRadius: 8
+  textSecondary: "#666"
 } as any
 
 const loc = (lat: number, lon: number) => ({

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -10,6 +10,7 @@ import type { MapRef, CameraRef, ViewStateChangeEvent, LngLatBounds } from "@map
 import type { NativeSyntheticEvent } from "react-native"
 import { Compass, Info, X } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
+import { radius } from "@colota/shared"
 import { useTheme } from "../../../hooks/useTheme"
 import {
   DEFAULT_MAP_ZOOM,
@@ -287,7 +288,7 @@ const styles = StyleSheet.create({
     // Clears the close control: space.xs inset plus space.xs padding either side of a 20 icon
     paddingEnd: space.xxl,
     paddingVertical: space.lg,
-    borderRadius: 10,
+    borderRadius: radius.md,
     gap: space.sm,
     elevation: elevation.overlay
   },

--- a/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/DisclosureModal.test.tsx
@@ -7,7 +7,6 @@ jest.mock("../../../hooks/useTheme", () => ({
     colors: {
       overlay: "rgba(0,0,0,0.5)",
       cardElevated: "#fff",
-      borderRadius: 12,
       primary: "#0d9488",
       text: "#000",
       textSecondary: "#666",

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react"
 import { Text, StyleSheet, View, ScrollView, Image } from "react-native"
 import { ScreenProps } from "../types/global"
+import { radius } from "@colota/shared"
 import { useTheme } from "../hooks/useTheme"
 import { Copy, Check } from "lucide-react-native"
 import { fontSizes, fonts, lineHeights, type } from "../styles/typography"
@@ -229,7 +230,7 @@ const styles = StyleSheet.create({
   appIconContainer: {
     width: 80,
     height: 80,
-    borderRadius: 20,
+    borderRadius: radius.lg,
     alignItems: "center",
     justifyContent: "center",
     marginBottom: space.lg,

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -780,7 +780,7 @@ const styles = StyleSheet.create({
   },
   fieldsCard: {
     padding: space.md,
-    borderRadius: 10
+    borderRadius: radius.md
   },
   fieldRow: {
     flexDirection: "row",

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -375,7 +375,7 @@ const styles = StyleSheet.create({
   strengthSegment: {
     flex: 1,
     height: 4,
-    borderRadius: 2
+    borderRadius: radius.pill
   },
   strengthLabel: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import { View, StyleSheet, FlatList, DeviceEventEmitter, Share, useWindowDimensions } from "react-native"
+import { radius } from "@colota/shared"
 import { useTheme } from "../hooks/useTheme"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
@@ -90,7 +91,7 @@ const GeofenceMap = React.memo(function GeofenceMapView({
   const initialZoom = hasRealCoords ? DEFAULT_MAP_ZOOM : WORLD_MAP_ZOOM
 
   return (
-    <View style={[styles.map, { borderRadius: colors.borderRadius }]}>
+    <View style={[styles.map, { borderRadius: radius.sm }]}>
       {hasInitialCoords && initialCenter.current ? (
         <ColotaMapView
           ref={mapRef}

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -882,8 +882,8 @@ const styles = StyleSheet.create({
   progressContainer: { gap: space.md },
   progressHeader: { flexDirection: "row", alignItems: "center", gap: space.md },
   progressLabel: { fontSize: fontSizes.body, ...fonts.semiBold },
-  progressTrack: { height: 6, borderRadius: 3, overflow: "hidden" },
-  progressFill: { height: "100%", borderRadius: 3 },
+  progressTrack: { height: 6, borderRadius: radius.pill, overflow: "hidden" },
+  progressFill: { height: "100%", borderRadius: radius.pill },
   progressSub: { fontSize: fontSizes.caption, ...fonts.regular },
   cancelBtn: {
     overflow: "hidden",

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -222,7 +222,7 @@ const styles = StyleSheet.create({
   iconWrap: {
     width: 36,
     height: 36,
-    borderRadius: 10,
+    borderRadius: radius.md,
     alignItems: "center",
     justifyContent: "center",
     marginEnd: space.md

--- a/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceEditorScreen.test.tsx
@@ -48,8 +48,7 @@ jest.mock("../../hooks/useTheme", () => ({
       error: "#ef4444",
       warning: "#f59e0b",
       success: "#22c55e",
-      placeholder: "#9ca3af",
-      borderRadius: 12
+      placeholder: "#9ca3af"
     }
   })
 }))

--- a/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
@@ -34,7 +34,6 @@ jest.mock("../../hooks/useTheme", () => ({
       info: "#3b82f6",
       background: "#fff",
       border: "#e5e7eb",
-      borderRadius: 12,
       success: "#22c55e",
       error: "#ef4444",
       link: "#0d9488",

--- a/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationHistoryScreen.test.tsx
@@ -65,8 +65,7 @@ jest.mock("../../hooks/useTheme", () => ({
       card: "#fff",
       surface: "#fff",
       backgroundElevated: "#f9fafb",
-      textOnPrimary: "#fff",
-      borderRadius: 8
+      textOnPrimary: "#fff"
     }
   })
 }))

--- a/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SetupImportScreen.test.tsx
@@ -58,8 +58,7 @@ jest.mock("../../hooks/useTheme", () => ({
       error: "#ef4444",
       card: "#fff",
       textOnPrimary: "#fff",
-      textDisabled: "#d1d5db",
-      borderRadius: 12
+      textDisabled: "#d1d5db"
     }
   })
 }))

--- a/apps/mobile/src/screens/__tests__/ShareSetupScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ShareSetupScreen.test.tsx
@@ -41,7 +41,6 @@ jest.mock("../../hooks/useTheme", () => ({
       background: "#fff",
       backgroundElevated: "#f9fafb",
       border: "#e5e7eb",
-      borderRadius: 12,
       success: "#22c55e",
       warning: "#f59e0b",
       info: "#3b82f6",

--- a/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TripDetailScreen.test.tsx
@@ -101,8 +101,7 @@ jest.mock("../../hooks/useTheme", () => ({
       border: "#e5e7eb",
       card: "#fff",
       background: "#fff",
-      error: "#ef4444",
-      borderRadius: 8
+      error: "#ef4444"
     }
   })
 }))

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -48,7 +48,6 @@ export interface ThemeColors {
 
   // Utility
   overlay: string
-  borderRadius: number
   textOnPrimary: string
 }
 
@@ -90,7 +89,6 @@ export const lightColors: ThemeColors = {
   overlay: "rgba(0, 0, 0, 0.5)",
 
   // Special
-  borderRadius: 8,
   textOnPrimary: "#FFFFFF"
 }
 
@@ -132,6 +130,5 @@ export const darkColors: ThemeColors = {
   overlay: "rgba(0, 0, 0, 0.7)",
 
   // Special
-  borderRadius: 8,
   textOnPrimary: "#121212"
 }


### PR DESCRIPTION
colors.borderRadius was an alias for radius.sm with five call sites, and seven other corners were written as numbers the radius rule could not see: it fired on 4, 8, 12 and 16, so 6, 10, 14 and 20 were invisible. The alias is deleted, the seven take the step their shape calls for, and the rule is inverted like spacing: radius names every corner the app draws, pill included, so any number is a literal and only 0 stays legal.

circleRadiusGuard needed a width and a height that matched, so it only ever caught squares. A rounded bar writes its corner as half its height by the same arithmetic, and reading a lone dimension found two at once: the offline-map progress bar and the backup password strength segments.

Nine test palettes carried a borderRadius key naming the deleted token. They are hand-written colour objects rather than lightColors, which is the drift the guide warns about; this removes the dead key, not the underlying mock.

Two numbers that look like radii are not: TrackMap's circleRadius is a MapLibre paint property beside circleStrokeWidth, and progressTrack's height is a painted dimension.
