### PR TITLE
feat(theme): the palette can come from the Android wallpaper

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -280,7 +280,7 @@ For backups, two `internal` methods support the export/import flow without expos
 | `PayloadBuilder` | Builds outgoing JSON payloads (field-mapped, Overland batch envelope, Traccar JSON) and extracts envelope custom fields |
 | `ServiceConfig` | Centralized configuration data class |
 | `TimedCache` | Generic TTL cache used for queue count, device info, profiles, and network state |
-| `BuildConfigModule` | Exposes build constants (SDK versions, app version) to JS |
+| `BuildConfigModule` | Exposes build constants (SDK versions, app version) to JS, plus `getSystemPalette` - the Android 12+ wallpaper tonal steps as `#RRGGBB` hex, null below API 31 |
 | `AppLogger` | Centralized logger - always active, all tags prefixed with `Colota.` for logcat filtering |
 | `AutoExportWorker` | WorkManager `CoroutineWorker` enqueued by `AutoExportAlarmReceiver` - performs the export (chunked writes to a per-run temp file, foreground service, retries, retention cleanup), verifies the copy by bytes written and re-arms the next alarm in `finally` |
 | `AutoExportAlarmReceiver` | Broadcast receiver fired by AlarmManager at the configured time - hands off to `AutoExportWorker` because the receiver's 10s budget can't run an export |

--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -25,7 +25,7 @@ Colota is a self-hosted GPS tracking app for Android. It sends your location to 
 - **App Shortcuts** - Long-press the app icon to start or stop tracking from the home screen. Compatible with automation apps like Tasker and Samsung Routines.
 - **Quick Setup** - Configure devices via `colota://setup` deep links or QR codes.
 - **Authentication** - Basic Auth, Bearer Token or custom headers. Optional mutual TLS (mTLS) with a PKCS12 client certificate stored in Android Keystore.
-- **Dark Mode** - Full light and dark theme support.
+- **Dark Mode** - Full light and dark theme support, optionally coloured from the Android wallpaper.
 
 ## App Screens
 
@@ -37,7 +37,7 @@ Colota has twenty-eight screens, each focused on a specific task:
 | **Settings** | Hub linking to Connection, Tracking and Sync, Request format, Tracking profiles, Appearance and data/about screens |
 | **Connection** | Server endpoint URL, offline mode toggle and connection test |
 | **Tracking & sync** | GPS polling interval, distance filter, accuracy threshold and sync strategy preset |
-| **Appearance** | Light/dark theme, unit system, time format and custom map tile URLs |
+| **Appearance** | Light/dark theme, wallpaper colors, unit system, time format and custom map tile URLs |
 | **Request format** | How the request is shaped: the backend template, the HTTP method, the field names and any custom fields |
 | **Backend template** | Pick the backend Colota formats its payload for, each option describing what it sends |
 | **Auth Settings** | Endpoint authentication (None, Basic Auth, Bearer Token) and custom HTTP headers |

--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/BuildConfigModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/BuildConfigModule.kt
@@ -2,12 +2,16 @@
  * Copyright (C) 2026 Max Dietrich
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
- 
+
  package com.Colota.bridge
 
+import android.os.Build
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.Colota.BuildConfig
 import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
 import java.util.Locale
 
 class BuildConfigModule(reactContext: ReactApplicationContext) :
@@ -29,4 +33,47 @@ class BuildConfigModule(reactContext: ReactApplicationContext) :
             "APP_LANGUAGE" to Locale.getDefault().toLanguageTag()
         )
     }
+
+    /**
+     * The wallpaper-derived tonal steps the theme reads, as `#RRGGBB`. Null below API 31, where
+     * the framework has no such palette. Hex rather than PlatformColor: the theme concatenates
+     * alpha onto its colours as strings, which an opaque colour object cannot do.
+     */
+    @ReactMethod
+    fun getSystemPalette(promise: Promise) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            promise.resolve(null)
+            return
+        }
+        val palette = Arguments.createMap()
+        for ((name, resId) in systemPaletteIds()) {
+            val color = reactApplicationContext.getColor(resId)
+            palette.putString(name, String.format(Locale.US, "#%06X", color and 0xFFFFFF))
+        }
+        promise.resolve(palette)
+    }
+
+    private fun systemPaletteIds(): List<Pair<String, Int>> = listOf(
+        "accent1_100" to android.R.color.system_accent1_100,
+        "accent1_200" to android.R.color.system_accent1_200,
+        "accent1_300" to android.R.color.system_accent1_300,
+        "accent1_600" to android.R.color.system_accent1_600,
+        "accent1_700" to android.R.color.system_accent1_700,
+        "accent1_800" to android.R.color.system_accent1_800,
+        "accent1_900" to android.R.color.system_accent1_900,
+        "neutral1_0" to android.R.color.system_neutral1_0,
+        "neutral1_50" to android.R.color.system_neutral1_50,
+        "neutral1_600" to android.R.color.system_neutral1_600,
+        "neutral1_700" to android.R.color.system_neutral1_700,
+        "neutral1_800" to android.R.color.system_neutral1_800,
+        "neutral1_900" to android.R.color.system_neutral1_900,
+        "neutral2_100" to android.R.color.system_neutral2_100,
+        "neutral2_200" to android.R.color.system_neutral2_200,
+        "neutral2_300" to android.R.color.system_neutral2_300,
+        "neutral2_400" to android.R.color.system_neutral2_400,
+        "neutral2_500" to android.R.color.system_neutral2_500,
+        "neutral2_600" to android.R.color.system_neutral2_600,
+        "neutral2_700" to android.R.color.system_neutral2_700,
+        "neutral2_800" to android.R.color.system_neutral2_800
+    )
 }

--- a/apps/mobile/android/app/src/test/java/com/Colota/bridge/BuildConfigModuleTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/bridge/BuildConfigModuleTest.kt
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+package com.Colota.bridge
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.BridgeReactContext
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableMap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class BuildConfigModuleTest {
+
+    private lateinit var module: BuildConfigModule
+    private var resolved: Any? = NOT_SETTLED
+
+    // The theme reads exactly these steps. One dropped here is an undefined colour in a style prop
+    // on the JS side, so the set is asserted rather than sampled.
+    private val expectedSteps = setOf(
+        "accent1_100", "accent1_200", "accent1_300", "accent1_600", "accent1_700", "accent1_800",
+        "accent1_900",
+        "neutral1_0", "neutral1_50", "neutral1_600", "neutral1_700", "neutral1_800", "neutral1_900",
+        "neutral2_100", "neutral2_200", "neutral2_300", "neutral2_400", "neutral2_500",
+        "neutral2_600", "neutral2_700", "neutral2_800"
+    )
+
+    @Before
+    fun setUp() {
+        // WritableNativeMap needs the RN native lib, which no unit test has.
+        mockkStatic(Arguments::class)
+        every { Arguments.createMap() } answers { JavaOnlyMap() }
+        val context: Context = ApplicationProvider.getApplicationContext()
+        module = BuildConfigModule(BridgeReactContext(context))
+        resolved = NOT_SETTLED
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Arguments::class)
+    }
+
+    @Test
+    fun `resolves every tonal step the theme reads`() {
+        module.getSystemPalette(capturingPromise())
+
+        assertEquals(expectedSteps, (resolved as WritableMap).toHashMap().keys)
+    }
+
+    @Test
+    fun `resolves opaque six-digit hex, because the theme appends its own alpha`() {
+        module.getSystemPalette(capturingPromise())
+
+        for ((step, value) in (resolved as WritableMap).toHashMap()) {
+            assertTrue("$step is $value", Regex("^#[0-9A-F]{6}$").matches(value as String))
+        }
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `resolves null below API 31, where the framework has no wallpaper palette`() {
+        module.getSystemPalette(capturingPromise())
+
+        assertNull(resolved)
+    }
+
+    private fun capturingPromise(): Promise {
+        val promise = mockk<Promise>()
+        every { promise.resolve(any()) } answers { resolved = firstArg<Any?>() }
+        return promise
+    }
+
+    private companion object {
+        // Distinguishes "resolved with null" from "never settled", which assertNull cannot.
+        val NOT_SETTLED = Any()
+    }
+}

--- a/apps/mobile/src/hooks/__tests__/useTheme.test.tsx
+++ b/apps/mobile/src/hooks/__tests__/useTheme.test.tsx
@@ -1,19 +1,23 @@
 import React from "react"
 import { renderHook, act, waitFor } from "@testing-library/react-native"
-import { Appearance } from "react-native"
+import { Appearance, AppState } from "react-native"
+import { lightColors, darkColors } from "@colota/shared"
 
 import NativeLocationService from "../../services/NativeLocationService"
+import type { SystemPalette } from "../../styles/dynamicColors"
 import { ThemeProvider, useTheme } from "../useTheme"
 
 jest.mock("../../services/NativeLocationService", () => ({
   __esModule: true,
   default: {
     getSetting: jest.fn().mockResolvedValue(null),
-    saveSetting: jest.fn().mockResolvedValue(undefined)
+    saveSetting: jest.fn().mockResolvedValue(undefined),
+    getSystemPalette: jest.fn().mockResolvedValue(null)
   }
 }))
 
 let appearanceListener: ((prefs: { colorScheme: string | null }) => void) | null = null
+let appStateListener: ((state: string) => void) | null = null
 
 jest.spyOn(Appearance, "getColorScheme").mockReturnValue("light")
 jest.spyOn(Appearance, "addChangeListener").mockImplementation((cb: any) => {
@@ -21,13 +25,47 @@ jest.spyOn(Appearance, "addChangeListener").mockImplementation((cb: any) => {
   return { remove: jest.fn() }
 })
 
+const palette: SystemPalette = {
+  accent1_100: "#D6E3FF",
+  accent1_200: "#ABC7FF",
+  accent1_300: "#8AB4F8",
+  accent1_600: "#2B5CB8",
+  accent1_700: "#12459E",
+  accent1_800: "#002E6B",
+  accent1_900: "#001B3F",
+  neutral1_0: "#FFFFFF",
+  neutral1_50: "#F3F3F6",
+  neutral1_600: "#5B5C63",
+  neutral1_700: "#43444B",
+  neutral1_800: "#2C2D33",
+  neutral1_900: "#1A1B1F",
+  neutral2_100: "#E3E2E9",
+  neutral2_200: "#C7C6CE",
+  neutral2_300: "#ABAAB2",
+  neutral2_400: "#909097",
+  neutral2_500: "#76767D",
+  neutral2_600: "#5E5E65",
+  neutral2_700: "#46464D",
+  neutral2_800: "#2F2F35"
+}
+
+const settings = (values: Record<string, string | null>) => {
+  ;(NativeLocationService.getSetting as jest.Mock).mockImplementation(async (key: string) => values[key] ?? null)
+}
+
 const wrapper = ({ children }: { children: React.ReactNode }) => <ThemeProvider>{children}</ThemeProvider>
 
 beforeEach(() => {
   appearanceListener = null
+  appStateListener = null
   ;(Appearance.getColorScheme as jest.Mock).mockReturnValue("light")
   ;(NativeLocationService.getSetting as jest.Mock).mockResolvedValue(null)
+  ;(NativeLocationService.getSystemPalette as jest.Mock).mockClear().mockResolvedValue(null)
   ;(NativeLocationService.saveSetting as jest.Mock).mockClear()
+  ;(AppState.addEventListener as jest.Mock).mockImplementation((_: string, cb: (state: string) => void) => {
+    appStateListener = cb
+    return { remove: jest.fn() }
+  })
 })
 
 describe("useTheme", () => {
@@ -158,12 +196,125 @@ describe("useTheme", () => {
   it("provides different color objects for light and dark modes", () => {
     const { result } = renderHook(() => useTheme(), { wrapper })
 
-    const lightColors = result.current.colors
+    const before = result.current.colors
 
     act(() => {
       result.current.setPreference("dark")
     })
 
-    expect(lightColors).not.toBe(result.current.colors)
+    expect(before).not.toBe(result.current.colors)
+  })
+})
+
+describe("wallpaper colors", () => {
+  it("offers nothing to turn on where the platform has no palette", async () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(NativeLocationService.getSystemPalette).toHaveBeenCalled()
+    })
+    expect(result.current.wallpaperColorsAvailable).toBe(false)
+  })
+
+  it("keeps the brand palette while the toggle is off, so having one is not using one", async () => {
+    ;(NativeLocationService.getSystemPalette as jest.Mock).mockResolvedValue(palette)
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.wallpaperColorsAvailable).toBe(true)
+    })
+    expect(result.current.colors.primary).toBe(lightColors.primary)
+  })
+
+  it("paints from the wallpaper once it is turned on", async () => {
+    ;(NativeLocationService.getSystemPalette as jest.Mock).mockResolvedValue(palette)
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.wallpaperColorsAvailable).toBe(true)
+    })
+    act(() => {
+      result.current.setWallpaperColors(true)
+    })
+
+    expect(result.current.colors.primary).toBe(palette.accent1_600)
+  })
+
+  it("stays on the brand palette when the bridge answers with nothing to map", async () => {
+    settings({ wallpaperColors: "true" })
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.wallpaperColors).toBe(true)
+    })
+    expect(result.current.colors).toBe(lightColors)
+  })
+
+  it("applies to dark as well, because the palette is not a fourth mode", async () => {
+    ;(NativeLocationService.getSystemPalette as jest.Mock).mockResolvedValue(palette)
+    settings({ themeMode: "dark", wallpaperColors: "true" })
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isDark).toBe(true)
+    })
+    expect(result.current.colors.primary).toBe(palette.accent1_200)
+    expect(result.current.colors.error).toBe(darkColors.error)
+  })
+
+  it("restores the saved choice on mount", async () => {
+    ;(NativeLocationService.getSystemPalette as jest.Mock).mockResolvedValue(palette)
+    settings({ wallpaperColors: "true" })
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.wallpaperColors).toBe(true)
+    })
+  })
+
+  it("persists the choice, so a restart does not lose it", async () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    act(() => {
+      result.current.setWallpaperColors(true)
+    })
+
+    expect(NativeLocationService.saveSetting).toHaveBeenCalledWith("wallpaperColors", "true")
+  })
+
+  it("re-reads the palette on foreground, because the wallpaper changes outside the app", async () => {
+    settings({ wallpaperColors: "true" })
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.wallpaperColors).toBe(true)
+    })
+    ;(NativeLocationService.getSystemPalette as jest.Mock).mockResolvedValue(palette)
+
+    await act(async () => {
+      appStateListener!("active")
+    })
+
+    expect(result.current.colors.primary).toBe(palette.accent1_600)
+  })
+
+  it("ignores a background transition, which cannot have changed the wallpaper on screen", async () => {
+    renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(NativeLocationService.getSystemPalette).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      appStateListener!("background")
+    })
+
+    expect(NativeLocationService.getSystemPalette).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/mobile/src/hooks/useTheme.tsx
+++ b/apps/mobile/src/hooks/useTheme.tsx
@@ -4,12 +4,14 @@
  */
 
 import React, { useState, useEffect, useContext, createContext, ReactNode, useMemo, useCallback } from "react"
-import { Appearance, ColorSchemeName } from "react-native"
+import { Appearance, AppState, ColorSchemeName } from "react-native"
 import { ThemeColors, ThemeMode } from "../types/global"
 import { darkColors, lightColors } from "../styles/colors"
+import { buildDynamicColors, type SystemPalette } from "../styles/dynamicColors"
 import NativeLocationService from "../services/NativeLocationService"
 
 const THEME_MODE_KEY = "themeMode"
+const WALLPAPER_COLORS_KEY = "wallpaperColors"
 
 export type ThemePreference = "system" | "light" | "dark"
 
@@ -22,6 +24,10 @@ interface ThemeContextType {
   preference: ThemePreference
   setPreference: (preference: ThemePreference) => void
   isDark: boolean
+  wallpaperColors: boolean
+  setWallpaperColors: (enabled: boolean) => void
+  /** False below API 31, where there is no wallpaper palette to offer. */
+  wallpaperColorsAvailable: boolean
 }
 
 /**
@@ -39,6 +45,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
  * Features:
  * - Follows the system scheme until the user picks light or dark
  * - The choice persists; picking "system" hands control back
+ * - Light, dark and the wallpaper palette are separate choices, so the palette applies to all three modes
  * - Memoized values for optimal performance
  *
  * @example
@@ -51,6 +58,8 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const [preference, setPreferenceState] = useState<ThemePreference>("system")
   const [systemScheme, setSystemScheme] = useState<ThemeMode>(() => normalizeScheme(Appearance.getColorScheme()))
+  const [wallpaperColors, setWallpaperColorsState] = useState(false)
+  const [palette, setPalette] = useState<SystemPalette | null>(null)
 
   // A stored value is an explicit choice; nothing stored means the system decides.
   useEffect(() => {
@@ -58,6 +67,9 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
       if (saved === "light" || saved === "dark" || saved === "system") {
         setPreferenceState(saved)
       }
+    })
+    NativeLocationService.getSetting(WALLPAPER_COLORS_KEY).then((saved) => {
+      if (saved === "true") setWallpaperColorsState(true)
     })
   }, [])
 
@@ -69,14 +81,38 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
     return () => subscription.remove()
   }, [])
 
+  // The palette changes with the wallpaper, which happens outside the app, so it is re-read on
+  // every foreground rather than once on mount. A null answer keeps the last palette: the API
+  // level cannot drop mid-process, so null after a success is a failed read, not a lost palette.
+  useEffect(() => {
+    const read = () =>
+      NativeLocationService.getSystemPalette().then((next) => {
+        if (next) setPalette(next)
+      })
+    read()
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") read()
+    })
+
+    return () => subscription.remove()
+  }, [])
+
   const setPreference = useCallback((next: ThemePreference) => {
     setPreferenceState(next)
     NativeLocationService.saveSetting(THEME_MODE_KEY, next)
   }, [])
 
+  const setWallpaperColors = useCallback((enabled: boolean) => {
+    setWallpaperColorsState(enabled)
+    NativeLocationService.saveSetting(WALLPAPER_COLORS_KEY, String(enabled))
+  }, [])
+
   const mode: ThemeMode = preference === "system" ? systemScheme : preference
 
-  const colors = useMemo(() => (mode === "dark" ? darkColors : lightColors), [mode])
+  const colors = useMemo(() => {
+    if (wallpaperColors && palette) return buildDynamicColors(palette, mode === "dark")
+    return mode === "dark" ? darkColors : lightColors
+  }, [mode, wallpaperColors, palette])
 
   const contextValue = useMemo(
     () => ({
@@ -84,9 +120,12 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
       mode,
       preference,
       setPreference,
-      isDark: mode === "dark"
+      isDark: mode === "dark",
+      wallpaperColors,
+      setWallpaperColors,
+      wallpaperColorsAvailable: palette !== null
     }),
-    [colors, mode, preference, setPreference]
+    [colors, mode, preference, setPreference, wallpaperColors, setWallpaperColors, palette]
   )
 
   return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>
@@ -95,7 +134,8 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 /**
  * Hook to access theme context.
  *
- * Provides colors, mode, preference, setPreference and isDark.
+ * Provides colors, mode, preference, setPreference, isDark, wallpaperColors, setWallpaperColors
+ * and wallpaperColorsAvailable.
  *
  * @throws If used outside ThemeProvider
  *

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -3,6 +3,8 @@
   "appearance.theme.system": "System",
   "appearance.theme.light": "Light",
   "appearance.theme.dark": "Dark",
+  "appearance.wallpaperColors": "Wallpaper colors",
+  "appearance.wallpaperColors.hint": "Take the palette from the Android wallpaper",
   "appearance.units": "Units",
   "appearance.units.metric": "Metric",
   "appearance.units.imperial": "Imperial",

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -10,7 +10,7 @@ import { useTheme, type ThemePreference } from "../hooks/useTheme"
 import { useTranslation } from "../i18n/useTranslation"
 import NativeLocationService from "../services/NativeLocationService"
 import { fontSizes, fonts } from "../styles/typography"
-import { Card, ChipGroup, Container, Divider, SettingRow, TextField, ListItem } from "../components"
+import { Card, ChipGroup, Container, Divider, SettingRow, TextField, ListItem, Toggle } from "../components"
 import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
@@ -18,7 +18,8 @@ import type { UnitSystem, TimeFormat } from "../utils/geo"
 import { space, STATE_LAYER_ALPHA } from "../constants"
 
 export function AppearanceScreen({}: ScreenProps) {
-  const { preference, setPreference, colors } = useTheme()
+  const { preference, setPreference, colors, wallpaperColors, setWallpaperColors, wallpaperColorsAvailable } =
+    useTheme()
   const { t } = useTranslation()
 
   const [unitSystem, setUnitSystem] = useState<UnitSystem>(getUnitSystem)
@@ -104,6 +105,21 @@ export function AppearanceScreen({}: ScreenProps) {
               onSelect={(value) => setPreference(value as ThemePreference)}
             />
           </SettingRow>
+
+          {wallpaperColorsAvailable && (
+            <>
+              <Divider tight />
+
+              <SettingRow label={t("appearance.wallpaperColors")} hint={t("appearance.wallpaperColors.hint")}>
+                <Toggle
+                  testID="wallpaper-colors-toggle"
+                  value={wallpaperColors}
+                  onValueChange={setWallpaperColors}
+                  accessibilityLabel={t("appearance.wallpaperColors")}
+                />
+              </SettingRow>
+            </>
+          )}
 
           <Divider tight />
 

--- a/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
@@ -4,24 +4,18 @@ import { render, fireEvent, waitFor } from "@testing-library/react-native"
 // --- Mocks ---
 
 const mockSetPreference = jest.fn()
+const mockSetWallpaperColors = jest.fn()
+const theme = { wallpaperColors: false, wallpaperColorsAvailable: true }
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
     mode: "light",
     preference: "system",
     setPreference: mockSetPreference,
-    colors: {
-      primary: "#0d9488",
-      primaryDark: "#115E59",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af"
-    }
+    wallpaperColors: theme.wallpaperColors,
+    setWallpaperColors: mockSetWallpaperColors,
+    wallpaperColorsAvailable: theme.wallpaperColorsAvailable,
+    colors: require("@colota/shared").lightColors
   })
 }))
 
@@ -70,18 +64,24 @@ jest.mock("../../components", () => {
       )
     },
     Toggle: function (props: any) {
-      return require("react").createElement(require("react-native").Switch, {
+      return require("react").createElement(require("react-native").Pressable, {
         testID: props.testID,
-        value: props.value,
-        onValueChange: props.onValueChange,
+        accessibilityLabel: props.accessibilityLabel,
         disabled: props.disabled,
-        accessibilityLabel: props.accessibilityLabel
+        onPress: () => props.onValueChange(!props.value)
       })
     },
     Container: ({ children }: any) => R.createElement(View, null, children),
     Card: ({ children }: any) => R.createElement(View, null, children),
     Divider: () => R.createElement(View, null),
-    SettingRow: ({ label, children }: any) => R.createElement(View, null, R.createElement(Text, null, label), children)
+    SettingRow: ({ label, hint, children }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        hint ? R.createElement(Text, null, hint) : null,
+        children
+      )
   }
 })
 
@@ -92,6 +92,8 @@ const mockNavigation = { navigate: jest.fn() } as any
 describe("AppearanceScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    theme.wallpaperColors = false
+    theme.wallpaperColorsAvailable = true
   })
 
   it("renders theme, units and time format rows", () => {
@@ -151,6 +153,29 @@ describe("AppearanceScreen", () => {
     fireEvent.press(getByTestId("theme-dark"))
 
     expect(mockSetPreference).toHaveBeenCalledWith("dark")
+  })
+
+  it("keeps the wallpaper palette out of the mode chips, which answer a different question", () => {
+    const { getByTestId, queryByTestId } = render(<AppearanceScreen navigation={mockNavigation} />)
+
+    expect(getByTestId("wallpaper-colors-toggle")).toBeTruthy()
+    expect(queryByTestId("theme-wallpaper")).toBeNull()
+  })
+
+  it("hides the wallpaper row where the platform has no palette, rather than disabling it", () => {
+    theme.wallpaperColorsAvailable = false
+
+    const { queryByTestId } = render(<AppearanceScreen navigation={mockNavigation} />)
+
+    expect(queryByTestId("wallpaper-colors-toggle")).toBeNull()
+  })
+
+  it("hands the wallpaper choice to the theme, which owns the palette", () => {
+    const { getByTestId } = render(<AppearanceScreen navigation={mockNavigation} />)
+
+    fireEvent.press(getByTestId("wallpaper-colors-toggle"))
+
+    expect(mockSetWallpaperColors).toHaveBeenCalledWith(true)
   })
 
   it("toggles the map tile server panel when pressed", () => {

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -20,6 +20,7 @@ import {
   TripBoundaryOverride
 } from "../types/global"
 import { logger } from "../utils/logger"
+import { parseSystemPalette, type SystemPalette } from "../styles/dynamicColors"
 import { SETTINGS_READ_ATTEMPTS, SETTINGS_READ_RETRY_DELAY_MS } from "../constants"
 
 const { LocationServiceModule, MtlsBridgeModule, BuildConfigModule } = NativeModules
@@ -723,6 +724,19 @@ class NativeLocationService {
       return null
     }
     return BuildConfigModule
+  }
+
+  /**
+   * The wallpaper-derived tonal steps, or null below API 31 and whenever the map is not the
+   * complete set the theme reads.
+   */
+  static async getSystemPalette(): Promise<SystemPalette | null> {
+    if (!BuildConfigModule) return null
+    return this.safeExecute(
+      async () => parseSystemPalette(await BuildConfigModule.getSystemPalette()),
+      null,
+      "Failed to read the system palette"
+    )
   }
 
   // ============================================================================

--- a/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
+++ b/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
@@ -89,7 +89,8 @@ jest.mock("react-native", () => ({
       NDK_VERSION: "25.1.8937393",
       VERSION_NAME: "1.0.0",
       VERSION_CODE: 1,
-      FLAVOR: "gms"
+      FLAVOR: "gms",
+      getSystemPalette: jest.fn().mockResolvedValue(null)
     }
   }
 }))
@@ -332,6 +333,58 @@ describe("NativeLocationService", () => {
           VERSION_NAME: "1.0.0"
         })
       )
+    })
+  })
+
+  describe("getSystemPalette", () => {
+    const palette = {
+      accent1_100: "#D6E3FF",
+      accent1_200: "#ABC7FF",
+      accent1_300: "#8AB4F8",
+      accent1_600: "#2B5CB8",
+      accent1_700: "#12459E",
+      accent1_800: "#002E6B",
+      accent1_900: "#001B3F",
+      neutral1_0: "#FFFFFF",
+      neutral1_50: "#F3F3F6",
+      neutral1_600: "#5B5C63",
+      neutral1_700: "#43444B",
+      neutral1_800: "#2C2D33",
+      neutral1_900: "#1A1B1F",
+      neutral2_100: "#E3E2E9",
+      neutral2_200: "#C7C6CE",
+      neutral2_300: "#ABAAB2",
+      neutral2_400: "#909097",
+      neutral2_500: "#76767D",
+      neutral2_600: "#5E5E65",
+      neutral2_700: "#46464D",
+      neutral2_800: "#2F2F35"
+    }
+
+    it("passes a complete palette through", async () => {
+      ;(NativeModules.BuildConfigModule.getSystemPalette as jest.Mock).mockResolvedValueOnce(palette)
+
+      await expect(NativeLocationService.getSystemPalette()).resolves.toEqual(palette)
+    })
+
+    it("returns null below API 31, where the native side has nothing to send", async () => {
+      ;(NativeModules.BuildConfigModule.getSystemPalette as jest.Mock).mockResolvedValueOnce(null)
+
+      await expect(NativeLocationService.getSystemPalette()).resolves.toBeNull()
+    })
+
+    it("drops a partial palette rather than letting undefined reach a style prop", async () => {
+      const incomplete: Record<string, string> = { ...palette }
+      delete incomplete.neutral2_500
+      ;(NativeModules.BuildConfigModule.getSystemPalette as jest.Mock).mockResolvedValueOnce(incomplete)
+
+      await expect(NativeLocationService.getSystemPalette()).resolves.toBeNull()
+    })
+
+    it("returns null when the bridge rejects, so a failed read is not a crash", async () => {
+      ;(NativeModules.BuildConfigModule.getSystemPalette as jest.Mock).mockRejectedValueOnce(new Error("no resource"))
+
+      await expect(NativeLocationService.getSystemPalette()).resolves.toBeNull()
     })
   })
 

--- a/apps/mobile/src/styles/__tests__/dynamicColors.test.ts
+++ b/apps/mobile/src/styles/__tests__/dynamicColors.test.ts
@@ -1,0 +1,98 @@
+import { lightColors, darkColors } from "@colota/shared"
+import { buildDynamicColors, parseSystemPalette, type SystemPalette } from "../dynamicColors"
+
+// A wallpaper palette in the Android numbering: 0 is the lightest step, 900 the darkest.
+const palette: SystemPalette = {
+  accent1_100: "#D6E3FF",
+  accent1_200: "#ABC7FF",
+  accent1_300: "#8AB4F8",
+  accent1_600: "#2B5CB8",
+  accent1_700: "#12459E",
+  accent1_800: "#002E6B",
+  accent1_900: "#001B3F",
+  neutral1_0: "#FFFFFF",
+  neutral1_50: "#F3F3F6",
+  neutral1_600: "#5B5C63",
+  neutral1_700: "#43444B",
+  neutral1_800: "#2C2D33",
+  neutral1_900: "#1A1B1F",
+  neutral2_100: "#E3E2E9",
+  neutral2_200: "#C7C6CE",
+  neutral2_300: "#ABAAB2",
+  neutral2_400: "#909097",
+  neutral2_500: "#76767D",
+  neutral2_600: "#5E5E65",
+  neutral2_700: "#46464D",
+  neutral2_800: "#2F2F35"
+}
+
+describe("parseSystemPalette", () => {
+  it("accepts the complete map the bridge returns", () => {
+    expect(parseSystemPalette({ ...palette })).toEqual(palette)
+  })
+
+  it("rejects a map missing a step, which would put undefined into a style prop", () => {
+    const incomplete: Record<string, string> = { ...palette }
+    delete incomplete.neutral2_500
+
+    expect(parseSystemPalette(incomplete)).toBeNull()
+  })
+
+  it("rejects a value that is not opaque hex, because the theme concatenates alpha onto it", () => {
+    expect(parseSystemPalette({ ...palette, accent1_600: "rgb(43, 92, 184)" })).toBeNull()
+  })
+
+  it("rejects null, which is what the bridge returns below API 31", () => {
+    expect(parseSystemPalette(null)).toBeNull()
+  })
+})
+
+describe("buildDynamicColors", () => {
+  it("keeps the status colours out of the wallpaper, so an error stays red", () => {
+    const light = buildDynamicColors(palette, false)
+    const dark = buildDynamicColors(palette, true)
+
+    expect(light.error).toBe(lightColors.error)
+    expect(light.warning).toBe(lightColors.warning)
+    expect(light.success).toBe(lightColors.success)
+    expect(light.info).toBe(lightColors.info)
+    expect(dark.error).toBe(darkColors.error)
+  })
+
+  it("fills every key the theme has, so no consumer reads undefined", () => {
+    expect(Object.keys(buildDynamicColors(palette, false)).sort()).toEqual(Object.keys(lightColors).sort())
+    expect(Object.keys(buildDynamicColors(palette, true)).sort()).toEqual(Object.keys(darkColors).sort())
+  })
+
+  it("pairs light text with a dark accent and the reverse, so contrast survives any wallpaper hue", () => {
+    const light = buildDynamicColors(palette, false)
+    const dark = buildDynamicColors(palette, true)
+
+    // Light mode paints on a dark accent, so its ink is the lightest neutral.
+    expect(light.primary).toBe(palette.accent1_600)
+    expect(light.textOnPrimary).toBe(palette.neutral1_0)
+    // Dark mode paints on a light accent, so its ink is the darkest.
+    expect(dark.primary).toBe(palette.accent1_200)
+    expect(dark.textOnPrimary).toBe(palette.neutral1_900)
+  })
+
+  it("puts dark ink on the light container and the reverse, which a single mapping could not", () => {
+    const light = buildDynamicColors(palette, false)
+    const dark = buildDynamicColors(palette, true)
+
+    expect(light.primaryContainer).toBe(palette.accent1_100)
+    expect(light.onPrimaryContainer).toBe(palette.accent1_900)
+    expect(dark.primaryContainer).toBe(palette.accent1_800)
+    expect(dark.onPrimaryContainer).toBe(palette.accent1_100)
+  })
+
+  it("puts text above its surface in tone, in both modes", () => {
+    const light = buildDynamicColors(palette, false)
+    const dark = buildDynamicColors(palette, true)
+
+    expect(light.background).toBe(palette.neutral1_50)
+    expect(light.text).toBe(palette.neutral1_900)
+    expect(dark.background).toBe(palette.neutral1_900)
+    expect(dark.text).toBe(palette.neutral1_50)
+  })
+})

--- a/apps/mobile/src/styles/dynamicColors.ts
+++ b/apps/mobile/src/styles/dynamicColors.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import { ThemeColors } from "../types/global"
+import { darkColors, lightColors } from "./colors"
+
+// The steps BuildConfigModule.getSystemPalette returns. Android numbers them the other way round
+// from Material tone: 0 is the lightest step and 900 the darkest.
+const PALETTE_STEPS = [
+  "accent1_100",
+  "accent1_200",
+  "accent1_300",
+  "accent1_600",
+  "accent1_700",
+  "accent1_800",
+  "accent1_900",
+  "neutral1_0",
+  "neutral1_50",
+  "neutral1_600",
+  "neutral1_700",
+  "neutral1_800",
+  "neutral1_900",
+  "neutral2_100",
+  "neutral2_200",
+  "neutral2_300",
+  "neutral2_400",
+  "neutral2_500",
+  "neutral2_600",
+  "neutral2_700",
+  "neutral2_800"
+] as const
+
+export type SystemPalette = Record<(typeof PALETTE_STEPS)[number], string>
+
+const HEX = /^#[0-9A-Fa-f]{6}$/
+
+/**
+ * A palette missing a step would put `undefined` into a style prop, so a partial map is no palette
+ * at all and the caller keeps the brand colours.
+ */
+export function parseSystemPalette(raw: unknown): SystemPalette | null {
+  if (!raw || typeof raw !== "object") return null
+  const map = raw as Record<string, unknown>
+  for (const step of PALETTE_STEPS) {
+    if (typeof map[step] !== "string" || !HEX.test(map[step] as string)) return null
+  }
+  return map as SystemPalette
+}
+
+/**
+ * Maps the wallpaper palette onto the theme. Status colours are never mapped: an error stays red
+ * whatever the wallpaper is. Text is paired with its surface by tone, so contrast does not depend
+ * on which hue the wallpaper produced.
+ */
+export function buildDynamicColors(palette: SystemPalette, isDark: boolean): ThemeColors {
+  const base = isDark ? darkColors : lightColors
+  const fixed = {
+    success: base.success,
+    warning: base.warning,
+    error: base.error,
+    info: base.info,
+    overlay: base.overlay
+  }
+
+  if (isDark) {
+    return {
+      ...fixed,
+      primary: palette.accent1_200,
+      primaryDark: palette.accent1_300,
+      primaryContainer: palette.accent1_800,
+      onPrimaryContainer: palette.accent1_100,
+      well: palette.neutral1_800,
+      background: palette.neutral1_900,
+      backgroundElevated: palette.neutral1_800,
+      card: palette.neutral1_700,
+      cardElevated: palette.neutral1_600,
+      surface: palette.neutral1_800,
+      text: palette.neutral1_50,
+      textSecondary: palette.neutral2_200,
+      textLight: palette.neutral2_300,
+      textDisabled: palette.neutral2_400,
+      border: palette.neutral2_700,
+      borderLight: palette.neutral2_800,
+      divider: palette.neutral2_700,
+      placeholder: palette.neutral2_400,
+      link: palette.accent1_200,
+      textOnPrimary: palette.neutral1_900
+    }
+  }
+
+  return {
+    ...fixed,
+    primary: palette.accent1_600,
+    primaryDark: palette.accent1_700,
+    primaryContainer: palette.accent1_100,
+    onPrimaryContainer: palette.accent1_900,
+    well: palette.neutral2_100,
+    background: palette.neutral1_50,
+    backgroundElevated: palette.neutral1_0,
+    card: palette.neutral1_0,
+    cardElevated: palette.neutral1_0,
+    surface: palette.neutral1_0,
+    text: palette.neutral1_900,
+    textSecondary: palette.neutral2_700,
+    textLight: palette.neutral2_600,
+    textDisabled: palette.neutral2_500,
+    border: palette.neutral2_200,
+    borderLight: palette.neutral2_100,
+    divider: palette.neutral2_200,
+    placeholder: palette.neutral2_500,
+    link: palette.accent1_700,
+    textOnPrimary: palette.neutral1_0
+  }
+}

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -5,3 +5,4 @@
 - Headings and labels read as sentences instead of shouting in capitals, and the smallest icons are easier to see
 - About now links to the release notes, feedback and the Play listing, with the legal detail on its own screen
 - Tapping the month in Location History picks a year and a month, instead of one chevron tap per month
+- Appearance can take the app colors from your Android wallpaper


### PR DESCRIPTION
A Wallpaper colors switch under the Theme chips. Light, dark and system answer how bright; the switch answers which hue, so the wallpaper palette applies to all three and no stored themeMode value changes meaning.

Status colours are never mapped, and a partial or non-hex palette is rejected whole rather than letting undefined reach a style prop.

Contrast under a real wallpaper still needs a device check, once saturated and once near-grey. The contrast guard measures the brand palette only and cannot pin values that come from the wallpaper.