### PR TITLE
refactor(ui): save indicator floats on the raised surface

### DIFF
--- a/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
+++ b/apps/mobile/src/components/ui/FloatingSaveIndicator.tsx
@@ -6,8 +6,9 @@
 import React, { useEffect, useRef } from "react"
 import { radius } from "@colota/shared"
 import { View, Text, StyleSheet, Animated } from "react-native"
-import { Check } from "lucide-react-native"
+import { Check, CircleAlert } from "lucide-react-native"
 import { SpinningLoader } from "./SpinningLoader"
+import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts } from "../../styles/typography"
 import { size, space, elevation } from "../../constants"
 
@@ -16,15 +17,10 @@ interface Props {
   /** Shown once the work is done; absent when there is nothing to report. */
   message?: string | null
   isError?: boolean
-  colors: {
-    info: string
-    success: string
-    error: string
-    text: string
-  }
 }
 
-export const FloatingSaveIndicator: React.FC<Props> = ({ saving, message, isError, colors }) => {
+export const FloatingSaveIndicator: React.FC<Props> = ({ saving, message, isError }) => {
+  const { colors } = useTheme()
   const hasMessage = message != null
   const visible = hasMessage || saving
 
@@ -48,19 +44,18 @@ export const FloatingSaveIndicator: React.FC<Props> = ({ saving, message, isErro
   const displayText = hasMessage ? message : "Saving..."
 
   return (
-    <Animated.View style={[styles.container, { opacity, transform: [{ translateY }] }]} pointerEvents="none">
-      <View
-        style={[
-          styles.badge,
-          {
-            backgroundColor: saving ? colors.info : isError ? colors.error : colors.success
-          }
-        ]}
-      >
+    <Animated.View
+      style={[styles.container, { opacity, transform: [{ translateY }] }]}
+      pointerEvents="none"
+      testID="floating-save-indicator"
+    >
+      <View style={[styles.badge, { backgroundColor: colors.surfaceRaised }]} testID="floating-save-indicator-pill">
         {saving ? (
-          <SpinningLoader size={size.icon.sm} color={colors.text} />
-        ) : isError ? null : (
-          <Check size={size.icon.sm} color={colors.text} />
+          <SpinningLoader size={size.icon.sm} color={colors.textSecondary} />
+        ) : isError ? (
+          <CircleAlert size={size.icon.sm} color={colors.error} />
+        ) : (
+          <Check size={size.icon.sm} color={colors.success} />
         )}
         <Text style={[styles.text, { color: colors.text }]}>{displayText}</Text>
       </View>
@@ -71,11 +66,10 @@ export const FloatingSaveIndicator: React.FC<Props> = ({ saving, message, isErro
 const styles = StyleSheet.create({
   container: {
     position: "absolute",
-    bottom: 20,
+    bottom: space.xl,
     left: 0,
     right: 0,
     alignItems: "center",
-    zIndex: 1000,
     pointerEvents: "none"
   },
   badge: {

--- a/apps/mobile/src/components/ui/__tests__/FloatingSaveIndicator.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/FloatingSaveIndicator.test.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { StyleSheet } from "react-native"
+import { lightColors } from "@colota/shared"
+import { space } from "../../../constants"
+import { FloatingSaveIndicator } from "../FloatingSaveIndicator"
+
+jest.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
+
+jest.mock("lucide-react-native", () => {
+  const R = require("react")
+  const { View } = require("react-native")
+  const stub = (name: string) => (props: Record<string, unknown>) =>
+    R.createElement(View, { testID: `icon-${name}`, ...props })
+  return { Check: stub("check"), CircleAlert: stub("alert"), Loader: stub("loader") }
+})
+
+const fill = (testID: string, api: ReturnType<typeof render>) =>
+  StyleSheet.flatten(api.getByTestId(testID).props.style).backgroundColor
+
+describe("FloatingSaveIndicator", () => {
+  it("paints the one raised surface in every state, so the verdict is never a fill colour", () => {
+    expect(fill("floating-save-indicator-pill", render(<FloatingSaveIndicator saving />))).toBe(
+      lightColors.surfaceRaised
+    )
+    expect(fill("floating-save-indicator-pill", render(<FloatingSaveIndicator saving={false} message="Saved" />))).toBe(
+      lightColors.surfaceRaised
+    )
+    expect(
+      fill(
+        "floating-save-indicator-pill",
+        render(<FloatingSaveIndicator saving={false} message="Could not save" isError />)
+      )
+    ).toBe(lightColors.surfaceRaised)
+  })
+
+  it("carries the state in the glyph and the word: a spinner, then a check or an alert", () => {
+    const saving = render(<FloatingSaveIndicator saving />)
+    expect(saving.getByTestId("icon-loader").props.color).toBe(lightColors.textSecondary)
+    expect(saving.getByText("Saving...")).toBeTruthy()
+
+    const done = render(<FloatingSaveIndicator saving={false} message="Tracking restarted" />)
+    expect(done.getByTestId("icon-check").props.color).toBe(lightColors.success)
+    expect(done.getByText("Tracking restarted")).toBeTruthy()
+
+    const failed = render(<FloatingSaveIndicator saving={false} message="Could not save" isError />)
+    expect(failed.getByTestId("icon-alert").props.color).toBe(lightColors.error)
+    expect(failed.queryByTestId("icon-check")).toBeNull()
+  })
+
+  it("floats at the 24 dp rhythm above the bottom edge and lets touches through", () => {
+    const { getByTestId } = render(<FloatingSaveIndicator saving />)
+    const container = StyleSheet.flatten(getByTestId("floating-save-indicator").props.style)
+    expect(container.bottom).toBe(space.xl)
+    expect(container.pointerEvents).toBe("none")
+  })
+})

--- a/apps/mobile/src/screens/ApiSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ApiSettingsScreen.tsx
@@ -731,7 +731,7 @@ export function ApiSettingsScreen({ navigation, route }: RootScreenProps<"Reques
       </ScrollView>
 
       {/* Floating Save Indicator */}
-      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/AuthSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AuthSettingsScreen.tsx
@@ -325,7 +325,7 @@ export function AuthSettingsScreen({ navigation }: ScreenProps) {
         </View>
       </ScrollView>
 
-      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/AutoExportScreen.tsx
+++ b/apps/mobile/src/screens/AutoExportScreen.tsx
@@ -661,7 +661,7 @@ export function AutoExportScreen(_props: ScreenProps) {
           </View>
         )}
       </ScrollView>
-      <FloatingSaveIndicator saving={saving} colors={colors} />
+      <FloatingSaveIndicator saving={saving} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/ConnectionScreen.tsx
+++ b/apps/mobile/src/screens/ConnectionScreen.tsx
@@ -52,7 +52,7 @@ export function ConnectionScreen({ navigation }: ScreenProps) {
         />
       </ScrollView>
 
-      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} />
     </Container>
   )
 }

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -386,7 +386,6 @@ export function DataManagementScreen({}: ScreenProps) {
           saving={isProcessing}
           message={feedback}
           isError={feedback?.toLowerCase().includes("failed") ?? false}
-          colors={colors}
         />
       </KeyboardAvoidingView>
     </Container>

--- a/apps/mobile/src/screens/TrackingSyncScreen.tsx
+++ b/apps/mobile/src/screens/TrackingSyncScreen.tsx
@@ -62,7 +62,7 @@ export function TrackingSyncScreen({}: ScreenProps) {
         />
       </ScrollView>
 
-      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} colors={colors} />
+      <FloatingSaveIndicator saving={saving} message={saveMessage} isError={saveIsError} />
     </Container>
   )
 }


### PR DESCRIPTION
One surfaceRaised pill for the save indicator on every settings screen; the glyph and the word carry the state. Callers no longer pass colors. STYLES.md and the src guide record the rule.
