### PR TITLE
refactor(ui): every icon comes from the ladder

### DIFF
--- a/apps/mobile/src/__tests__/designSystemGuard.test.ts
+++ b/apps/mobile/src/__tests__/designSystemGuard.test.ts
@@ -41,7 +41,9 @@ const RULES = [
   // here is a literal. 0 squares a corner off rather than setting one, and stays legal.
   { name: "radius", pattern: /borderRadius:\s*-?(?!0\b)\d/ },
   { name: "fontSize", pattern: /fontSize:\s*(?:10|11|12|13|14|15|16|18|20|24|28)\b/ },
-  { name: "iconSize", pattern: /size=\{(?:16|20|24)\}/ },
+  // Inverted with spacing and radius: size.icon names 16, 20 and 24, and a hero glyph is
+  // size.icon.lg in a size.emptyIcon disc, so there is no icon this scale does not cover.
+  { name: "iconSize", pattern: /size=\{\d/ },
   // These three ban a property outright rather than a value, because the scale covers every case:
   // elevation names its four levels, fonts names its four weights, and the type spec has no
   // letter spacing at all.
@@ -93,7 +95,7 @@ describe("design system guard", () => {
     expect(caught("<Icon size={size.icon.md} />")).toEqual([])
     // No constant names these, so they are not drift and rounding them would move the design.
     expect(caught("{ borderRadius: radius.md }")).toEqual([])
-    expect(caught("<Icon size={28} />")).toEqual([])
+    expect(caught("<Icon size={size.icon.lg} />")).toEqual([])
   })
 
   it("flags any spacing number, because space has a name for every step it uses", () => {
@@ -103,6 +105,9 @@ describe("design system guard", () => {
     expect(caught("{ marginTop: 20 }")).toEqual(["spacing"])
     expect(caught("{ borderRadius: 10 }")).toEqual(["radius"])
     expect(caught("{ borderRadius: 0 }")).toEqual([])
+    // 28 and 32 sat above the ladder, so the value list could not see either.
+    expect(caught("<Icon size={28} />")).toEqual(["iconSize"])
+    expect(caught("<Icon size={32} />")).toEqual(["iconSize"])
     expect(caught("{ gap: 3 }")).toEqual(["spacing"])
     expect(caught("{ paddingBottom: insets.bottom + 8 }")).toEqual(["spacingExpression"])
     // 0 cancels a spacing value rather than setting one, and a token composes freely.

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -178,7 +178,7 @@ export function DashboardMap({
           style={[styles.stateContainer, styles.overlay, { backgroundColor: colors.card, borderRadius: radius.sm }]}
         >
           <View style={[styles.iconCircle, { backgroundColor: colors.warning + "20" }]}>
-            <TriangleAlert size={32} color={colors.warning} />
+            <TriangleAlert size={size.icon.lg} color={colors.warning} />
           </View>
           <Text style={[styles.stateTitle, { color: colors.warning }]}>Location services off</Text>
           <Text style={[styles.stateSubtext, { color: colors.textSecondary }]}>
@@ -253,8 +253,8 @@ const styles = StyleSheet.create({
   },
   icon: { width: 64, height: 64 },
   iconCircle: {
-    width: 80,
-    height: 80,
+    width: size.emptyIcon,
+    height: size.emptyIcon,
     borderRadius: radius.pill,
     justifyContent: "center",
     alignItems: "center",

--- a/apps/mobile/src/components/ui/AppModal.tsx
+++ b/apps/mobile/src/components/ui/AppModal.tsx
@@ -66,7 +66,7 @@ export function AppModal() {
       <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
         <View style={[styles.card, { backgroundColor: colors.card, borderRadius: radius.lg }]}>
           <View style={[styles.iconContainer, { backgroundColor: iconColor + "15" }]}>
-            <Icon size={28} color={iconColor} />
+            <Icon size={size.icon.lg} color={iconColor} />
           </View>
 
           <Text style={[styles.title, { color: colors.text }]}>{current.title}</Text>
@@ -143,8 +143,8 @@ const styles = StyleSheet.create({
     elevation: elevation.overlay
   },
   iconContainer: {
-    width: 56,
-    height: 56,
+    width: size.emptyIcon,
+    height: size.emptyIcon,
     borderRadius: radius.pill,
     justifyContent: "center",
     alignItems: "center",

--- a/apps/mobile/src/components/ui/DisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/DisclosureModal.tsx
@@ -114,8 +114,8 @@ const styles = StyleSheet.create({
     elevation: elevation.overlay
   },
   iconContainer: {
-    width: 56,
-    height: 56,
+    width: size.emptyIcon,
+    height: size.emptyIcon,
     borderRadius: radius.pill,
     justifyContent: "center",
     alignItems: "center",

--- a/apps/mobile/src/components/ui/LocalNetworkDisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/LocalNetworkDisclosureModal.tsx
@@ -5,6 +5,7 @@
 
 import React from "react"
 import { Wifi } from "lucide-react-native"
+import { size } from "../../constants"
 import { useTheme } from "../../hooks/useTheme"
 import { registerLocalNetworkDisclosureCallback } from "../../services/LocationServicePermission"
 import { DisclosureModal } from "./DisclosureModal"
@@ -18,7 +19,7 @@ export function LocalNetworkDisclosureModal() {
 
   return (
     <DisclosureModal
-      icon={<Wifi size={28} color={colors.primary} />}
+      icon={<Wifi size={size.icon.lg} color={colors.primary} />}
       title="Local network access"
       paragraphs={[
         "Your server is on the local network. Colota needs local network access permission to reach it.",

--- a/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
+++ b/apps/mobile/src/components/ui/LocationDisclosureModal.tsx
@@ -5,6 +5,7 @@
 
 import React from "react"
 import { MapPin } from "lucide-react-native"
+import { size } from "../../constants"
 import { useTheme } from "../../hooks/useTheme"
 import { registerDisclosureCallback } from "../../services/LocationServicePermission"
 import { DisclosureModal } from "./DisclosureModal"
@@ -18,7 +19,7 @@ export function LocationDisclosureModal() {
 
   return (
     <DisclosureModal
-      icon={<MapPin size={28} color={colors.primary} />}
+      icon={<MapPin size={size.icon.lg} color={colors.primary} />}
       title="Location data collection"
       paragraphs={[
         "Colota collects location data to enable GPS tracking and sending your position to your configured server, even when the app is closed or not in use.",


### PR DESCRIPTION
size.icon fires on 16, 20 and 24, so a glyph at 28 or 32 was invisible to it, the same blind spot that hid an elevation of 4 and a corner of 22. Four sat above the ladder, and each had re-invented the hero shape rather than just the size: EmptyState settled it as size.icon.lg in a size.emptyIcon disc, and the two disclosure modals, AppModal and the map's location-off overlay had 28 in a 56 disc three times over and 32 in an 80. Material's dialog icon is 24dp, which is the same answer.

With none left, the rule inverts like spacing and radius: any number on size={} fails, because there is no icon the scale does not cover.
