### PR TITLE
refactor(theme): border means a stroke and nothing else

### DIFF
--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -157,7 +157,7 @@ export function DashboardMap({
         <View
           style={[styles.stateContainer, styles.overlay, { backgroundColor: colors.card, borderRadius: radius.sm }]}
         >
-          <View style={[styles.iconCircle, { backgroundColor: colors.border }]}>
+          <View style={[styles.iconCircle, { backgroundColor: colors.well }]}>
             <Image source={icon} style={styles.icon} />
           </View>
           <Text style={[styles.stateTitle, { color: isBatteryCritical ? colors.error : colors.text }]}>

--- a/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
+++ b/apps/mobile/src/components/features/inspector/CalendarPicker.tsx
@@ -229,7 +229,7 @@ export function CalendarPicker({
     pane === "days" ? "Opens the year picker" : pane === "years" ? "Closes the year picker" : "Back to the year picker"
 
   return (
-    <View style={[styles.container, { borderBottomColor: colors.border }]}>
+    <View style={[styles.container, { borderBottomColor: colors.divider }]}>
       {/* Compact header row */}
       <View style={styles.row}>
         <Pressable

--- a/apps/mobile/src/components/features/inspector/LocationTable.tsx
+++ b/apps/mobile/src/components/features/inspector/LocationTable.tsx
@@ -45,7 +45,7 @@ const LocationRow = React.memo(
     speedUnit: { factor: number; unit: string }
     colors: ThemeColors
   }) => (
-    <View style={[styles.row, { borderBottomColor: colors.border }]}>
+    <View style={[styles.row, { borderBottomColor: colors.divider }]}>
       <Text style={[styles.cell, styles.cellTime, { color: colors.text }]} numberOfLines={1}>
         {item.timestamp ? formatTime(item.timestamp, true) : "-"}
       </Text>
@@ -123,7 +123,7 @@ export function LocationTable({ locations, colors }: Props) {
       <View style={styles.tableWrapper}>
         {/* Header */}
         <View
-          style={[styles.row, styles.header, { borderBottomColor: colors.border, backgroundColor: colors.surface }]}
+          style={[styles.row, styles.header, { borderBottomColor: colors.divider, backgroundColor: colors.surface }]}
         >
           <Text style={[styles.cell, styles.cellTime, styles.headerText, { color: colors.textSecondary }]}>Time</Text>
           <Text style={[styles.cell, styles.cellNum, styles.headerText, { color: colors.textSecondary }]}>Δs</Text>

--- a/apps/mobile/src/components/features/inspector/TrackMap.tsx
+++ b/apps/mobile/src/components/features/inspector/TrackMap.tsx
@@ -373,7 +373,7 @@ export function TrackMap({
             <Text style={[styles.popupValue, { color: colors.text }]}>{popup.altitude.toFixed(0)}m</Text>
           </View>
           {popup.id >= 0 && (onPointNoteChange || popup.note !== "") && (
-            <View style={[styles.noteSection, { borderTopColor: colors.border }]}>
+            <View style={[styles.noteSection, { borderTopColor: colors.divider }]}>
               <Text style={[styles.popupLabel, { color: colors.textSecondary }]}>Note</Text>
               {onPointNoteChange ? (
                 <View style={styles.noteRow}>

--- a/apps/mobile/src/components/ui/IconButton.tsx
+++ b/apps/mobile/src/components/ui/IconButton.tsx
@@ -40,7 +40,7 @@ export function IconButton({
 }: IconButtonProps) {
   const { colors } = useTheme()
   const hue = tone === "danger" ? colors.error : tone === "primary" ? colors.primary : colors.textSecondary
-  const fill = tone === "neutral" ? colors.border : hue + "15"
+  const fill = tone === "neutral" ? colors.well : hue + "15"
   const content = disabled ? colors.textDisabled : hue
 
   return (

--- a/apps/mobile/src/screens/ActivityLogScreen.tsx
+++ b/apps/mobile/src/screens/ActivityLogScreen.tsx
@@ -263,7 +263,7 @@ export function ActivityLogScreen({ navigation }: ScreenProps) {
         </View>
       </View>
 
-      <View style={[styles.separator, { backgroundColor: colors.border }]} />
+      <View style={[styles.separator, { backgroundColor: colors.divider }]} />
 
       <ScrollView
         ref={scrollRef}

--- a/apps/mobile/src/screens/GeofenceEditorScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceEditorScreen.tsx
@@ -367,7 +367,7 @@ export function GeofenceEditorScreen({ navigation, route }: RootScreenProps<"Geo
           )}
 
           {pauseTracking && pauseOnWifi && pauseOnMotionless && (
-            <View style={[styles.combinedNote, { borderTopColor: colors.border }]}>
+            <View style={[styles.combinedNote, { borderTopColor: colors.divider }]}>
               <Text style={[styles.combinedNoteText, { color: colors.textSecondary }]}>
                 GPS resumes only when both WiFi is disconnected and motion is detected
               </Text>

--- a/apps/mobile/src/screens/OfflineMapsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineMapsScreen.tsx
@@ -144,7 +144,7 @@ const DownloadForm = memo(
                   <ActivityIndicator size="small" color={colors.primary} />
                   <Text style={[styles.progressLabel, { color: colors.text }]}>Downloading {progressLabel}</Text>
                 </View>
-                <View style={[styles.progressTrack, { backgroundColor: colors.border }]}>
+                <View style={[styles.progressTrack, { backgroundColor: colors.well }]}>
                   <View style={[styles.progressFill, { backgroundColor: colors.primary, width: `${progressPct}%` }]} />
                 </View>
                 {downloadProgress && (

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -128,12 +128,12 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
               <View style={styles.nameRow}>
                 <Text style={[styles.name, { color: colors.text }]}>{item.name}</Text>
                 {isActive && (
-                  <View style={[styles.activeBadge, { backgroundColor: colors.border }]}>
+                  <View style={[styles.activeBadge, { backgroundColor: colors.well }]}>
                     <View style={[styles.activeDot, { backgroundColor: colors.success }]} />
                     <Text style={[styles.activeBadgeText, { color: colors.textSecondary }]}>Active</Text>
                   </View>
                 )}
-                <View style={[styles.priorityBadge, { backgroundColor: colors.border }]}>
+                <View style={[styles.priorityBadge, { backgroundColor: colors.well }]}>
                   <Text style={[styles.priorityText, { color: colors.textSecondary }]}>P{item.priority}</Text>
                 </View>
               </View>

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -14,6 +14,7 @@ export interface ThemeColors {
   primaryDark: string
   primaryContainer: string
   onPrimaryContainer: string
+  border: string
   well: string
 
   // Secondary colors
@@ -38,7 +39,6 @@ export interface ThemeColors {
   textDisabled: string
 
   // Borders & dividers
-  border: string
   borderLight: string
   divider: string
 


### PR DESCRIPTION
colors.border was doing three unrelated jobs at sixteen sites: five strokes that are the affordance, six rules between rows, and five low-emphasis fills including a progress track and two badges. Material separates those into outline, outlineVariant and a surface role precisely because outline owes 3:1 against its surface and outlineVariant is explicitly exempt, so one token cannot serve both.

That overloading is why border sits at 1.18:1 and why raising it has been impossible: the value is tuned for the fills and hairlines, and the stroke use is collateral damage. The app already had divider and well, so the sites just went to the wrong tokens.

This moves them and nothing else. The token now carries its contract, and raising it to a real outline is a separate change: it unblocks fields being the only stroked neutral element, and lets Card outlined go back to Material's 1dp instead of buying legibility with 1.5.
