### PR TITLE
refactor(summary): location summary reads as a ledger

### DIFF
--- a/apps/mobile/src/components/ui/ChipGroup.tsx
+++ b/apps/mobile/src/components/ui/ChipGroup.tsx
@@ -17,15 +17,23 @@ interface ChipGroupProps<T extends string> {
   selected: T
   onSelect: (value: T) => void
   disabled?: ReadonlySet<T>
-  /** Ignored: the group reads the theme itself. Kept so existing callers still compile. */
+  accessibilityLabel?: string
   colors?: ThemeColors
 }
 
-export function ChipGroup<T extends string>({ options, selected, onSelect, disabled }: ChipGroupProps<T>) {
+export function ChipGroup<T extends string>({
+  options,
+  selected,
+  onSelect,
+  disabled,
+  accessibilityLabel
+}: ChipGroupProps<T>) {
   const { colors } = useTheme()
 
   return (
-    <View style={styles.row}>
+    // The chips carry the radio role, so the row has to be the group or a screen reader reads
+    // loose radios with nothing binding them.
+    <View style={styles.row} accessibilityRole="radiogroup" accessibilityLabel={accessibilityLabel}>
       {options.map(({ value, label, testID }) => {
         const isSelected = selected === value
         const isDisabled = disabled?.has(value) ?? false

--- a/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ChipGroup.test.tsx
@@ -55,4 +55,12 @@ describe("ChipGroup", () => {
     expect(style.minHeight).toBe(size.chip)
     expect(style.minHeight + slop.top + slop.bottom).toBeGreaterThanOrEqual(size.touch)
   })
+
+  it("binds the chips into a group, because a loose radio has nothing to belong to", () => {
+    const { getByLabelText } = render(
+      <ChipGroup options={OPTIONS} selected="b" onSelect={jest.fn()} accessibilityLabel="Period" />
+    )
+
+    expect(getByLabelText("Period").props.accessibilityRole).toBe("radiogroup")
+  })
 })

--- a/apps/mobile/src/screens/LocationSummaryScreen.tsx
+++ b/apps/mobile/src/screens/LocationSummaryScreen.tsx
@@ -4,25 +4,15 @@
  */
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from "react"
-import {
-  View,
-  Text,
-  FlatList,
-  StyleSheet,
-  ActivityIndicator,
-  Animated,
-  RefreshControl,
-  StyleProp,
-  TextStyle
-} from "react-native"
+import { View, Text, FlatList, StyleSheet, ActivityIndicator, Animated, RefreshControl } from "react-native"
 import { Route, Calendar, MapPin, TrendingUp, ChevronRight } from "lucide-react-native"
-import { Card, Container, EmptyState } from "../components"
+import { Card, Container, EmptyState, StatRow } from "../components"
 import { ChipGroup } from "../components/ui/ChipGroup"
 import { useTheme } from "../hooks/useTheme"
 import { DailyStat } from "../types/global"
 import NativeLocationService from "../services/NativeLocationService"
 import { formatDistance, formatDuration, startOfDaySec } from "../utils/geo"
-import { fontSizes, fonts, type } from "../styles/typography"
+import { fontSizes, fonts } from "../styles/typography"
 import { logger } from "../utils/logger"
 import { size, space } from "../constants"
 
@@ -31,7 +21,7 @@ type Period = "week" | "month" | "30days"
 const PERIOD_OPTIONS = [
   { value: "week" as const, label: "This week" },
   { value: "month" as const, label: "This month" },
-  { value: "30days" as const, label: "Last 30 Days" }
+  { value: "30days" as const, label: "Last 30 days" }
 ]
 const COUNT_UP_DURATION = 600 // ms
 
@@ -55,16 +45,8 @@ function getDateRange(period: Period): { start: number; end: number } {
   return { start: startOfDaySec(startDate), end: endTs }
 }
 
-/** Animated number that counts up from 0 to target */
-function AnimatedNumber({
-  value,
-  format,
-  style
-}: {
-  value: number
-  format: (n: number) => string
-  style: StyleProp<TextStyle>
-}) {
+/** Counts a figure up from zero and returns it formatted. StatRow draws it tabular, so it cannot jitter. */
+function useCountUp(value: number, format: (n: number) => string): string {
   const animRef = useRef(new Animated.Value(0)).current
   const [display, setDisplay] = useState(format(0))
   const mountedRef = useRef(true)
@@ -88,7 +70,7 @@ function AnimatedNumber({
     }
   }, [value]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  return <Text style={style}>{display}</Text>
+  return display
 }
 
 export function LocationSummaryScreen({ navigation }: { navigation: any }) {
@@ -163,71 +145,44 @@ export function LocationSummaryScreen({ navigation }: { navigation: any }) {
             <ChevronRight size={size.icon.sm} color={colors.textDisabled} />
           </View>
         </View>
-        <View style={styles.dayStats}>
-          <Text style={[styles.dayStat, { color: colors.textSecondary }]}>
-            {item.tripCount} {item.tripCount === 1 ? "trip" : "trips"}
-          </Text>
-          <Text style={[styles.dayStat, { color: colors.textSecondary }]}>{item.count} points</Text>
-          <Text style={[styles.dayStat, { color: colors.textSecondary }]}>
-            {formatDuration(item.endTime - item.startTime)}
-          </Text>
-        </View>
+        <Text style={[styles.dayStat, { color: colors.textSecondary }]}>
+          {item.tripCount} {item.tripCount === 1 ? "trip" : "trips"} · {item.count} points ·{" "}
+          {formatDuration(item.endTime - item.startTime)}
+        </Text>
       </Card>
     ),
     [colors, formatDayLabel, handleDayPress]
   )
 
+  // Four cards each holding one number is the shape #791 retired: a card holds a subject, not a
+  // figure. One card of ledger rows, the way Trip Detail reads.
+  const totalDistance = useCountUp(summary.totalDistance, formatDistance)
+  const totalTrips = useCountUp(summary.totalTrips, String)
+  const activeDays = useCountUp(summary.activeDays, String)
+  const avgDistance = useCountUp(summary.avgDistance, formatDistance)
+
   const summaryHeader = useMemo(
     () => (
-      <View style={styles.summaryGrid}>
-        <Card style={styles.summaryCard}>
-          <Route size={size.icon.sm} color={colors.primary} />
-          <AnimatedNumber
-            value={summary.totalDistance}
-            format={(n) => formatDistance(n)}
-            style={[styles.summaryValue, { color: colors.text }]}
-          />
-          <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Distance</Text>
-        </Card>
-
-        <Card style={styles.summaryCard}>
-          <MapPin size={size.icon.sm} color={colors.primary} />
-          <AnimatedNumber
-            value={summary.totalTrips}
-            format={(n) => String(n)}
-            style={[styles.summaryValue, { color: colors.text }]}
-          />
-          <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Trips</Text>
-        </Card>
-
-        <Card style={styles.summaryCard}>
-          <Calendar size={size.icon.sm} color={colors.primary} />
-          <AnimatedNumber
-            value={summary.activeDays}
-            format={(n) => String(n)}
-            style={[styles.summaryValue, { color: colors.text }]}
-          />
-          <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Active days</Text>
-        </Card>
-
-        <Card style={styles.summaryCard}>
-          <TrendingUp size={size.icon.sm} color={colors.primary} />
-          <AnimatedNumber
-            value={summary.avgDistance}
-            format={(n) => formatDistance(n)}
-            style={[styles.summaryValue, { color: colors.text }]}
-          />
-          <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Avg / Day</Text>
-        </Card>
-      </View>
+      <Card rows style={styles.summaryCard}>
+        <StatRow icon={Route} label="Distance" value={totalDistance} />
+        <StatRow icon={MapPin} label="Trips" value={totalTrips} />
+        <StatRow icon={Calendar} label="Active days" value={activeDays} />
+        <StatRow icon={TrendingUp} label="Avg / day" value={avgDistance} />
+      </Card>
     ),
-    [summary, colors]
+    [totalDistance, totalTrips, activeDays, avgDistance]
   )
 
   return (
     <Container>
       <View style={styles.header}>
-        <ChipGroup options={PERIOD_OPTIONS} selected={period} onSelect={setPeriod} colors={colors} />
+        <ChipGroup
+          accessibilityLabel="Period"
+          options={PERIOD_OPTIONS}
+          selected={period}
+          onSelect={setPeriod}
+          colors={colors}
+        />
       </View>
 
       {loading && !refreshing ? (
@@ -271,29 +226,11 @@ const styles = StyleSheet.create({
     justifyContent: "center"
   },
   listContent: {
-    paddingHorizontal: space.md,
+    paddingHorizontal: space.lg,
     paddingBottom: space.xxl
   },
-  summaryGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: space.md,
-    marginBottom: space.lg
-  },
   summaryCard: {
-    flexBasis: "45%",
-    flexGrow: 1,
-    flexShrink: 0,
-    alignItems: "center",
-    padding: space.md,
-    gap: space.xxs
-  },
-  summaryValue: {
-    ...type.heading
-  },
-  summaryLabel: {
-    fontSize: fontSizes.micro,
-    ...fonts.semiBold
+    marginBottom: space.lg
   },
   dayCard: {
     marginBottom: space.sm,
@@ -303,7 +240,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: space.xs
+    marginBottom: space.xxs
   },
   dayHeaderRight: {
     flexDirection: "row",
@@ -312,15 +249,14 @@ const styles = StyleSheet.create({
   },
   dayLabel: {
     fontSize: fontSizes.body,
-    ...fonts.bold
+    ...fonts.semiBold
   },
+  // The label is the name and the distance is the datum: one weight step apart, not two bolds
+  // competing across the row.
   dayDistance: {
     fontSize: fontSizes.body,
-    ...fonts.bold
-  },
-  dayStats: {
-    flexDirection: "row",
-    gap: space.lg
+    ...fonts.medium,
+    fontVariant: ["tabular-nums"]
   },
   dayStat: {
     fontSize: fontSizes.caption,

--- a/apps/mobile/src/screens/__tests__/LocationSummaryScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/LocationSummaryScreen.test.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+import { render, waitFor } from "@testing-library/react-native"
+
+const mockGetDailyStats = jest.fn()
+jest.mock("../../services/NativeLocationService", () => ({
+  __esModule: true,
+  default: {
+    getDailyStats: (...args: any[]) => mockGetDailyStats(...args)
+  }
+}))
+
+jest.mock("../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+jest.mock("../../components", () => {
+  const R = require("react")
+  const { View, Text, Pressable } = require("react-native")
+  return {
+    Container: ({ children }: any) => R.createElement(View, null, children),
+    Card: ({ children, onPress }: any) =>
+      onPress
+        ? R.createElement(Pressable, { onPress, accessibilityRole: "button" }, children)
+        : R.createElement(View, null, children),
+    EmptyState: ({ title }: any) => R.createElement(Text, null, title),
+    StatRow: ({ label, value }: any) =>
+      R.createElement(View, null, R.createElement(Text, null, label), R.createElement(Text, null, value))
+  }
+})
+
+jest.mock("../../utils/logger", () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn(), info: jest.fn() }
+}))
+
+import { LocationSummaryScreen } from "../LocationSummaryScreen"
+
+describe("LocationSummaryScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetDailyStats.mockResolvedValue([
+      { day: "2026-09-06", count: 412, distanceMeters: 8200, tripCount: 3, startTime: 0, endTime: 8040 }
+    ])
+  })
+
+  function renderScreen() {
+    return render(<LocationSummaryScreen navigation={{ navigate: jest.fn() } as any} />)
+  }
+
+  it("reads the totals as a ledger, not as four cards each holding one number", async () => {
+    const { getByText } = renderScreen()
+
+    await waitFor(() => expect(getByText("Distance")).toBeTruthy())
+    expect(getByText("Trips")).toBeTruthy()
+    expect(getByText("Active days")).toBeTruthy()
+    expect(getByText("Avg / day")).toBeTruthy()
+  })
+
+  it("names the period group, because its chips are radios with nothing binding them", async () => {
+    const { getByLabelText } = renderScreen()
+
+    await waitFor(() => expect(getByLabelText("Period")).toBeTruthy())
+    expect(getByLabelText("Period").props.accessibilityRole).toBe("radiogroup")
+  })
+
+  it("offers the periods in sentence case", async () => {
+    const { getByText } = renderScreen()
+
+    await waitFor(() => expect(getByText("Last 30 days")).toBeTruthy())
+    expect(getByText("This week")).toBeTruthy()
+  })
+
+  it("gives a day one caption rather than three loose stats", async () => {
+    const { getByText } = renderScreen()
+
+    await waitFor(() => expect(getByText(/3 trips · 412 points/)).toBeTruthy())
+  })
+})


### PR DESCRIPTION
Four cards each holding one number is the shape #791 retired: a card holds a subject, not a figure, which is why Trip Detail's stat cards became rows. This is the last instance. One Card of four StatRows, and AnimatedNumber becomes a useCountUp hook so the count survives while the primitive draws it. StatRow's value is already tabular, so the figure cannot jitter and type.heading is no longer standing in for type.figure.

ChipGroup had no group role at all. Its chips carry accessibilityRole radio with nothing binding them, so every chip group in the app announced loose radios; the row is the group now, with an optional name for a group nothing else labels. This screen was the only one with no label of any kind.

The rest of the screen: Last 30 Days and Avg / Day into sentence case, the list inset from space.md to space.lg where it was the one screen under Material's compact margin, and a day row down to a name, a value and one caption, with the distance a weight step below the label rather than a second bold competing across the row.

The screen had no test. STYLES.md claimed a motion export that does not exist.
