### PR TITLE
refactor(geofences): the tab reads like its siblings

### DIFF
--- a/apps/docs/docs/guides/geofencing.md
+++ b/apps/docs/docs/guides/geofencing.md
@@ -15,11 +15,11 @@ Create zones where location recording stops automatically. These "pause zones" s
 ## Setup
 
 1. Go to the **Geofences** tab
-2. Tap **Create geofence**
+2. Tap **+** in the top bar
 3. Give the zone a name and a radius, then tap **Location** and pick a point on the map
 4. Set the pause options, then tap **Save geofence**
 
-Tap any zone in the list to reopen the editor. Every field can be changed there, **Location** included.
+Tap any zone in the list, or its circle on the map, to reopen the editor. Every field can be changed there, **Location** included. The zone you are paused in reads **Paused here** in the list.
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
@@ -66,7 +66,7 @@ Changes made in the editor take effect immediately, even when you are already in
 You can share all your geofences with another device or another user via a setup link instead of recreating zones by hand.
 
 1. Open the **Geofences** screen
-2. Tap the share icon next to "Active geofences"
+2. Tap the share icon in the top bar
 3. The system share sheet opens with a `colota://setup?config=...` link
 4. Send the link through any messenger, email or as a QR code
 

--- a/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
+++ b/apps/mobile/src/components/features/dashboard/DashboardMap.tsx
@@ -20,12 +20,16 @@ import {
 } from "../../../constants"
 import { MapCenterButton } from "../map/MapCenterButton"
 import { ColotaMapView, ColotaMapRef } from "../map/ColotaMapView"
-import { buildGeofencesGeoJSON } from "../map/mapUtils"
+import { buildGeofencesGeoJSON, geofenceBounds } from "../map/mapUtils"
 import { GeofenceLayers } from "../map/GeofenceLayers"
 import { CurrentTrackLayers } from "../map/CurrentTrackLayers"
 import { UserLocationOverlay } from "../map/UserLocationOverlay"
 import { useTodayTrack } from "../../../hooks/useTodayTrack"
 import { logger } from "../../../utils/logger"
+
+const isValidCoords = (c: LocationCoords | null): c is LocationCoords => {
+  return c !== null && c.latitude !== 0 && c.longitude !== 0
+}
 
 export type LastKnownLocation = {
   latitude: number
@@ -49,28 +53,6 @@ type Props = {
 }
 
 const WORLD_CENTER: [number, number] = [0, 20]
-const METERS_PER_DEGREE = 111_320
-
-const isValidCoords = (c: LocationCoords | null): c is LocationCoords => {
-  return c !== null && c.latitude !== 0 && c.longitude !== 0
-}
-
-function geofenceBounds(geofences: Geofence[]): [number, number, number, number] {
-  let west = Infinity
-  let south = Infinity
-  let east = -Infinity
-  let north = -Infinity
-  for (const zone of geofences) {
-    const dLat = zone.radius / METERS_PER_DEGREE
-    const dLon = zone.radius / (METERS_PER_DEGREE * Math.cos((zone.lat * Math.PI) / 180))
-    west = Math.min(west, zone.lon - dLon)
-    east = Math.max(east, zone.lon + dLon)
-    south = Math.min(south, zone.lat - dLat)
-    north = Math.max(north, zone.lat + dLat)
-  }
-  return [west, south, east, north]
-}
-
 export function DashboardMap({
   tracking,
   activeZoneName,

--- a/apps/mobile/src/components/features/inspector/ExportFormatDialog.tsx
+++ b/apps/mobile/src/components/features/inspector/ExportFormatDialog.tsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 import { StyleSheet, Text, View } from "react-native"
-import { Share } from "lucide-react-native"
+import { Upload } from "lucide-react-native"
 import { useTheme } from "../../../hooks/useTheme"
 import { space } from "../../../constants"
 import { fonts, fontSizes, lineHeights } from "../../../styles/typography"
@@ -41,7 +41,7 @@ export function ExportFormatDialog({ visible, title, message, onSelect, onReques
             <ListItem
               label={EXPORT_FORMATS[key].label}
               sub={EXPORT_FORMATS[key].description}
-              trailingIcon={Share}
+              trailingIcon={Upload}
               onPress={() => onSelect(key)}
               testID={`export-${key}`}
             />

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -17,7 +17,14 @@ import type { NativeSyntheticEvent } from "react-native"
 import { Compass, ExternalLink, Info } from "lucide-react-native"
 import { useIsFocused } from "@react-navigation/native"
 import { useTheme } from "../../../hooks/useTheme"
-import { DEFAULT_MAP_ZOOM, MAP_STYLE_URL_DARK, MAP_STYLE_URL_LIGHT, size, space } from "../../../constants"
+import {
+  DEFAULT_MAP_ZOOM,
+  MAP_STYLE_URL_DARK,
+  MAP_STYLE_URL_LIGHT,
+  MAX_MAP_ZOOM,
+  size,
+  space
+} from "../../../constants"
 import NativeLocationService from "../../../services/NativeLocationService"
 import { MapActionButton, mapActionStyles } from "./MapActionButton"
 import { DialogShell } from "../../ui/DialogShell"
@@ -239,6 +246,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
       >
         <Camera
           ref={cameraRef}
+          maxZoom={MAX_MAP_ZOOM}
           initialViewState={{
             center: initialCenter,
             zoom: initialZoom,

--- a/apps/mobile/src/components/features/map/GeofenceLayers.tsx
+++ b/apps/mobile/src/components/features/map/GeofenceLayers.tsx
@@ -3,8 +3,10 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useMemo } from "react"
-import { GeoJSONSource, Layer } from "@maplibre/maplibre-react-native"
+import React, { useCallback, useMemo } from "react"
+import type { NativeSyntheticEvent } from "react-native"
+import { GeoJSONSource, Layer, type PressEventWithFeatures } from "@maplibre/maplibre-react-native"
+import { pickSmallestZone, ZONE_HITBOX } from "./mapUtils"
 
 const geofenceFillStyle: any = {
   fillColor: ["get", "fillColor"],
@@ -21,9 +23,19 @@ interface Props {
   fills: GeoJSON.FeatureCollection
   labels: GeoJSON.FeatureCollection
   haloColor: string
+  /** Makes the circles tappable; absent, the layers stay a drawing. */
+  onPressZone?: (id: number) => void
 }
 
-export function GeofenceLayers({ fills, labels, haloColor }: Props) {
+export function GeofenceLayers({ fills, labels, haloColor, onPressZone }: Props) {
+  const handlePress = useCallback(
+    (event: NativeSyntheticEvent<PressEventWithFeatures>) => {
+      const id = pickSmallestZone(event.nativeEvent.features)
+      if (id !== null) onPressZone?.(id)
+    },
+    [onPressZone]
+  )
+
   const labelStyle = useMemo<any>(
     () => ({
       textField: ["get", "name"],
@@ -40,7 +52,12 @@ export function GeofenceLayers({ fills, labels, haloColor }: Props) {
   return (
     <>
       {fills.features.length > 0 && (
-        <GeoJSONSource id="geofence-fills" data={fills}>
+        <GeoJSONSource
+          id="geofence-fills"
+          data={fills}
+          onPress={onPressZone ? handlePress : undefined}
+          hitbox={onPressZone ? ZONE_HITBOX : undefined}
+        >
           <Layer id="geofence-fill" type="fill" style={geofenceFillStyle} />
           <Layer id="geofence-stroke" type="line" style={geofenceStrokeStyle} />
         </GeoJSONSource>

--- a/apps/mobile/src/components/features/map/MapActionButton.tsx
+++ b/apps/mobile/src/components/features/map/MapActionButton.tsx
@@ -18,6 +18,7 @@ interface Props {
   accessibilityRole?: PressableProps["accessibilityRole"]
   accessibilityState?: PressableProps["accessibilityState"]
   anchored?: boolean
+  testID?: string
 }
 
 export function MapActionButton({
@@ -28,7 +29,8 @@ export function MapActionButton({
   accessibilityLabel,
   accessibilityRole,
   accessibilityState,
-  anchored = true
+  anchored = true,
+  testID
 }: Props) {
   const { colors } = useTheme()
 
@@ -43,6 +45,7 @@ export function MapActionButton({
         accessibilityLabel={accessibilityLabel}
         accessibilityRole={accessibilityRole}
         accessibilityState={accessibilityState}
+        testID={testID}
       >
         {children}
       </Pressable>

--- a/apps/mobile/src/components/features/map/__tests__/ColotaMapView.test.tsx
+++ b/apps/mobile/src/components/features/map/__tests__/ColotaMapView.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render, fireEvent } from "@testing-library/react-native"
 import { StyleSheet } from "react-native"
-import { HIT_SLOP_SM, size, space } from "../../../../constants"
+import { HIT_SLOP_SM, size, space, MAX_MAP_ZOOM } from "../../../../constants"
 
 const mockSetStop = jest.fn()
 const mockCameraProps = jest.fn()
@@ -73,6 +73,7 @@ describe("ColotaMapView camera padding", () => {
   it("frames the first camera inside the padding so the dock never covers the position dot", () => {
     render(<ColotaMapView initialCenter={center} cameraPadding={padding} />)
 
+    expect(mockCameraProps.mock.calls[0][0].maxZoom).toBe(MAX_MAP_ZOOM)
     expect(mockCameraProps.mock.calls[0][0].initialViewState).toEqual({
       center,
       zoom: expect.any(Number),

--- a/apps/mobile/src/components/features/map/__tests__/GeofenceLayers.test.tsx
+++ b/apps/mobile/src/components/features/map/__tests__/GeofenceLayers.test.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+import { GeofenceLayers } from "../GeofenceLayers"
+
+jest.mock("@maplibre/maplibre-react-native", () => {
+  const R = require("react")
+  const { View, Pressable } = require("react-native")
+  return {
+    GeoJSONSource: ({ children, id, onPress, hitbox }: any) =>
+      R.createElement(
+        View,
+        { testID: id, hitbox },
+        onPress &&
+          R.createElement(Pressable, {
+            testID: `${id}-press`,
+            onPress: () =>
+              onPress({
+                nativeEvent: {
+                  features: [
+                    {
+                      type: "Feature",
+                      properties: { id: 1, radius: 500 },
+                      geometry: { type: "Point", coordinates: [0, 0] }
+                    },
+                    {
+                      type: "Feature",
+                      properties: { id: 2, radius: 50 },
+                      geometry: { type: "Point", coordinates: [0, 0] }
+                    }
+                  ]
+                }
+              })
+          }),
+        children
+      ),
+    Layer: ({ id }: any) => R.createElement(View, { testID: id })
+  }
+})
+
+const feature = (id: number) => ({
+  type: "Feature" as const,
+  properties: {
+    id,
+    name: `Z${id}`,
+    fillColor: "#000",
+    fillOpacity: 0.3,
+    strokeColor: "#000",
+    pauseTracking: true,
+    radius: id
+  },
+  geometry: { type: "Point" as const, coordinates: [0, 0] }
+})
+const fills = { type: "FeatureCollection" as const, features: [feature(1), feature(2)] }
+const labels = { type: "FeatureCollection" as const, features: [] }
+
+describe("GeofenceLayers", () => {
+  it("stays a drawing without a handler, so the Dashboard and Place Zone maps take no taps", () => {
+    const { getByTestId, queryByTestId } = render(<GeofenceLayers fills={fills} labels={labels} haloColor="#fff" />)
+
+    expect(getByTestId("geofence-fills").props.hitbox).toBeUndefined()
+    expect(queryByTestId("geofence-fills-press")).toBeNull()
+  })
+
+  it("hands the smallest circle under the finger to the screen with a 48 dp target when asked to", () => {
+    const onPressZone = jest.fn()
+    const { getByTestId } = render(
+      <GeofenceLayers fills={fills} labels={labels} haloColor="#fff" onPressZone={onPressZone} />
+    )
+
+    expect(getByTestId("geofence-fills").props.hitbox).toEqual({ top: 24, right: 24, bottom: 24, left: 24 })
+    fireEvent.press(getByTestId("geofence-fills-press"))
+    expect(onPressZone).toHaveBeenCalledWith(2)
+  })
+})

--- a/apps/mobile/src/components/features/map/__tests__/mapUtils.test.ts
+++ b/apps/mobile/src/components/features/map/__tests__/mapUtils.test.ts
@@ -539,3 +539,45 @@ describe("buildTripTerminalsGeoJSON", () => {
     ])
   })
 })
+
+describe("geofenceBounds and pickSmallestZone", () => {
+  const utils = require("../mapUtils")
+  const zone = (id: number, lat: number, lon: number, radius: number) => ({
+    id,
+    name: `Z${id}`,
+    lat,
+    lon,
+    radius,
+    enabled: true,
+    pauseTracking: true,
+    pauseOnWifi: false,
+    pauseOnMotionless: false,
+    motionlessTimeoutMinutes: 5,
+    heartbeatEnabled: false,
+    heartbeatIntervalMinutes: 15
+  })
+
+  it("boxes every circle, wider in longitude the further north it sits", () => {
+    const [west, south, east, north] = utils.geofenceBounds([zone(1, 60, 10, 1113.2)])
+    expect(north - south).toBeCloseTo(0.02, 4)
+    expect(east - west).toBeGreaterThan(0.03)
+    const two = utils.geofenceBounds([zone(1, 48, 11, 100), zone(2, 49, 12, 100)])
+    expect(two[0]).toBeLessThan(11)
+    expect(two[2]).toBeGreaterThan(12)
+  })
+
+  it("picks the smallest circle under a tap, since the larger ones cover it, and ignores features with no id", () => {
+    const hits = [
+      { type: "Feature", properties: { id: 1, radius: 500 }, geometry: { type: "Point", coordinates: [0, 0] } },
+      { type: "Feature", properties: { id: 2, radius: 50 }, geometry: { type: "Point", coordinates: [0, 0] } },
+      { type: "Feature", properties: { radius: 1 }, geometry: { type: "Point", coordinates: [0, 0] } }
+    ]
+    expect(utils.pickSmallestZone(hits)).toBe(2)
+    expect(utils.pickSmallestZone([])).toBeNull()
+  })
+
+  it("carries the radius on the fill feature so a tap can rank overlapping circles", () => {
+    const { fills } = utils.buildGeofencesGeoJSON([zone(7, 48, 11, 120)], require("@colota/shared").lightColors)
+    expect(fills.features[0].properties.radius).toBe(120)
+  })
+})

--- a/apps/mobile/src/components/features/map/mapUtils.ts
+++ b/apps/mobile/src/components/features/map/mapUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ThemeColors, Geofence } from "../../../types/global"
+import { size } from "../../../constants"
 
 /** MapLibre line-layer style for colored track segments (`color` is a per-feature property). */
 export const TRACK_LINE_STYLE: any = {
@@ -250,7 +251,8 @@ export function buildGeofencesGeoJSON(
         fillColor,
         fillOpacity: 0.3,
         strokeColor: fillColor,
-        pauseTracking: zone.pauseTracking
+        pauseTracking: zone.pauseTracking,
+        radius: zone.radius
       },
       geometry: createCirclePolygon([zone.lon, zone.lat], zone.radius)
     })
@@ -383,4 +385,38 @@ export function darkifyStyle(style: any): object {
   }
 
   return result
+}
+
+const METERS_PER_DEGREE = 111_320
+
+/** The box around every zone's circle, for fitBounds. */
+export function geofenceBounds(geofences: Geofence[]): [number, number, number, number] {
+  let west = Infinity
+  let south = Infinity
+  let east = -Infinity
+  let north = -Infinity
+  for (const zone of geofences) {
+    const dLat = zone.radius / METERS_PER_DEGREE
+    const dLon = zone.radius / (METERS_PER_DEGREE * Math.cos((zone.lat * Math.PI) / 180))
+    west = Math.min(west, zone.lon - dLon)
+    east = Math.max(east, zone.lon + dLon)
+    south = Math.min(south, zone.lat - dLat)
+    north = Math.max(north, zone.lat + dLat)
+  }
+  return [west, south, east, north]
+}
+
+/** A zone circle takes a 48 dp target like a point does. */
+export const ZONE_HITBOX = { top: size.touch / 2, right: size.touch / 2, bottom: size.touch / 2, left: size.touch / 2 }
+
+/** Where circles overlap, the smallest is the one the finger meant; it is the one the others hide. */
+export function pickSmallestZone(features: GeoJSON.Feature[]): number | null {
+  let best: { id: number; radius: number } | null = null
+  for (const f of features) {
+    const id = f.properties?.id
+    const radius = f.properties?.radius ?? Infinity
+    if (typeof id !== "number") continue
+    if (!best || radius < best.radius) best = { id, radius }
+  }
+  return best?.id ?? null
 }

--- a/apps/mobile/src/screens/GeofenceScreen.tsx
+++ b/apps/mobile/src/screens/GeofenceScreen.tsx
@@ -3,155 +3,180 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useEffect, useRef, useMemo, useCallback } from "react"
-import { View, StyleSheet, FlatList, DeviceEventEmitter, Share, useWindowDimensions } from "react-native"
-import { radius } from "@colota/shared"
+import React, { useState, useEffect, useRef, useMemo, useCallback, useLayoutEffect } from "react"
+import { View, StyleSheet, ScrollView, Pressable, DeviceEventEmitter, Share, useWindowDimensions } from "react-native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { useFocusEffect } from "@react-navigation/native"
 import { useTheme } from "../hooks/useTheme"
 import NativeLocationService from "../services/NativeLocationService"
 import { showAlert } from "../services/modalService"
 import { Geofence, ScreenProps } from "../types/global"
 import { useTracking, useCoords } from "../contexts/TrackingProvider"
-import { MapPinHouse, Share2, Plus } from "lucide-react-native"
-import { Button, Card, Container, Divider, EmptyState, IconButton, ListItem, SectionTitle } from "../components"
-import { DEFAULT_MAP_ZOOM, MAP_ANIMATION_DURATION_MS, WORLD_MAP_ZOOM, space } from "../constants"
-import { MapCenterButton } from "../components/features/map/MapCenterButton"
+import { MapPinHouse, MapPinCheck, Share2, Plus, LocateFixed, type LucideIcon } from "lucide-react-native"
+import { Card, Container, Divider, EmptyState, ListItem } from "../components"
+import {
+  DEFAULT_MAP_ZOOM,
+  GEOFENCE_ZOOM_PADDING,
+  MAP_ANIMATION_DURATION_MS,
+  WORLD_MAP_ZOOM,
+  size,
+  space,
+  STATE_LAYER_ALPHA
+} from "../constants"
+import { MapActionButton } from "../components/features/map/MapActionButton"
 import { ColotaMapView, ColotaMapRef } from "../components/features/map/ColotaMapView"
-import { buildGeofencesGeoJSON } from "../components/features/map/mapUtils"
+import { buildGeofencesGeoJSON, geofenceBounds } from "../components/features/map/mapUtils"
 import { GeofenceLayers } from "../components/features/map/GeofenceLayers"
 import { UserLocationOverlay } from "../components/features/map/UserLocationOverlay"
 import { logger } from "../utils/logger"
-import { formatShortDistance } from "../utils/geo"
+import { zoneRowSub } from "../utils/geofenceRow"
 import { buildGeofencesLink } from "../utils/setupLink"
 
-const ZoneSeparator = () => <Divider tight />
+const MAP_VIEWPORT_SHARE = 0.5
+const WORLD_CENTER: [number, number] = [0, 20]
 
-const GeofenceMap = React.memo(function GeofenceMapView({
-  tracking,
-  geofenceData,
-  currentPauseZone
+type Fix = { latitude: number; longitude: number; accuracy: number }
+
+function HeaderAction({
+  icon: Icon,
+  label,
+  color,
+  onPress,
+  testID
 }: {
-  tracking: boolean
-  geofenceData: ReturnType<typeof buildGeofencesGeoJSON>
-  currentPauseZone: string | null
+  icon: LucideIcon
+  label: string
+  color: string
+  onPress: () => void
+  testID: string
 }) {
-  const coords = useCoords()
-  const { colors } = useTheme()
-
-  const mapRef = useRef<ColotaMapRef>(null)
-  const isCenteredRef = useRef(true)
-  const [isCentered, setIsCentered] = useState(true)
-  const [hasInitialCoords, setHasInitialCoords] = useState(false)
-  const initialCenter = useRef<{ latitude: number; longitude: number; accuracy: number } | null>(null)
-
-  useEffect(() => {
-    if (hasInitialCoords) return
-    if (coords) {
-      initialCenter.current = { latitude: coords.latitude, longitude: coords.longitude, accuracy: coords.accuracy ?? 0 }
-      setHasInitialCoords(true)
-      return
-    }
-    NativeLocationService.getMostRecentLocation().then((latest) => {
-      if (initialCenter.current) return
-      initialCenter.current = latest
-        ? { latitude: latest.latitude, longitude: latest.longitude, accuracy: latest.accuracy ?? 0 }
-        : { latitude: 0, longitude: 0, accuracy: 0 }
-      setHasInitialCoords(true)
-    })
-  }, [coords, hasInitialCoords])
-
-  useEffect(() => {
-    if (!coords || !isCenteredRef.current || !tracking || !mapRef.current?.camera) return
-    mapRef.current.camera.easeTo({
-      center: [coords.longitude, coords.latitude],
-      duration: MAP_ANIMATION_DURATION_MS
-    })
-  }, [coords, tracking])
-
-  const handleCenterMe = useCallback(() => {
-    if (coords && mapRef.current?.camera) {
-      mapRef.current.camera.flyTo({
-        center: [coords.longitude, coords.latitude],
-        zoom: DEFAULT_MAP_ZOOM,
-        duration: MAP_ANIMATION_DURATION_MS
-      })
-      isCenteredRef.current = true
-      setIsCentered(true)
-    }
-  }, [coords])
-
-  const handleRegionChange = useCallback((payload: { isUserInteraction: boolean }) => {
-    if (payload.isUserInteraction) {
-      isCenteredRef.current = false
-      setIsCentered(false)
-    }
-  }, [])
-
-  const hasRealCoords =
-    initialCenter.current && (initialCenter.current.latitude !== 0 || initialCenter.current.longitude !== 0)
-  const initialZoom = hasRealCoords ? DEFAULT_MAP_ZOOM : WORLD_MAP_ZOOM
-
   return (
-    <View style={[styles.map, { borderRadius: radius.sm }]}>
-      {hasInitialCoords && initialCenter.current ? (
-        <ColotaMapView
-          ref={mapRef}
-          initialCenter={[initialCenter.current.longitude, initialCenter.current.latitude]}
-          initialZoom={initialZoom}
-          onRegionDidChange={handleRegionChange}
-        >
-          <GeofenceLayers fills={geofenceData.fills} labels={geofenceData.labels} haloColor={colors.card} />
-          {coords && tracking && <UserLocationOverlay coords={coords} isPaused={!!currentPauseZone} colors={colors} />}
-        </ColotaMapView>
-      ) : null}
-      <MapCenterButton visible={!isCentered && tracking} onPress={handleCenterMe} />
-    </View>
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      android_ripple={{ color: color + STATE_LAYER_ALPHA, borderless: true, radius: size.touch / 2 }}
+      style={styles.headerAction}
+      testID={testID}
+    >
+      <Icon size={size.icon.lg} color={color} />
+    </Pressable>
   )
-})
-
-const MAP_VIEWPORT_SHARE = 0.4
+}
 
 export function GeofenceScreen({ navigation }: ScreenProps) {
   const { height: viewportHeight } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
   const mapHeight = Math.round(viewportHeight * MAP_VIEWPORT_SHARE)
   const { tracking } = useTracking()
+  const coords = useCoords()
   const { colors } = useTheme()
 
-  const [geofences, setGeofences] = useState<Geofence[]>([])
+  const [geofences, setGeofences] = useState<Geofence[] | null>(null)
   const [currentPauseZone, setCurrentPauseZone] = useState<string | null>(null)
+  // `undefined` until the database has answered, so the tiles never open on the world view and jump.
+  const [lastFix, setLastFix] = useState<Fix | null | undefined>(undefined)
+  const [mapReady, setMapReady] = useState(false)
+  const [panned, setPanned] = useState(false)
+  const mapRef = useRef<ColotaMapRef>(null)
+  const fittedRef = useRef<string | null>(null)
 
   const loadGeofences = useCallback(async () => {
     try {
-      const data = await NativeLocationService.getGeofences()
-      setGeofences(data)
+      setGeofences(await NativeLocationService.getGeofences())
     } catch (err) {
       logger.error("[GeofenceScreen] Failed to load geofences:", err)
     }
   }, [])
 
-  useEffect(() => {
-    loadGeofences()
-  }, [loadGeofences])
-
-  useEffect(() => {
-    const checkPauseZone = async () => {
-      try {
-        const result = await NativeLocationService.checkCurrentPauseZone()
-        setCurrentPauseZone(result?.zoneName ?? null)
-      } catch (err) {
-        logger.error("[GeofenceScreen] Failed to check pause zone:", err)
-      }
+  const checkPauseZone = useCallback(async () => {
+    try {
+      const result = await NativeLocationService.checkCurrentPauseZone()
+      setCurrentPauseZone(result?.zoneName ?? null)
+    } catch (err) {
+      logger.error("[GeofenceScreen] Failed to check pause zone:", err)
     }
+  }, [])
 
-    checkPauseZone()
-    const listener = DeviceEventEmitter.addListener("geofenceUpdated", () => {
-      checkPauseZone()
+  useFocusEffect(
+    useCallback(() => {
       loadGeofences()
+      checkPauseZone()
+    }, [loadGeofences, checkPauseZone])
+  )
+
+  useEffect(() => {
+    const updated = DeviceEventEmitter.addListener("geofenceUpdated", () => {
+      loadGeofences()
+      checkPauseZone()
     })
-    return () => listener.remove()
-  }, [loadGeofences])
+    const zone = DeviceEventEmitter.addListener(
+      "onPauseZoneChange",
+      (data: { entered: boolean; zoneName: string | null }) => setCurrentPauseZone(data.entered ? data.zoneName : null)
+    )
+    return () => {
+      updated.remove()
+      zone.remove()
+    }
+  }, [loadGeofences, checkPauseZone])
+
+  useEffect(() => {
+    if (coords) {
+      setLastFix({ latitude: coords.latitude, longitude: coords.longitude, accuracy: coords.accuracy ?? 0 })
+      return
+    }
+    let active = true
+    NativeLocationService.getMostRecentLocation()
+      .then((latest) => {
+        if (!active) return
+        setLastFix(
+          latest ? { latitude: latest.latitude, longitude: latest.longitude, accuracy: latest.accuracy ?? 0 } : null
+        )
+      })
+      .catch((err) => {
+        logger.error("[GeofenceScreen] Failed to read the last known location:", err)
+        if (active) setLastFix(null)
+      })
+    return () => {
+      active = false
+    }
+  }, [coords])
+
+  const edgeStart = space.lg + insets.left
+  const edgeEnd = space.lg + insets.right
+  const controlsBottom = space.lg + space.sm
+  const cameraPadding = useMemo(
+    () => ({ top: space.lg, bottom: space.lg, left: edgeStart, right: edgeEnd + size.iconColumn + space.lg }),
+    [edgeStart, edgeEnd]
+  )
+  const fitPadding = useMemo(() => {
+    const [top, right, bottom, left] = GEOFENCE_ZOOM_PADDING
+    return {
+      top: top + cameraPadding.top,
+      right: right + cameraPadding.right,
+      bottom: bottom + cameraPadding.bottom,
+      left: left + cameraPadding.left
+    }
+  }, [cameraPadding])
+
+  const fitZones = useCallback(
+    (zones: Geofence[], duration: number) => {
+      mapRef.current?.camera?.fitBounds(geofenceBounds(zones), { padding: fitPadding, duration })
+      setPanned(false)
+    },
+    [fitPadding]
+  )
+
+  const zoneKey = geofences?.map((z) => z.id).join(",") ?? null
+  useEffect(() => {
+    if (!mapReady || !geofences || geofences.length === 0 || zoneKey === fittedRef.current) return
+    // The first fit lands before the tiles show; a changed zone set animates so the eye can follow.
+    fitZones(geofences, fittedRef.current === null ? 0 : MAP_ANIMATION_DURATION_MS)
+    fittedRef.current = zoneKey
+  }, [mapReady, geofences, zoneKey, fitZones])
 
   const handleShareGeofences = useCallback(async () => {
-    if (geofences.length === 0) return
+    if (!geofences || geofences.length === 0) return
     try {
       await Share.share({ message: buildGeofencesLink(geofences) })
     } catch (err) {
@@ -160,73 +185,150 @@ export function GeofenceScreen({ navigation }: ScreenProps) {
     }
   }, [geofences])
 
-  const geofenceData = useMemo(() => buildGeofencesGeoJSON(geofences, colors), [geofences, colors])
-
-  const renderItem = useCallback(
-    ({ item }: { item: Geofence }) => {
-      const modes = [item.pauseOnWifi && "WiFi pause", item.pauseOnMotionless && "motionless pause"].filter(Boolean)
-      return (
-        <ListItem
-          testID={`edit-geofence-${item.id}`}
-          icon={MapPinHouse}
-          label={item.name}
-          sub={[`${formatShortDistance(item.radius)} radius`, ...modes].join(" · ")}
-          onPress={() => navigation.navigate("Geofence Editor", { geofenceId: item.id })}
-        />
-      )
+  const openEditor = useCallback(
+    (geofenceId?: number) => {
+      navigation.navigate("Geofence Editor", geofenceId === undefined ? {} : { geofenceId })
     },
     [navigation]
   )
 
+  const hasZones = (geofences?.length ?? 0) > 0
+  const renderHeaderActions = useCallback(
+    () => (
+      <View style={styles.headerRow}>
+        {hasZones && (
+          <HeaderAction
+            icon={Share2}
+            label="Share all geofences"
+            color={colors.text}
+            onPress={handleShareGeofences}
+            testID="share-geofences-btn"
+          />
+        )}
+        <HeaderAction
+          icon={Plus}
+          label="Create geofence"
+          color={colors.text}
+          onPress={() => openEditor()}
+          testID="add-geofence-btn"
+        />
+      </View>
+    ),
+    [hasZones, colors.text, handleShareGeofences, openEditor]
+  )
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerRight: renderHeaderActions })
+  }, [navigation, renderHeaderActions])
+
+  const handleRegionChange = useCallback((payload: { isUserInteraction: boolean }) => {
+    if (payload.isUserInteraction) setPanned(true)
+  }, [])
+
+  const handleFit = useCallback(() => {
+    if (geofences && geofences.length > 0) {
+      fitZones(geofences, MAP_ANIMATION_DURATION_MS)
+    } else if (lastFix) {
+      mapRef.current?.camera?.flyTo({
+        center: [lastFix.longitude, lastFix.latitude],
+        zoom: DEFAULT_MAP_ZOOM,
+        padding: cameraPadding,
+        duration: MAP_ANIMATION_DURATION_MS
+      })
+      setPanned(false)
+    }
+  }, [geofences, lastFix, fitZones, cameraPadding])
+
+  const geofenceData = useMemo(() => buildGeofencesGeoJSON(geofences ?? [], colors), [geofences, colors])
+  const liveFix = tracking && coords ? coords : null
+  const showDisc = panned && (hasZones || lastFix !== null)
+
   return (
     <Container>
       <View style={{ height: mapHeight }}>
-        <GeofenceMap tracking={tracking} geofenceData={geofenceData} currentPauseZone={currentPauseZone} />
-      </View>
-
-      <View style={styles.listWrap}>
-        <Button
-          title="Create geofence"
-          icon={Plus}
-          testID="add-geofence-btn"
-          onPress={() => navigation.navigate("Geofence Editor", {})}
-        />
-
-        {geofences.length > 0 && (
-          <View style={styles.activeHeader}>
-            <SectionTitle>Active geofences ({geofences.length})</SectionTitle>
-            <IconButton
-              icon={Share2}
-              testID="share-geofences-btn"
-              accessibilityLabel="Share all zones"
-              onPress={handleShareGeofences}
+        {lastFix !== undefined && (
+          <ColotaMapView
+            ref={mapRef}
+            initialCenter={lastFix ? [lastFix.longitude, lastFix.latitude] : WORLD_CENTER}
+            initialZoom={lastFix ? DEFAULT_MAP_ZOOM : WORLD_MAP_ZOOM}
+            cameraPadding={cameraPadding}
+            controlsBottom={controlsBottom}
+            controlsEnd={edgeEnd}
+            onRegionDidChange={handleRegionChange}
+            onMapReady={() => setMapReady(true)}
+          >
+            <GeofenceLayers
+              fills={geofenceData.fills}
+              labels={geofenceData.labels}
+              haloColor={colors.card}
+              onPressZone={openEditor}
             />
-          </View>
+            {liveFix && <UserLocationOverlay coords={liveFix} isPaused={!!currentPauseZone} colors={colors} />}
+          </ColotaMapView>
         )}
-        <Card rows style={styles.listCard}>
-          <FlatList
-            data={geofences}
-            keyExtractor={(item) => item.id!.toString()}
-            contentContainerStyle={styles.listContent}
-            ItemSeparatorComponent={ZoneSeparator}
-            showsVerticalScrollIndicator={false}
-            renderItem={renderItem}
-          />
-        </Card>
-        {geofences.length === 0 && (
-          <EmptyState title="No geofences yet" hint="Create a geofence to stop recording locations in specific areas" />
+        {showDisc && (
+          <MapActionButton
+            anchored={false}
+            style={[styles.disc, { bottom: controlsBottom + size.iconColumn + space.lg, right: edgeEnd }]}
+            accessibilityRole="button"
+            accessibilityLabel={hasZones ? "Fit geofences" : "Centre map on my position"}
+            onPress={handleFit}
+            testID="fit-geofences-btn"
+          >
+            <LocateFixed size={size.icon.md} color={colors.textLight} />
+          </MapActionButton>
         )}
       </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        {geofences === null ? null : hasZones ? (
+          <Card rows>
+            {geofences.map((zone, i) => {
+              const pausedHere = tracking && currentPauseZone === zone.name
+              return (
+                <React.Fragment key={zone.id}>
+                  {i > 0 && <Divider tight inset />}
+                  <ListItem
+                    testID={`edit-geofence-${zone.id}`}
+                    icon={pausedHere ? MapPinCheck : MapPinHouse}
+                    label={zone.name}
+                    sub={zoneRowSub(zone, pausedHere)}
+                    onPress={() => openEditor(zone.id)}
+                  />
+                </React.Fragment>
+              )
+            })}
+          </Card>
+        ) : (
+          <EmptyState
+            icon={MapPinHouse}
+            title="No geofences yet"
+            hint="A geofence stops recording while you are inside it."
+            action={{ label: "Create geofence", onPress: () => openEditor() }}
+            style={styles.empty}
+          />
+        )}
+      </ScrollView>
     </Container>
   )
 }
 
 const styles = StyleSheet.create({
-  map: { flex: 1, overflow: "hidden" },
-  listWrap: { flex: 1, padding: space.lg },
-  // ListItem cancels the padding of whatever contains it, and inside a list that is the content
-  // container rather than the card. Moving this back onto the card clips the leading icon.
-  listCard: { flex: 1, paddingHorizontal: 0 },
-  listContent: { paddingHorizontal: space.lg },
-  activeHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" }
+  headerRow: {
+    flexDirection: "row"
+  },
+  headerAction: {
+    padding: space.md
+  },
+  disc: {
+    position: "absolute"
+  },
+  content: {
+    flexGrow: 1,
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.xxl
+  },
+  empty: {
+    paddingHorizontal: 0
+  }
 })

--- a/apps/mobile/src/screens/LocationInspectorScreen.tsx
+++ b/apps/mobile/src/screens/LocationInspectorScreen.tsx
@@ -15,7 +15,7 @@ import {
   Merge,
   RotateCcwClock,
   Route,
-  Share,
+  Upload,
   Table,
   Trash2,
   X,
@@ -484,7 +484,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
     () => (
       <View style={styles.headerRow}>
         <HeaderAction
-          icon={Share}
+          icon={Upload}
           label="Export selected trips"
           color={colors.text}
           rippleColor={colors.text}
@@ -546,7 +546,7 @@ export function LocationHistoryScreen({ navigation, route }: RootScreenProps<"Lo
         )}
         {trips.length > 0 && (
           <HeaderAction
-            icon={Share}
+            icon={Upload}
             label="Export day"
             color={colors.text}
             rippleColor={colors.text}

--- a/apps/mobile/src/screens/TripDetailScreen.tsx
+++ b/apps/mobile/src/screens/TripDetailScreen.tsx
@@ -6,7 +6,7 @@
 import React, { useMemo, useState, useCallback, useLayoutEffect, useEffect, useRef } from "react"
 import { View, Text, StyleSheet, ScrollView, Pressable, useWindowDimensions } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { Share, Trash2, Route, Clock, Gauge, MapPin, TrendingUp, TrendingDown } from "lucide-react-native"
+import { Upload, Trash2, Route, Clock, Gauge, MapPin, TrendingUp, TrendingDown } from "lucide-react-native"
 import { useTheme } from "../hooks/useTheme"
 import { fontSizes, fonts } from "../styles/typography"
 // Deep paths on purpose: the components barrel re-exports DashboardMap, which reaches
@@ -241,7 +241,7 @@ export function TripDetailScreen({ route, navigation }: RootScreenProps<"Trip De
           style={styles.headerBtn}
           testID="export-trip-btn"
         >
-          <Share size={size.icon.md} color={colors.text} />
+          <Upload size={size.icon.md} color={colors.text} />
         </Pressable>
         <Pressable
           accessibilityRole="button"

--- a/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/GeofenceScreen.test.tsx
@@ -1,392 +1,338 @@
 import React from "react"
-import { render, fireEvent, waitFor } from "@testing-library/react-native"
-import { Share } from "react-native"
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native"
+import { DeviceEventEmitter, Share } from "react-native"
 import { Geofence } from "../../types/global"
-
-// --- Mocks ---
-
-jest.mock("@maplibre/maplibre-react-native", () => {
-  const R = require("react")
-  const { View } = require("react-native")
-  return {
-    __esModule: true,
-    Map: (props: any) => R.createElement(View, { testID: "mapview", ...props }),
-    Camera: () => null,
-    GeoJSONSource: ({ children }: any) => children,
-    Layer: () => null,
-    Marker: ({ children }: any) => children
-  }
-})
+import { GEOFENCE_ZOOM_PADDING, size, space } from "../../constants"
 
 jest.mock("@react-navigation/native", () => ({
-  useFocusEffect: jest.fn()
+  useFocusEffect: (cb: () => (() => void) | void) => {
+    const R = require("react")
+    R.useEffect(() => {
+      const cleanup = cb()
+      return typeof cleanup === "function" ? cleanup : undefined
+    }, [cb])
+  }
+}))
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })
 }))
 
 jest.mock("../../hooks/useTheme", () => ({
-  useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textDisabled: "#d1d5db",
-      card: "#fff",
-      warning: "#f59e0b",
-      info: "#3b82f6",
-      background: "#fff",
-      border: "#e5e7eb",
-      success: "#22c55e",
-      error: "#ef4444",
-      link: "#0d9488",
-      textLight: "#9ca3af",
-      textOnPrimary: "#fff",
-      placeholder: "#d1d5db",
-      primaryDark: "#0d9488",
-      backgroundElevated: "#f9fafb",
-      surface: "#fff",
-      overlay: "rgba(0,0,0,0.5)"
-    },
-    mode: "light"
-  })
+  useTheme: () => ({ colors: require("@colota/shared").lightColors, mode: "light" })
 }))
 
+let mockTracking = true
+let mockCoords: { latitude: number; longitude: number; accuracy: number } | null = null
 jest.mock("../../contexts/TrackingProvider", () => ({
-  useTracking: () => ({ tracking: true }),
-  useCoords: () => ({ latitude: 48.1, longitude: 11.5, accuracy: 10 })
+  useTracking: () => ({ tracking: mockTracking }),
+  useCoords: () => mockCoords
 }))
 
-const mockGetGeofences = jest.fn().mockResolvedValue([])
-const mockCreateGeofence = jest.fn().mockResolvedValue(undefined)
-const mockUpdateGeofence = jest.fn().mockResolvedValue(undefined)
-const mockDeleteGeofence = jest.fn().mockResolvedValue(undefined)
-const mockCheckCurrentPauseZone = jest.fn().mockResolvedValue(null)
-const mockIsNetworkAvailable = jest.fn().mockResolvedValue(true)
-const mockRecheckZoneSettings = jest.fn().mockResolvedValue(undefined)
-const mockGetMostRecentLocation = jest.fn().mockResolvedValue(null)
-
+const mockGetGeofences = jest.fn()
+const mockCheckCurrentPauseZone = jest.fn()
+const mockGetMostRecentLocation = jest.fn()
 jest.mock("../../services/NativeLocationService", () => ({
   __esModule: true,
   default: {
     getGeofences: (...args: any[]) => mockGetGeofences(...args),
-    createGeofence: (...args: any[]) => mockCreateGeofence(...args),
-    updateGeofence: (...args: any[]) => mockUpdateGeofence(...args),
-    deleteGeofence: (...args: any[]) => mockDeleteGeofence(...args),
     checkCurrentPauseZone: (...args: any[]) => mockCheckCurrentPauseZone(...args),
-    isNetworkAvailable: (...args: any[]) => mockIsNetworkAvailable(...args),
-    recheckZoneSettings: (...args: any[]) => mockRecheckZoneSettings(...args),
-    getMostRecentLocation: (...args: any[]) => mockGetMostRecentLocation(...args),
-    getSetting: jest.fn().mockResolvedValue(null)
+    getMostRecentLocation: (...args: any[]) => mockGetMostRecentLocation(...args)
   }
 }))
 
 const mockShowAlert = jest.fn()
-
 jest.mock("../../services/modalService", () => ({
   showAlert: (...args: any[]) => mockShowAlert(...args)
 }))
 
+const mockFitBounds = jest.fn()
+const mockFlyTo = jest.fn()
+const mockMapProps = jest.fn()
 jest.mock("../../components/features/map/ColotaMapView", () => {
   const R = require("react")
-  const { View } = require("react-native")
-  const { Pressable } = require("react-native")
+  const { View, Pressable } = require("react-native")
   return {
-    ColotaMapView: R.forwardRef(({ children, onPress }: any, _ref: any) =>
-      R.createElement(
+    ColotaMapView: R.forwardRef((props: any, ref: any) => {
+      R.useImperativeHandle(ref, () => ({ camera: { fitBounds: mockFitBounds, flyTo: mockFlyTo }, mapView: null }))
+      mockMapProps(props)
+      return R.createElement(
         View,
         { testID: "colota-map" },
+        R.createElement(Pressable, { testID: "map-ready", onPress: () => props.onMapReady?.() }),
         R.createElement(Pressable, {
-          testID: "map-press",
-          onPress: () => onPress?.({ latitude: 52.5, longitude: 13.4 })
+          testID: "map-pan",
+          onPress: () => props.onRegionDidChange?.({ isUserInteraction: true })
         }),
-        children
+        props.children
       )
-    )
+    })
   }
 })
 
 jest.mock("../../components/features/map/GeofenceLayers", () => {
   const R = require("react")
-  const { View } = require("react-native")
+  const { View, Pressable } = require("react-native")
   return {
-    GeofenceLayers: () => R.createElement(View, { testID: "geofence-layers" })
+    GeofenceLayers: (props: any) =>
+      R.createElement(
+        View,
+        { testID: "geofence-layers", ...props },
+        props.onPressZone && R.createElement(Pressable, { testID: "tap-zone-2", onPress: () => props.onPressZone(2) })
+      )
   }
 })
 
 jest.mock("../../components/features/map/UserLocationOverlay", () => {
   const R = require("react")
   const { View } = require("react-native")
-  return {
-    UserLocationOverlay: () => R.createElement(View, { testID: "user-location-overlay" })
-  }
+  return { UserLocationOverlay: (props: any) => R.createElement(View, { testID: "user-location-overlay", ...props }) }
 })
 
-jest.mock("../../components/features/map/MapCenterButton", () => {
+jest.mock("../../components/features/map/MapActionButton", () => {
   const R = require("react")
-  const { View } = require("react-native")
+  const { Pressable } = require("react-native")
   return {
-    MapCenterButton: () => R.createElement(View, { testID: "center-button" })
+    MapActionButton: (props: any) =>
+      R.createElement(Pressable, {
+        testID: props.testID,
+        accessibilityRole: "button",
+        accessibilityLabel: props.accessibilityLabel,
+        onPress: props.onPress,
+        style: props.style
+      })
   }
 })
-
-jest.mock("../../components/features/map/mapUtils", () => ({
-  buildGeofencesGeoJSON: jest.fn().mockReturnValue({ fills: null, labels: null })
-}))
 
 jest.mock("../../components", () => {
   const R = require("react")
   const { View, Text, Pressable } = require("react-native")
   return {
-    EmptyState: require("../../testing/componentStubs").EmptyStateStub,
-    IconButton: require("../../testing/componentStubs").IconButtonStub,
-    TextField: require("../../testing/componentStubs").TextFieldStub,
-    Button: function (props: any) {
-      return require("react").createElement(
-        require("react-native").Pressable,
-        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
-        require("react").createElement(require("react-native").Text, null, props.title)
-      )
-    },
-    Toggle: function (props: any) {
-      return require("react").createElement(require("react-native").Switch, {
-        testID: props.testID,
-        value: props.value,
-        onValueChange: props.onValueChange,
-        disabled: props.disabled,
-        accessibilityLabel: props.accessibilityLabel
-      })
-    },
     Container: ({ children }: any) => R.createElement(View, null, children),
-    SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
-    Card: ({ children, style }: any) => R.createElement(View, { style }, children),
-    Divider: () => R.createElement(View, null),
-    ListItem: ({ label, sub, onPress, testID }: any) =>
+    Card: ({ children }: any) => R.createElement(View, { testID: "zone-card" }, children),
+    Divider: () => null,
+    EmptyState: ({ title, hint, action }: any) =>
+      R.createElement(
+        View,
+        { testID: "EmptyState" },
+        R.createElement(Text, null, title),
+        R.createElement(Text, null, hint),
+        action &&
+          R.createElement(
+            Pressable,
+            { testID: "empty-action", onPress: action.onPress },
+            R.createElement(Text, null, action.label)
+          )
+      ),
+    ListItem: ({ label, sub, onPress, testID, icon }: any) =>
       R.createElement(
         Pressable,
-        { testID, onPress, accessibilityRole: "button" },
+        { accessibilityRole: "button", onPress, testID, accessibilityLabel: `${label}, ${sub}` },
         R.createElement(Text, null, label),
-        R.createElement(Text, null, sub)
+        R.createElement(Text, null, sub),
+        R.createElement(Text, { testID: `${testID}-glyph` }, icon?.displayName ?? icon?.name ?? "icon")
       )
-  }
-})
-
-jest.mock("../../assets/icons/icon.png", () => "mock-icon")
-
-jest.mock("lucide-react-native", () => {
-  const R = require("react")
-  const { Text } = require("react-native")
-  return {
-    ChevronRight: (props: any) => R.createElement(Text, props, "ChevronRight"),
-    Wifi: (props: any) => R.createElement(Text, props, "Wifi"),
-    PersonStanding: (props: any) => R.createElement(Text, props, "PersonStanding"),
-    MapPinHouse: (props: any) => R.createElement(Text, props, "MapPinHouse"),
-    Share2: (props: any) => R.createElement(Text, props, "Share2"),
-    Plus: (props: any) => R.createElement(Text, props, "Plus"),
-    X: (props: any) => R.createElement(Text, props, "X")
   }
 })
 
 jest.mock("../../utils/logger", () => ({
-  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn(), info: jest.fn() }
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }
 }))
 
 jest.mock("../../utils/geo", () => ({
-  formatShortDistance: (meters: number) => `${Math.round(meters)}m`,
-  shortDistanceUnit: () => "m",
-  inputToMeters: (value: number) => value
+  ...jest.requireActual("../../utils/geo"),
+  formatShortDistance: (m: number) => `${m}m`
 }))
 
 import { GeofenceScreen } from "../GeofenceScreen"
 
-// --- Test data ---
+const zone = (id: number, name: string, overrides: Partial<Geofence> = {}): Geofence => ({
+  id,
+  name,
+  lat: 48.1 + id * 0.01,
+  lon: 11.5,
+  radius: 100 * id,
+  enabled: true,
+  pauseTracking: true,
+  pauseOnWifi: id === 1,
+  pauseOnMotionless: false,
+  motionlessTimeoutMinutes: 5,
+  heartbeatEnabled: false,
+  heartbeatIntervalMinutes: 15,
+  ...overrides
+})
+const zones = [zone(1, "Home"), zone(2, "Office", { pauseTracking: false })]
 
-const mockGeofences: Geofence[] = [
-  {
-    id: 1,
-    name: "Home",
-    lat: 48.1,
-    lon: 11.5,
-    radius: 100,
-    enabled: true,
-    pauseTracking: true,
-    pauseOnWifi: false,
-    pauseOnMotionless: false,
-    motionlessTimeoutMinutes: 10,
-    heartbeatEnabled: false,
-    heartbeatIntervalMinutes: 15
-  },
-  {
-    id: 2,
-    name: "Office",
-    lat: 48.2,
-    lon: 11.6,
-    radius: 200,
-    enabled: true,
-    pauseTracking: false,
-    pauseOnWifi: false,
-    pauseOnMotionless: false,
-    motionlessTimeoutMinutes: 10,
-    heartbeatEnabled: false,
-    heartbeatIntervalMinutes: 15
-  }
-]
+const lastOptions = (props: any) => props.navigation.setOptions.mock.calls.at(-1)[0]
+const headerRight = (props: any) => render(lastOptions(props).headerRight())
 
-// --- Tests ---
+function createProps() {
+  return { navigation: { navigate: jest.fn(), setOptions: jest.fn() } } as any
+}
+
+async function renderReady(props = createProps()) {
+  const utils = render(<GeofenceScreen {...props} />)
+  await waitFor(() => expect(utils.getByTestId("colota-map")).toBeTruthy())
+  fireEvent.press(utils.getByTestId("map-ready"))
+  await act(async () => {})
+  return { ...utils, props }
+}
 
 describe("GeofenceScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetGeofences.mockResolvedValue([])
+    mockTracking = true
+    mockCoords = null
+    mockGetGeofences.mockResolvedValue(zones)
+    mockCheckCurrentPauseZone.mockResolvedValue(null)
+    mockGetMostRecentLocation.mockResolvedValue({ latitude: 48.1, longitude: 11.5, accuracy: 8 })
   })
 
-  function renderScreen() {
-    return render(<GeofenceScreen navigation={{ setOptions: jest.fn() } as any} />)
-  }
+  it("lists every geofence as a row that says what it does, with no header counting them", async () => {
+    const { getByText, queryByText, getByTestId } = await renderReady()
 
-  it("shows empty state when no geofences exist", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("No geofences yet")).toBeTruthy()
-    })
+    expect(getByTestId("zone-card")).toBeTruthy()
+    expect(getByText("Home")).toBeTruthy()
+    expect(getByText("100m · WiFi pause")).toBeTruthy()
+    expect(getByText("200m · recording continues")).toBeTruthy()
+    expect(queryByText(/Active geofences/)).toBeNull()
+    expect(queryByText("Create geofence")).toBeNull()
   })
 
-  it("renders geofence list with name and radius", async () => {
-    mockGetGeofences.mockResolvedValue(mockGeofences)
-
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Home")).toBeTruthy()
-      expect(getByText("100m radius")).toBeTruthy()
-      expect(getByText("Office")).toBeTruthy()
-      expect(getByText("200m radius")).toBeTruthy()
-    })
-  })
-
-  it("creates through the editor, so a zone is configured before it exists", async () => {
-    const navigate = jest.fn()
-    const { getByTestId } = render(<GeofenceScreen navigation={{ navigate, setOptions: jest.fn() } as any} />)
-
-    await waitFor(() => expect(getByTestId("add-geofence-btn")).toBeTruthy())
-    fireEvent.press(getByTestId("add-geofence-btn"))
-
-    expect(navigate).toHaveBeenCalledWith("Geofence Editor", {})
-    expect(mockCreateGeofence).not.toHaveBeenCalled()
-  })
-
-  it("opens the editor from the zone row", async () => {
-    mockGetGeofences.mockResolvedValue(mockGeofences)
-    const mockNavigate = jest.fn()
-
-    const { getByTestId } = render(
-      <GeofenceScreen navigation={{ navigate: mockNavigate, setOptions: jest.fn() } as any} />
-    )
-
-    await waitFor(() => expect(getByTestId("edit-geofence-1")).toBeTruthy())
+  it("opens the editor from a row, from a circle on the map and from the header Create", async () => {
+    const { getByTestId, props } = await renderReady()
 
     fireEvent.press(getByTestId("edit-geofence-1"))
+    expect(props.navigation.navigate).toHaveBeenCalledWith("Geofence Editor", { geofenceId: 1 })
 
-    expect(mockNavigate).toHaveBeenCalledWith("Geofence Editor", { geofenceId: 1 })
+    fireEvent.press(getByTestId("tap-zone-2"))
+    expect(props.navigation.navigate).toHaveBeenLastCalledWith("Geofence Editor", { geofenceId: 2 })
+
+    fireEvent.press(headerRight(props).getByLabelText("Create geofence"))
+    expect(props.navigation.navigate).toHaveBeenLastCalledWith("Geofence Editor", {})
   })
 
-  describe("share geofences", () => {
-    let shareSpy: jest.SpyInstance
+  it("shares every geofence from the header, only once there is one to share", async () => {
+    const shareSpy = jest.spyOn(Share, "share").mockResolvedValue({ action: "sharedAction", activityType: undefined })
+    const { props } = await renderReady()
 
-    beforeEach(() => {
-      shareSpy = jest.spyOn(Share, "share").mockResolvedValue({ action: "sharedAction", activityType: undefined })
+    const bar = headerRight(props)
+    fireEvent.press(bar.getByLabelText("Share all geofences"))
+    await waitFor(() => expect(shareSpy).toHaveBeenCalledWith({ message: expect.stringContaining("colota://setup") }))
+
+    mockGetGeofences.mockResolvedValue([])
+    const emptyProps = createProps()
+    await renderReady(emptyProps)
+    expect(headerRight(emptyProps).queryByLabelText("Share all geofences")).toBeNull()
+    shareSpy.mockRestore()
+  })
+
+  it("says so when the share sheet fails", async () => {
+    const shareSpy = jest.spyOn(Share, "share").mockRejectedValue(new Error("no sheet"))
+    const { props } = await renderReady()
+
+    fireEvent.press(headerRight(props).getByLabelText("Share all geofences"))
+
+    await waitFor(() => expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to share geofences.", "error"))
+    shareSpy.mockRestore()
+  })
+
+  it("marks the geofence you stand in with a check and the words Paused here, and clears it when you leave", async () => {
+    mockCheckCurrentPauseZone.mockResolvedValue({ zoneName: "Home", pauseReason: "wifi" })
+    const { getByText, queryByText, getByTestId } = await renderReady()
+
+    await waitFor(() => expect(getByText("Paused here · 100m · WiFi pause")).toBeTruthy())
+    expect(getByTestId("edit-geofence-1-glyph").props.children).toBe("MapPinCheck")
+    expect(getByTestId("edit-geofence-2-glyph").props.children).toBe("MapPinHouse")
+
+    act(() => {
+      DeviceEventEmitter.emit("onPauseZoneChange", { entered: false, zoneName: null, pauseReason: null })
     })
+    await waitFor(() => expect(queryByText(/Paused here/)).toBeNull())
 
-    afterEach(() => {
-      shareSpy.mockRestore()
+    act(() => {
+      DeviceEventEmitter.emit("onPauseZoneChange", { entered: true, zoneName: "Home", pauseReason: "wifi" })
     })
+    await waitFor(() => expect(getByText(/^Paused here/)).toBeTruthy())
+  })
 
-    it("does not render the share button when there are no geofences", async () => {
-      const { queryByTestId, getByText } = renderScreen()
+  it("fits the camera to every geofence once the map is ready, inside the control column, and again only when the set changes", async () => {
+    const { getByTestId } = await renderReady()
 
-      await waitFor(() => {
-        expect(getByText("No geofences yet")).toBeTruthy()
-      })
-
-      expect(queryByTestId("share-geofences-btn")).toBeNull()
+    expect(mockFitBounds).toHaveBeenCalledTimes(1)
+    const [bounds, options] = mockFitBounds.mock.calls[0]
+    expect(bounds[1]).toBeLessThan(48.11)
+    expect(bounds[3]).toBeGreaterThan(48.12)
+    expect(options.padding).toEqual({
+      top: GEOFENCE_ZOOM_PADDING[0] + space.lg,
+      right: GEOFENCE_ZOOM_PADDING[1] + space.lg + size.iconColumn + space.lg,
+      bottom: GEOFENCE_ZOOM_PADDING[2] + space.lg,
+      left: GEOFENCE_ZOOM_PADDING[3] + space.lg
     })
+    expect(options.duration).toBe(0)
 
-    it("renders the share button when at least one geofence exists", async () => {
-      mockGetGeofences.mockResolvedValue(mockGeofences)
-      const { getByTestId } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByTestId("share-geofences-btn")).toBeTruthy()
-      })
+    act(() => {
+      DeviceEventEmitter.emit("geofenceUpdated")
     })
+    await act(async () => {})
+    expect(mockFitBounds).toHaveBeenCalledTimes(1)
 
-    it("opens the share sheet with a colota://setup link on press", async () => {
-      mockGetGeofences.mockResolvedValue(mockGeofences)
-      const { getByTestId } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByTestId("share-geofences-btn")).toBeTruthy()
-      })
-
-      fireEvent.press(getByTestId("share-geofences-btn"))
-
-      await waitFor(() => {
-        expect(shareSpy).toHaveBeenCalledTimes(1)
-      })
-
-      const arg = shareSpy.mock.calls[0][0]
-      expect(arg.message).toMatch(/^colota:\/\/setup\?config=/)
+    mockGetGeofences.mockResolvedValue([...zones, zone(3, "Gym")])
+    act(() => {
+      DeviceEventEmitter.emit("geofenceUpdated")
     })
+    await waitFor(() => expect(mockFitBounds).toHaveBeenCalledTimes(2))
+    expect(mockFitBounds.mock.calls[1][1].duration).toBeGreaterThan(0)
+    expect(getByTestId("colota-map")).toBeTruthy()
+  })
 
-    it("encodes geofences without id, createdAt, or enabled fields", async () => {
-      mockGetGeofences.mockResolvedValue(mockGeofences)
-      const { getByTestId } = renderScreen()
+  it("offers a fit disc only after a pan, and hides it again once pressed", async () => {
+    const { getByTestId, queryByTestId, getByLabelText } = await renderReady()
 
-      await waitFor(() => {
-        expect(getByTestId("share-geofences-btn")).toBeTruthy()
-      })
+    expect(queryByTestId("fit-geofences-btn")).toBeNull()
+    fireEvent.press(getByTestId("map-pan"))
+    const disc = getByLabelText("Fit geofences")
+    expect(disc.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ bottom: space.lg + space.sm + size.iconColumn + space.lg })])
+    )
 
-      fireEvent.press(getByTestId("share-geofences-btn"))
+    fireEvent.press(disc)
+    expect(mockFitBounds).toHaveBeenCalledTimes(2)
+    expect(queryByTestId("fit-geofences-btn")).toBeNull()
+  })
 
-      await waitFor(() => {
-        expect(shareSpy).toHaveBeenCalledTimes(1)
-      })
+  it("shows the empty tab under a map on the last fix, with one action, and the disc centres on the fix after a pan", async () => {
+    mockGetGeofences.mockResolvedValue([])
+    const { getByText, getByTestId, queryByTestId, getByLabelText, props } = await renderReady()
 
-      const link = shareSpy.mock.calls[0][0].message as string
-      const encoded = link.split("config=")[1]
-      const decoded = JSON.parse(atob(encoded))
+    expect(queryByTestId("zone-card")).toBeNull()
+    expect(getByText("No geofences yet")).toBeTruthy()
+    expect(mockMapProps.mock.calls[0][0].initialCenter).toEqual([11.5, 48.1])
+    fireEvent.press(getByTestId("empty-action"))
+    expect(props.navigation.navigate).toHaveBeenCalledWith("Geofence Editor", {})
 
-      expect(decoded.geofences).toHaveLength(2)
-      expect(decoded.geofences[0]).toEqual({
-        name: "Home",
-        lat: 48.1,
-        lon: 11.5,
-        radius: 100,
-        pauseTracking: true,
-        pauseOnWifi: false,
-        pauseOnMotionless: false,
-        motionlessTimeoutMinutes: 10,
-        heartbeatEnabled: false,
-        heartbeatIntervalMinutes: 15
-      })
-      expect(decoded.geofences[0]).not.toHaveProperty("id")
-      expect(decoded.geofences[0]).not.toHaveProperty("createdAt")
-      expect(decoded.geofences[0]).not.toHaveProperty("enabled")
-    })
+    fireEvent.press(getByTestId("map-pan"))
+    fireEvent.press(getByLabelText("Centre map on my position"))
+    expect(mockFlyTo).toHaveBeenCalledWith(expect.objectContaining({ center: [11.5, 48.1] }))
+    expect(mockFitBounds).not.toHaveBeenCalled()
+  })
 
-    it("shows an error alert when sharing fails", async () => {
-      mockGetGeofences.mockResolvedValue(mockGeofences)
-      shareSpy.mockRejectedValueOnce(new Error("share failed"))
+  it("draws no tiles until the database has answered, so the map never opens on the world view and jumps", async () => {
+    mockGetMostRecentLocation.mockReturnValue(new Promise(() => {}))
+    const { queryByTestId } = render(<GeofenceScreen {...createProps()} />)
+    await act(async () => {})
 
-      const { getByTestId } = renderScreen()
+    expect(queryByTestId("colota-map")).toBeNull()
+  })
 
-      await waitFor(() => {
-        expect(getByTestId("share-geofences-btn")).toBeTruthy()
-      })
+  it("draws the live dot only while tracking, greyed inside the geofence you are paused in", async () => {
+    mockCoords = { latitude: 48.1, longitude: 11.5, accuracy: 4 }
+    mockCheckCurrentPauseZone.mockResolvedValue({ zoneName: "Home", pauseReason: null })
+    const { getByTestId } = await renderReady()
+    await waitFor(() => expect(getByTestId("user-location-overlay").props.isPaused).toBe(true))
 
-      fireEvent.press(getByTestId("share-geofences-btn"))
-
-      await waitFor(() => {
-        expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to share geofences.", "error")
-      })
-    })
+    mockTracking = false
+    const { queryByTestId } = await renderReady()
+    expect(queryByTestId("user-location-overlay")).toBeNull()
   })
 })

--- a/apps/mobile/src/utils/__tests__/geofenceRow.test.ts
+++ b/apps/mobile/src/utils/__tests__/geofenceRow.test.ts
@@ -1,0 +1,42 @@
+import { zoneRowSub } from "../geofenceRow"
+import type { Geofence } from "../../types/global"
+
+jest.mock("../geo", () => ({
+  formatShortDistance: (m: number) => `${m}m`
+}))
+
+const zone = (overrides: Partial<Geofence> = {}): Geofence => ({
+  id: 1,
+  name: "Home",
+  lat: 48.1,
+  lon: 11.5,
+  radius: 50,
+  enabled: true,
+  pauseTracking: true,
+  pauseOnWifi: false,
+  pauseOnMotionless: false,
+  motionlessTimeoutMinutes: 5,
+  heartbeatEnabled: false,
+  heartbeatIntervalMinutes: 15,
+  ...overrides
+})
+
+describe("zoneRowSub", () => {
+  it("names the radius and every pause mode that is on, so the row says what the zone does", () => {
+    expect(zoneRowSub(zone({ pauseOnWifi: true, pauseOnMotionless: true }), false)).toBe(
+      "50m · WiFi pause · motionless pause"
+    )
+    expect(zoneRowSub(zone({ pauseOnWifi: true }), false)).toBe("50m · WiFi pause")
+    expect(zoneRowSub(zone(), false)).toBe("50m")
+  })
+
+  it("says recording continues when the master switch is off, since the modes do nothing then", () => {
+    expect(zoneRowSub(zone({ pauseTracking: false, pauseOnWifi: true, pauseOnMotionless: true }), false)).toBe(
+      "50m · recording continues"
+    )
+  })
+
+  it("leads with Paused here for the zone you stand in, so the state survives an ellipsis", () => {
+    expect(zoneRowSub(zone({ pauseOnWifi: true }), true)).toBe("Paused here · 50m · WiFi pause")
+  })
+})

--- a/apps/mobile/src/utils/geofenceRow.ts
+++ b/apps/mobile/src/utils/geofenceRow.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import type { Geofence } from "../types/global"
+import { formatShortDistance } from "./geo"
+
+/** The caption under a zone's name: what it does, and "Paused here" first when you stand in it. */
+export function zoneRowSub(zone: Geofence, pausedHere: boolean): string {
+  const parts: string[] = []
+  if (pausedHere) parts.push("Paused here")
+  parts.push(formatShortDistance(zone.radius))
+  if (!zone.pauseTracking) {
+    // The pause modes are inert without the master switch, so naming them would promise a pause that never comes.
+    parts.push("recording continues")
+  } else {
+    if (zone.pauseOnWifi) parts.push("WiFi pause")
+    if (zone.pauseOnMotionless) parts.push("motionless pause")
+  }
+  return parts.join(" · ")
+}

--- a/packages/shared/src/colors.ts
+++ b/packages/shared/src/colors.ts
@@ -119,7 +119,7 @@ export const darkColors: ThemeColors = {
   // Border & divider
   border: "#767676",
   borderLight: "#333333",
-  divider: "#333333",
+  divider: "#505050",
 
   // Interactive
   placeholder: "#AAAAAA",


### PR DESCRIPTION
Geofences takes the siblings' grammar: app-bar Create and Share, a half map fitted to the zones, one card of rows with the zone you stand in marked, a circle tap opening the editor. Second commit: export, import and share each keep one glyph, and the dark divider becomes visible.