### PR TITLE
feat(theme): border reaches the outline contrast floor

### DIFF
--- a/apps/mobile/src/__tests__/contrastGuard.test.ts
+++ b/apps/mobile/src/__tests__/contrastGuard.test.ts
@@ -45,10 +45,11 @@ const PAIRS: Pair[] = [
   ["warning", "card", TEXT],
   ["info", "background", TEXT],
   ["info", "card", TEXT],
-  // success only ever paints a dot or an icon, never a word, so it answers to the UI floor.
+  ["border", "background", UI],
+  ["border", "card", UI],
+  ["border", "well", UI],
   ["success", "background", UI],
   ["success", "card", UI],
-  // The focus ring on an unselected chip.
   ["primary", "well", UI]
 ]
 

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -69,7 +69,9 @@ export function Card({
         return {
           backgroundColor: "transparent",
           borderColor: colors.border,
-          borderWidth: 1.5
+          // Material's outlined card is 1dp. It was 1.5 only to stay visible while border sat at
+          // 1.18:1; the token clears the outline floor now, so the weight goes back to the spec.
+          borderWidth: 1
         }
       case "interactive":
         return {

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -79,7 +79,7 @@ export const lightColors: ThemeColors = {
   textDisabled: "#9AA0A6",
 
   // Border & divider
-  border: "#e5e7eb",
+  border: "#7e889c",
   borderLight: "#f3f4f6",
   divider: "#e5e7eb",
 
@@ -120,7 +120,7 @@ export const darkColors: ThemeColors = {
   textDisabled: "#666666",
 
   // Border & divider
-  border: "#424242",
+  border: "#767676",
   borderLight: "#333333",
   divider: "#333333",
 


### PR DESCRIPTION
Material's outline owes 3:1 against the surface it is drawn on, because the stroke is the affordance. border measured 1.12, 1.24 and 1.05 against background, card and well in light, and 1.86, 1.37 and 1.56 in dark. It was never in contrastGuard's pair list, so nothing said so.

Light goes to #7e889c and dark to #767676, solved in HSL so only lightness moves: hue 220 at 13 percent survives in light and dark stays neutral, the same shape of move #763 made for seven other tokens. Three guard pairs pin all three surfaces in both themes.

It could only be raised because #814 stopped it painting six rules and five fills; the old value was tuned for those, which is what held the stroke down.

Card outlined goes back to Material's 1dp, having been 1.5 only to stay visible at 1.18:1. The 33 fields still paint a well fill at rest: fields being the only stroked neutral element is unblocked now, not done.
