### PR TITLE
refactor(settings): tracking and sync rows price what they set

### DIFF
--- a/apps/docs/docs/configuration/sync-presets.md
+++ b/apps/docs/docs/configuration/sync-presets.md
@@ -4,27 +4,29 @@ sidebar_position: 1
 
 # Sync Presets
 
-Colota includes built-in presets that configure tracking interval, movement threshold, and sync interval together.
+Colota includes built-in presets that configure interval, movement threshold, sync interval and retry interval together. Each row on the screen prints its fix rate, its sync cadence and what it costs.
 
-| Preset          | Interval | Distance | Sync Interval | Best For        |
-| --------------- | -------- | -------- | ------------- | --------------- |
-| **Instant**     | 5s       | 0m       | Instant (0s)  | City navigation |
-| **Balanced**    | 30s      | 2m       | 5 minutes     | Daily commute   |
-| **Power Saver** | 60s      | 2m       | 15 minutes    | Long trips      |
-| **Custom**      | 1s-∞     | 0m-∞     | 0s-∞          | Advanced users  |
+| Preset          | Interval | Distance | Sync interval | Retry interval | Cost                             |
+| --------------- | -------- | -------- | ------------- | -------------- | -------------------------------- |
+| **Instant**     | 5 s      | 0 m      | Each fix      | 30 s           | Most battery, finest track       |
+| **Balanced**    | 30 s     | 2 m      | 5 min         | 5 min          | Moderate battery, fewer wake-ups |
+| **Power saver** | 60 s     | 2 m      | 15 min        | 15 min         | Least battery, coarser track     |
+| **Custom**      | 1 s-∞    | 0 m-∞    | 0 s-∞         | last preset's  | Printed from the numbers you set |
 
-Select a preset in **Settings → Tracking & sync** or choose **Custom** to configure each parameter individually.
+Select a preset in **Settings → Tracking & sync → Recording** or choose **Custom** to set the interval and movement threshold under it. A preset owns those four values and nothing else: choosing a row in **Sync interval** or typing an interval there moves the preset to Custom, while the sync condition, the network name, the batch size and the accuracy filter leave it alone. The retry interval is how long a failed sync waits before the next attempt; Custom keeps whichever preset held it last.
+
+If a [tracking profile](/docs/guides/tracking-profiles) is active it supplies its own sync interval, and the **Sync interval** group opens with a line naming the profile and the cadence in force.
 
 ## Sync Condition
 
 Controls when Colota uploads locations. Locations are always recorded and queued locally regardless of this setting.
 
-| Option                     | Behavior                                             |
-| -------------------------- | ---------------------------------------------------- |
-| **Any network**            | Uploads over mobile data as well as Wi-Fi (default)  |
-| **Wi-Fi**                  | Uploads only on unmetered networks (Wi-Fi, Ethernet) |
-| **Specific Wi-Fi network** | Uploads only on one network you choose               |
-| **VPN**                    | Uploads only while a VPN is active                   |
+| Option                     | Behavior                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| **Any network**            | Syncs over mobile data as well as Wi-Fi, counting against your plan (default) |
+| **Wi-Fi or Ethernet**      | Syncs only on unmetered networks; fixes wait on mobile data                   |
+| **Specific Wi-Fi network** | Syncs only on the network you name; nothing syncs until one is named          |
+| **VPN**                    | Syncs only while a VPN is up                                                  |
 
 This is useful for:
 
@@ -32,8 +34,8 @@ This is useful for:
 - **Private backends** - Only sync when on your home network or VPN
 - **Roaming** - Prevent expensive data charges while traveling abroad
 
-Configure this in **Settings → Tracking & sync → Network settings → Sync only on**.
+Configure this in **Settings → Tracking & sync → Sync only on**. For a specific network, type the name as shown in Wi-Fi settings, or take the one the phone is on from the button under the field.
 
 ## Offline Mode
 
-In [offline mode](/docs/configuration/server-settings#offline-mode), network settings (sync interval, retry behavior, sync condition) are hidden since no syncing occurs. Preset descriptions adjust to show only tracking parameters. For displaying the maps network requests are still made to maps.mxd.codes. See [Offline maps](/docs/guides/offline-maps) for predownloading maps.
+In [offline mode](/docs/configuration/server-settings#offline-mode), the Sync interval and Sync only on groups are hidden since no syncing occurs, and the retry interval in the table above is not used. Preset rows show only their recording values. For displaying the maps network requests are still made to maps.mxd.codes. See [Offline maps](/docs/guides/offline-maps) for predownloading maps.

--- a/apps/docs/docs/configuration/tracking-settings.md
+++ b/apps/docs/docs/configuration/tracking-settings.md
@@ -4,28 +4,28 @@ sidebar_position: 2
 
 # Tracking Settings
 
-Found under **Settings → Tracking & sync → Tracking configuration**.
+Found under **Settings → Tracking & sync → Recording**. The accuracy filter has its own group, **Accuracy filter**, at the bottom of the same screen.
 
 ## Available Settings
 
-| Setting            | Description                          | Default   | Minimum |
-| ------------------ | ------------------------------------ | --------- | ------- |
-| Tracking Interval  | Time between GPS fixes               | 5 seconds | 1s      |
-| Movement Threshold | Minimum movement to trigger update   | 0         | 0       |
-| Accuracy Threshold | Filter out fixes above this accuracy | 50        | 1       |
-| Filter Inaccurate  | Enable/disable accuracy filtering    | Disabled  | On/Off  |
+| Setting                     | Description                       | Default   | Minimum |
+| --------------------------- | --------------------------------- | --------- | ------- |
+| Interval                    | Time between GPS fixes            | 5 seconds | 1 s     |
+| Movement threshold          | Minimum movement to keep a fix    | 0         | 0       |
+| Filter inaccurate locations | Enable/disable accuracy filtering | Off       | On/Off  |
+| Accuracy threshold          | Drop fixes rated worse than this  | 50        | 1       |
 
-The two distance settings use whichever unit you picked in **Settings → Appearance**, so they read as meters or feet. There is no upper limit on any of the three numbers.
+The interval and movement threshold sit under **Custom** in the Recording group; picking a preset sets both. The two distance settings use whichever unit you picked in **Settings → Appearance**, so they read as meters or feet. Every number field takes whole numbers only and states its minimum under its label; a value below it is set to the minimum when you leave the field. There is no upper limit on any of the three numbers.
 
 :::info[Tracking profiles override two of these]
 
-If a [tracking profile](/docs/guides/tracking-profiles) is active, it supplies its own tracking interval and movement threshold for as long as its condition holds. The values on this screen are what the app falls back to when no profile applies, so a profile is the usual reason fixes arrive at a different rate than the one set here.
+If a [tracking profile](/docs/guides/tracking-profiles) is active, it supplies its own interval, movement threshold and sync interval for as long as its condition holds. The Recording and Sync interval groups then open with a line naming the profile and the values in force, and the rows below stay the defaults the app falls back to when no profile applies. A profile is the usual reason fixes arrive at a different rate than the one set here.
 
 :::
 
-## Tracking Interval
+## Interval
 
-How often the app requests a GPS fix. Shorter intervals give denser track points but drain more battery.
+How often the app requests a GPS fix. Shorter intervals keep the GPS awake more of the time and record more points.
 
 - **1-5 seconds**: High detail, suitable for driving or cycling
 - **15-30 seconds**: Good balance for walking or commuting
@@ -33,14 +33,14 @@ How often the app requests a GPS fix. Shorter intervals give denser track points
 
 ## Movement Threshold
 
-Only records a new location if you've moved at least this far since the last recorded point. Useful for filtering out stationary noise.
+Only records a new location if you've moved at least this far since the last recorded point. Both the interval and this distance must pass before a fix is kept, so a higher threshold saves storage and sync data rather than battery. It is not applied inside a pause zone or by a stationary profile.
 
 - **0**: Record every GPS fix (default)
 - **10-50 m**: Skip stationary updates, good for daily use
 
 ## Accuracy Filter
 
-When enabled, GPS fixes with accuracy worse than the threshold are discarded. This prevents recording poor-quality positions from indoor or urban environments.
+When on, fixes the chip rates worse than the threshold are dropped. A stricter threshold leaves gaps indoors and in dense streets, where every fix is rated poorly. The switch's own caption carries the threshold in both states, so turning the filter off hides the field without losing the number.
 
 The accuracy value comes from the GPS chip's own estimate of its confidence, not from ground truth. Chips sometimes report a tight accuracy on a position that is badly wrong, and no threshold can reject those, because the fix does not admit to being imprecise. If a stationary device is filling your history with drift, the [Movement Threshold](#movement-threshold) is the setting that keeps those points out of the log.
 

--- a/apps/docs/docs/guides/tracking-profiles.md
+++ b/apps/docs/docs/guides/tracking-profiles.md
@@ -103,7 +103,7 @@ Note that Stationary has the highest priority so it takes over from Walking when
 - If the condition matches again before the delay expires, the timer is cancelled
 - After the delay expires, settings revert to the defaults configured in the Settings screen
 - Profile changes made in the editor take effect immediately on the running service
-- **Tracking & sync** names the active profile at the top. The values on that screen are the defaults the profile is overriding, not the ones in force
+- **Tracking & sync** shows the active profile above the Recording and Sync interval groups with the values in force. The rows below are the defaults the profile is overriding
 
 ## Active Profile Indicators
 

--- a/apps/docs/docs/guides/troubleshooting.md
+++ b/apps/docs/docs/guides/troubleshooting.md
@@ -130,9 +130,9 @@ If you denied the permission and the system no longer shows the dialog, reset it
 
 ## Locations not syncing on certain networks
 
-If **Sync Only On** is set to Wi-Fi, a specific SSID or VPN, uploads are skipped when the condition is not met. Locations continue to be recorded and queued locally - they sync automatically when the condition is satisfied.
+If **Sync only on** is set to Wi-Fi or Ethernet, a specific Wi-Fi network or VPN, uploads are skipped when the condition is not met. Locations continue to be recorded and queued locally - they sync automatically when the condition is satisfied.
 
-To change: **Settings > Advanced Settings > Network Settings > Sync Only On**.
+To change: **Settings > Tracking & sync > Sync only on**.
 
 ## Auto-export not working
 

--- a/apps/docs/docs/integrations/dawarich.md
+++ b/apps/docs/docs/integrations/dawarich.md
@@ -71,7 +71,7 @@ Bundles up to N queued points into a single request to `/api/v1/overland/batches
 
 **Endpoint URL**: change the saved endpoint to `https://dawarich.yourdomain.com/api/v1/overland/batches?api_key=YOUR_API_KEY`. The chip only updates the placeholder hint, not your saved endpoint.
 
-**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & sync > Advanced > Network Settings > Batch Size** (only shown when batch mode is active).
+**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & sync > Sync interval > Batch size** (only shown when batch mode is active).
 
 **Requires non-zero sync interval**: batch mode is incompatible with instant sync. Pick a batched preset or set a custom sync interval before enabling. The chip is disabled when sync interval is 0.
 

--- a/apps/docs/docs/integrations/overland.md
+++ b/apps/docs/docs/integrations/overland.md
@@ -14,7 +14,7 @@ Colota is a drop-in Android client for the [Overland](https://github.com/aaronpk
    https://overland.yourdomain.com/
    ```
    Some implementations use a path like `/api/v1/overland/batches`. Check your server's docs.
-3. **Choose a batched sync preset** (Balanced or Power Saver). Instant sync is not supported because Overland is a batch-only protocol.
+3. **Choose a batched sync preset** (Balanced or Power saver). Instant sync is not supported because Overland is a batch-only protocol.
 4. **Set a `device_id`** in custom fields if you want to override the default `"colota"`.
 
 ## Payload Format
@@ -49,7 +49,7 @@ Each upload is a single POST containing one or more locations as GeoJSON Feature
 
 ## Configuration
 
-**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & sync > Advanced > Network Settings > Batch Size**. Larger bundles mean fewer round trips but bigger payloads on flaky networks.
+**Batch size**: defaults to 50 points per POST, configurable 1-500 under **Settings > Tracking & sync > Sync interval > Batch size**. Larger bundles mean fewer round trips but bigger payloads on flaky networks.
 
 **HTTP method**: POST only. The Overland protocol does not support GET; the option is hidden when this template is selected.
 

--- a/apps/mobile/src/components/features/settings/SyncIntervalPicker.tsx
+++ b/apps/mobile/src/components/features/settings/SyncIntervalPicker.tsx
@@ -6,17 +6,30 @@
 import React, { useEffect, useRef, useState } from "react"
 import { View, Text, StyleSheet } from "react-native"
 import { useTheme } from "../../../hooks/useTheme"
+import { useTimeout } from "../../../hooks/useTimeout"
 import { fontSizes, fonts, lineHeights } from "../../../styles/typography"
-import { SYNC_INTERVAL_LABELS, SYNC_INTERVAL_PRESETS, size, space } from "../../../constants"
+import {
+  SAVE_SUCCESS_DISPLAY_MS,
+  SYNC_INTERVAL_LABELS,
+  SYNC_INTERVAL_PRESETS,
+  SYNC_INTERVAL_SUBS,
+  size,
+  space
+} from "../../../constants"
 import { NumericInput } from "../../ui/NumericInput"
 import { RadioRow } from "../../ui/RadioRow"
+import { formatDuration } from "../../../utils/dashboardState"
+import { parseWholeNumber, wholeNumberError } from "../../../utils/settingsValidation"
 
 type SyncIntervalPickerProps = {
-  label: string
-  hint: string
+  /** A heading above the group; the settings screen titles the card instead and passes neither. */
+  label?: string
+  hint?: string
   value: number
   /** The floor a blurred value is clamped to. Settings takes 1, a profile takes 0. */
   min?: number
+  /** Pull the first row up under a SectionTitle or the heading; off when a row precedes the group. */
+  pullUp?: boolean
   /** A preset row was chosen. */
   onSelect: (seconds: number) => void
   /** A valid number was typed into the custom field. */
@@ -40,6 +53,7 @@ export function SyncIntervalPicker({
   hint,
   value,
   min = 1,
+  pullUp = true,
   onSelect,
   onChange,
   onClamp,
@@ -48,6 +62,8 @@ export function SyncIntervalPicker({
   const { colors } = useTheme()
   const [customOpen, setCustomOpen] = useState(false)
   const [input, setInput] = useState(value.toString())
+  const [clampMessage, setClampMessage] = useState<string | undefined>()
+  const clampTimer = useTimeout()
   const isCustom = customOpen || !SYNC_INTERVAL_PRESETS.includes(value)
 
   const emitted = useRef(value)
@@ -63,18 +79,20 @@ export function SyncIntervalPicker({
     notify(seconds)
   }
 
+  const fieldHint = `${min > 0 ? `At least ${min} s. ` : ""}Longer means fewer requests and a later server.`
+
   return (
     <View>
-      <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
-      <Text style={[styles.hint, { color: colors.textSecondary }]}>{hint}</Text>
+      {label ? <Text style={[styles.label, { color: colors.text }]}>{label}</Text> : null}
+      {hint ? <Text style={[styles.hint, { color: colors.textSecondary }]}>{hint}</Text> : null}
 
-      <View accessibilityRole="radiogroup" style={styles.group}>
+      <View accessibilityRole="radiogroup" style={pullUp && styles.group}>
         {SYNC_INTERVAL_PRESETS.map((seconds) => (
           <RadioRow
             key={seconds}
             testID={`${testIDPrefix}-${seconds}`}
             label={SYNC_INTERVAL_LABELS[seconds]}
-            sub={seconds === 0 ? "Uploads each fix as soon as it is recorded" : undefined}
+            sub={SYNC_INTERVAL_SUBS[seconds]}
             selected={!isCustom && value === seconds}
             onPress={() => {
               setCustomOpen(false)
@@ -85,7 +103,13 @@ export function SyncIntervalPicker({
         <RadioRow
           testID={`${testIDPrefix}-custom`}
           label="Custom"
-          sub={isCustom ? `Every ${value} seconds` : "Set your own interval"}
+          sub={
+            isCustom
+              ? value === 0
+                ? "Syncs each fix"
+                : `Syncs every ${formatDuration(value)}`
+              : "Set your own interval"
+          }
           selected={isCustom}
           onPress={() => {
             setInput(value.toString())
@@ -96,22 +120,27 @@ export function SyncIntervalPicker({
         {isCustom && (
           <View style={styles.customField}>
             <NumericInput
-              label="Custom sync interval"
+              label="Sync interval"
               value={input}
               onChange={(next) => {
                 setInput(next)
-                const parsed = Number(next)
-                if (!isNaN(parsed) && parsed >= min) report(parsed, onChange)
+                setClampMessage(undefined)
+                const parsed = parseWholeNumber(next)
+                if (parsed !== null && parsed >= min) report(parsed, onChange)
               }}
               onBlur={() => {
-                const parsed = Number(input)
-                if (isNaN(parsed) || parsed < min) {
-                  setInput(min.toString())
-                  report(min, onClamp)
-                }
+                const parsed = parseWholeNumber(input)
+                if (parsed !== null && parsed >= min) return
+                setInput(min.toString())
+                setClampMessage(`Set to ${min} s`)
+                clampTimer.set(() => setClampMessage(undefined), SAVE_SUCCESS_DISPLAY_MS)
+                report(min, onClamp)
               }}
-              unit="seconds"
-              hint="Custom interval in seconds"
+              unit="s"
+              placeholder="300"
+              hint={fieldHint}
+              error={wholeNumberError(input, min, "s")}
+              message={clampMessage}
             />
           </View>
         )}
@@ -136,7 +165,6 @@ const styles = StyleSheet.create({
   },
   customField: {
     paddingLeft: size.iconColumn,
-    marginTop: -space.xs,
-    paddingBottom: space.lg
+    marginTop: -space.xs
   }
 })

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -3,56 +3,82 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useCallback, useEffect, useMemo } from "react"
-import { Text, StyleSheet, View, Pressable, AppState } from "react-native"
-import { Settings, TRACKING_PRESETS, SelectablePreset, ThemeColors, SyncCondition } from "../../../types/global"
+import React, { useState, useCallback, useEffect } from "react"
+import { Text, StyleSheet, View, AppState } from "react-native"
+import { UserRoundPen } from "lucide-react-native"
+import {
+  Settings,
+  TRACKING_PRESETS,
+  SelectablePreset,
+  SyncCondition,
+  SavedTrackingProfile
+} from "../../../types/global"
 import { fonts, fontSizes, lineHeights } from "../../../styles/typography"
-import { HIT_SLOP_MD, OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, size, space, STATE_LAYER_ALPHA } from "../../../constants"
-import { Card, NumericInput, RadioRow, SectionTitle, SettingRow, TextField, Toggle } from "../../index"
+import { OVERLAND_BATCH_MAX, OVERLAND_BATCH_MIN, SAVE_SUCCESS_DISPLAY_MS, size, space } from "../../../constants"
+import {
+  Button,
+  Card,
+  Divider,
+  NumericInput,
+  RadioRow,
+  SectionTitle,
+  SettingRow,
+  StateLine,
+  TextField,
+  Toggle
+} from "../../index"
 import { SyncIntervalPicker } from "./SyncIntervalPicker"
+import { useTheme } from "../../../hooks/useTheme"
+import { useTimeout } from "../../../hooks/useTimeout"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
+import { recordingSummary, syncSummary, trackingSummary } from "../../../utils/dashboardState"
+import { parseWholeNumber, wholeNumberError } from "../../../utils/settingsValidation"
 import { isOverlandFormat } from "../../../utils/apiPayload"
 import NativeLocationService from "../../../services/NativeLocationService"
-import { radius } from "@colota/shared"
 
 interface SyncStrategySettingsProps {
   settings: Settings
   onSettingsChange: (newSettings: Settings) => void
   onDebouncedSave: (newSettings: Settings) => void
   onImmediateSave: (newSettings: Settings) => void
-  activeProfileName?: string | null
-  colors: ThemeColors
+  /** The profile in force, whose values the Recording and Sync interval groups then show as overridden. */
+  activeProfile?: SavedTrackingProfile | null
 }
+
+type NumericKey = "interval" | "distance" | "accuracyThreshold"
+
+const NUMERIC_MIN: Record<NumericKey, number> = { interval: 1, distance: 0, accuracyThreshold: 1 }
 
 const SYNC_CONDITION_OPTIONS: { value: SyncCondition; label: string; sub: string }[] = [
-  { value: "any", label: "Any network", sub: "Uploads over mobile data as well as Wi-Fi" },
-  { value: "wifi_any", label: "Wi-Fi", sub: "Uploads only while connected to any Wi-Fi" },
-  { value: "wifi_ssid", label: "Specific Wi-Fi network", sub: "Uploads only on one network you choose" },
-  { value: "vpn", label: "VPN", sub: "Uploads only while a VPN is active" }
+  {
+    value: "any",
+    label: "Any network",
+    sub: "Mobile data and Wi-Fi · syncs never wait, counts against your data plan"
+  },
+  { value: "wifi_any", label: "Wi-Fi or Ethernet", sub: "Unmetered networks only · fixes wait on mobile data" },
+  { value: "wifi_ssid", label: "Specific Wi-Fi network", sub: "One network by name · fixes wait elsewhere" },
+  { value: "vpn", label: "VPN", sub: "Only while a VPN is up · fixes wait otherwise" }
 ]
 
-function presetSummary(preset: SelectablePreset, isOfflineMode: boolean): string {
-  const config = TRACKING_PRESETS[preset]
-  const base = isOfflineMode ? config.description.split(" • ")[0] : config.description
-  if (preset === "balanced") return `${base} • recommended`
-  if (config.batteryImpact === "High") return `${base} • high battery`
-  return base
-}
+const lowerFirst = (text: string) => text.charAt(0).toLowerCase() + text.slice(1)
 
 export function SyncStrategySettings({
   settings,
   onSettingsChange,
   onDebouncedSave,
   onImmediateSave,
-  activeProfileName,
-  colors
+  activeProfile = null
 }: SyncStrategySettingsProps) {
+  const { colors } = useTheme()
+  const unit = shortDistanceUnit()
   const [intervalInput, setIntervalInput] = useState(settings.interval.toString())
   const [distanceInput, setDistanceInput] = useState(metersToInput(settings.distance ?? 0).toString())
   const [accuracyThresholdInput, setAccuracyThresholdInput] = useState(
     metersToInput(settings.accuracyThreshold).toString()
   )
   const [overlandBatchSizeInput, setOverlandBatchSizeInput] = useState(settings.overlandBatchSize.toString())
+  const [clampMessage, setClampMessage] = useState<{ key: string; text: string } | null>(null)
+  const clampTimer = useTimeout()
   const showOverlandBatchSize = isOverlandFormat(settings.apiTemplate, settings.dawarichMode)
   const [currentSsid, setCurrentSsid] = useState("")
 
@@ -71,65 +97,52 @@ export function SyncStrategySettings({
     return () => sub.remove()
   }, [settings.syncCondition])
 
-  // Sync inputs with settings changes (e.g. preset selection)
+  // A preset press rewrites the fields; a keystroke that already means the stored value keeps its text.
   useEffect(() => {
-    setIntervalInput(settings.interval.toString())
-    setDistanceInput(metersToInput(settings.distance ?? 0).toString())
-    setAccuracyThresholdInput(metersToInput(settings.accuracyThreshold).toString())
-    setOverlandBatchSizeInput(settings.overlandBatchSize.toString())
-  }, [
-    settings.interval,
-    settings.distance,
-    settings.accuracyThreshold,
-    settings.syncInterval,
-    settings.overlandBatchSize
-  ])
+    const keep = (shown: number) => (text: string) => (parseWholeNumber(text) === shown ? text : shown.toString())
+    setIntervalInput(keep(settings.interval))
+    setDistanceInput(keep(metersToInput(settings.distance ?? 0)))
+    setAccuracyThresholdInput(keep(metersToInput(settings.accuracyThreshold)))
+    setOverlandBatchSizeInput(keep(settings.overlandBatchSize))
+  }, [settings.interval, settings.distance, settings.accuracyThreshold, settings.overlandBatchSize])
 
-  const handleNumericChange = useCallback(
-    (key: "interval" | "distance" | "accuracyThreshold", value: string, min: number = 0) => {
-      if (key === "interval") setIntervalInput(value)
-      if (key === "distance") setDistanceInput(value)
-      if (key === "accuracyThreshold") setAccuracyThresholdInput(value)
+  const noteClamp = (key: string, text: string) => {
+    setClampMessage({ key, text })
+    clampTimer.set(() => setClampMessage(null), SAVE_SUCCESS_DISPLAY_MS)
+  }
+  const clampNote = (key: string) => (clampMessage?.key === key ? clampMessage.text : undefined)
 
-      const num = Number(value)
-      if (!isNaN(num) && num >= min) {
-        const stored = key === "distance" || key === "accuracyThreshold" ? inputToMeters(num) : num
-        const next = { ...settings, [key]: stored, syncPreset: "custom" as const }
-        onDebouncedSave(next)
-      }
-    },
-    [settings, onDebouncedSave]
-  )
+  const setInput = (key: NumericKey, value: string) => {
+    if (key === "interval") setIntervalInput(value)
+    if (key === "distance") setDistanceInput(value)
+    if (key === "accuracyThreshold") setAccuracyThresholdInput(value)
+  }
+  const inputOf = (key: NumericKey) =>
+    key === "interval" ? intervalInput : key === "distance" ? distanceInput : accuracyThresholdInput
+  const toStored = (key: NumericKey, value: number) => (key === "interval" ? value : inputToMeters(value))
 
-  const handleNumericBlur = useCallback(
-    (key: "interval" | "distance" | "accuracyThreshold", min: number = 0) => {
-      const currentStr =
-        key === "interval" ? intervalInput : key === "distance" ? distanceInput : accuracyThresholdInput
-      let val = Number(currentStr)
+  const handleNumericChange = (key: NumericKey, value: string) => {
+    setInput(key, value)
+    setClampMessage(null)
+    const num = parseWholeNumber(value)
+    if (num === null || num < NUMERIC_MIN[key]) return
+    const next = { ...settings, [key]: toStored(key, num) }
+    onSettingsChange(next)
+    onDebouncedSave(next)
+  }
 
-      if (isNaN(val) || val < min) {
-        val = min
-        if (key === "interval") setIntervalInput(min.toString())
-        if (key === "distance") setDistanceInput(min.toString())
-        if (key === "accuracyThreshold") setAccuracyThresholdInput(min.toString())
-
-        const stored = key === "distance" || key === "accuracyThreshold" ? inputToMeters(val) : val
-        const next = { ...settings, [key]: stored }
-        onSettingsChange(next)
-        onImmediateSave(next)
-      }
-    },
-    [intervalInput, distanceInput, accuracyThresholdInput, settings, onSettingsChange, onImmediateSave]
-  )
+  const handleNumericBlur = (key: NumericKey) => {
+    const min = NUMERIC_MIN[key]
+    const num = parseWholeNumber(inputOf(key))
+    if (num !== null && num >= min) return
+    setInput(key, min.toString())
+    noteClamp(key, `Set to ${min} ${key === "interval" ? "s" : unit}`)
+    const next = { ...settings, [key]: toStored(key, min) }
+    onSettingsChange(next)
+    onImmediateSave(next)
+  }
 
   const isCustomPreset = settings.syncPreset === "custom"
-
-  const customSummary = useMemo(() => {
-    const track = `Track every ${settings.interval}s`
-    if (settings.isOfflineMode) return track
-    const send = settings.syncInterval === 0 ? "Send instantly" : `Batch ${Math.round(settings.syncInterval / 60)} min`
-    return `${track} • ${send}`
-  }, [settings.interval, settings.syncInterval, settings.isOfflineMode])
 
   const handleCustomSelect = useCallback(() => {
     const next: Settings = { ...settings, syncPreset: "custom" }
@@ -154,38 +167,85 @@ export function SyncStrategySettings({
     [settings, onSettingsChange, onImmediateSave]
   )
 
-  const handleGridSelect = useCallback(
-    (key: string, value: number) => {
-      const next = {
-        ...settings,
-        [key]: value,
-        syncPreset: "custom" as const
-      }
+  // A preset owns the sync interval, so changing it is Custom; nothing else on the screen flips the preset.
+  const handleSyncIntervalChange = useCallback(
+    (seconds: number, save: (next: Settings) => void) => {
+      const next: Settings = { ...settings, syncInterval: seconds, syncPreset: "custom" }
       onSettingsChange(next)
-      onDebouncedSave(next)
+      save(next)
     },
-    [settings, onSettingsChange, onDebouncedSave]
+    [settings, onSettingsChange]
   )
 
+  const handleBatchChange = (value: string) => {
+    setOverlandBatchSizeInput(value)
+    setClampMessage(null)
+    const num = parseWholeNumber(value)
+    if (num === null || num < OVERLAND_BATCH_MIN || num > OVERLAND_BATCH_MAX) return
+    const next = { ...settings, overlandBatchSize: num }
+    onSettingsChange(next)
+    onDebouncedSave(next)
+  }
+
+  const handleBatchBlur = () => {
+    const num = parseWholeNumber(overlandBatchSizeInput)
+    if (num !== null && num >= OVERLAND_BATCH_MIN && num <= OVERLAND_BATCH_MAX) return
+    const clamped = num === null || num < OVERLAND_BATCH_MIN ? OVERLAND_BATCH_MIN : OVERLAND_BATCH_MAX
+    setOverlandBatchSizeInput(clamped.toString())
+    noteClamp("batch", `Set to ${clamped} points`)
+    const next = { ...settings, overlandBatchSize: clamped }
+    onSettingsChange(next)
+    onImmediateSave(next)
+  }
+
+  const batchError = (() => {
+    if (overlandBatchSizeInput === "") return undefined
+    const num = parseWholeNumber(overlandBatchSizeInput)
+    if (num === null) return "A whole number"
+    if (num < OVERLAND_BATCH_MIN || num > OVERLAND_BATCH_MAX) return `${OVERLAND_BATCH_MIN} to ${OVERLAND_BATCH_MAX}`
+    return undefined
+  })()
+
+  const presetSub = (preset: SelectablePreset) => {
+    const config = TRACKING_PRESETS[preset]
+    return `${trackingSummary(config.interval, config.distance, config.syncInterval, settings.isOfflineMode)} · ${config.cost}`
+  }
+
+  const thresholdShown = `${metersToInput(settings.accuracyThreshold)} ${unit}`
+  const filterHint = settings.filterInaccurateLocations
+    ? `Drops fixes the chip rates worse than ${thresholdShown}. Stricter leaves gaps indoors.`
+    : `Every fix is kept. When on, fixes worse than ${thresholdShown} are dropped.`
+
+  const ssidTyped = settings.syncSsid
+  const offerCurrentSsid = currentSsid !== "" && currentSsid.toLowerCase() !== ssidTyped.toLowerCase()
+
   return (
-    <View style={styles.section}>
+    <View>
       <Text style={[styles.intro, { color: colors.textSecondary }]}>
-        How often a fix is recorded, and when it uploads
+        How often a fix is recorded and when it syncs. Changes apply at once and restart tracking.
       </Text>
-      {activeProfileName ? (
-        <Text testID="profile-override-notice" style={[styles.override, { color: colors.warning }]}>
-          {activeProfileName} is active and is overriding these values while its condition holds.
-        </Text>
-      ) : null}
-      <SectionTitle>Tracking configuration</SectionTitle>
+
+      <SectionTitle>Recording</SectionTitle>
       <Card rows>
-        <View accessibilityRole="radiogroup">
+        {activeProfile && (
+          <>
+            <StateLine
+              icon={UserRoundPen}
+              iconColor={colors.textSecondary}
+              label={`${activeProfile.name} is active`}
+              caption={`In force: ${lowerFirst(recordingSummary(activeProfile.interval, activeProfile.distance))}`}
+              testID="profile-override-recording"
+            />
+            <Divider tight />
+          </>
+        )}
+        <View accessibilityRole="radiogroup" style={!activeProfile && styles.group}>
           {(Object.keys(TRACKING_PRESETS) as SelectablePreset[]).map((preset) => (
             <RadioRow
               key={preset}
               testID={`preset-${preset}`}
               label={TRACKING_PRESETS[preset].label}
-              sub={presetSummary(preset, settings.isOfflineMode)}
+              sub={presetSub(preset)}
               selected={settings.syncPreset === preset}
               onPress={() => handlePresetSelect(preset)}
             />
@@ -193,31 +253,39 @@ export function SyncStrategySettings({
           <RadioRow
             testID="preset-custom"
             label="Custom"
-            sub={customSummary}
+            sub={
+              isCustomPreset
+                ? trackingSummary(settings.interval, settings.distance, settings.syncInterval, settings.isOfflineMode)
+                : "Your own interval and movement threshold"
+            }
             selected={isCustomPreset}
             onPress={handleCustomSelect}
           />
 
           {isCustomPreset && (
-            <View style={styles.customParams}>
+            <View style={styles.reveal}>
               <NumericInput
-                label="Tracking interval"
+                label="Interval"
                 value={intervalInput}
-                onChange={(val) => handleNumericChange("interval", val, 1)}
-                onBlur={() => handleNumericBlur("interval", 1)}
-                unit="seconds"
-                placeholder="1"
-                hint="How often to capture GPS position"
+                onChange={(val) => handleNumericChange("interval", val)}
+                onBlur={() => handleNumericBlur("interval")}
+                unit="s"
+                placeholder="30"
+                hint="At least 1 s. Shorter keeps the GPS awake more of the time and records more points."
+                error={wholeNumberError(intervalInput, NUMERIC_MIN.interval, "s")}
+                message={clampNote("interval")}
               />
 
               <NumericInput
                 label="Movement threshold"
                 value={distanceInput}
-                onChange={(val) => handleNumericChange("distance", val, 0)}
-                onBlur={() => handleNumericBlur("distance", 0)}
-                unit={shortDistanceUnit()}
-                placeholder="10"
-                hint="Only record if moved more than this distance"
+                onChange={(val) => handleNumericChange("distance", val)}
+                onBlur={() => handleNumericBlur("distance")}
+                unit={unit}
+                placeholder="2"
+                hint="0 keeps every fix. Both the interval and this distance must pass before a fix is kept; higher saves storage and sync data, not battery. Not applied in a pause zone or by a stationary profile."
+                error={wholeNumberError(distanceInput, NUMERIC_MIN.distance, unit)}
+                message={clampNote("distance")}
               />
             </View>
           )}
@@ -226,139 +294,129 @@ export function SyncStrategySettings({
 
       {!settings.isOfflineMode && (
         <>
-          <SectionTitle style={styles.groupTop}>Network settings</SectionTitle>
+          <SectionTitle style={styles.groupTop}>Sync interval</SectionTitle>
           <Card rows>
-            <View style={styles.settingBlock}>
-              <SyncIntervalPicker
-                label="Sync interval"
-                hint="How often to upload data to server"
-                value={settings.syncInterval}
-                onSelect={(seconds) => handleGridSelect("syncInterval", seconds)}
-                onChange={(seconds) => onDebouncedSave({ ...settings, syncInterval: seconds, syncPreset: "custom" })}
-                onClamp={(seconds) => {
-                  const next = { ...settings, syncInterval: seconds, syncPreset: "custom" as const }
-                  onSettingsChange(next)
-                  onImmediateSave(next)
-                }}
-              />
-            </View>
+            {activeProfile && (
+              <>
+                <StateLine
+                  icon={UserRoundPen}
+                  iconColor={colors.textSecondary}
+                  label={`${activeProfile.name} is active`}
+                  caption={`In force: ${syncSummary(activeProfile.syncInterval)}`}
+                  testID="profile-override-sync"
+                />
+                <Divider tight />
+              </>
+            )}
+            <SyncIntervalPicker
+              pullUp={!activeProfile}
+              value={settings.syncInterval}
+              onSelect={(seconds) => handleSyncIntervalChange(seconds, onImmediateSave)}
+              onChange={(seconds) => handleSyncIntervalChange(seconds, onDebouncedSave)}
+              onClamp={(seconds) => handleSyncIntervalChange(seconds, onImmediateSave)}
+            />
 
             {showOverlandBatchSize && (
-              <View style={styles.customSyncInput}>
-                <NumericInput
-                  label="Batch size"
-                  value={overlandBatchSizeInput}
-                  onChange={(val) => {
-                    setOverlandBatchSizeInput(val)
-                    const num = Number(val)
-                    if (!isNaN(num) && num >= OVERLAND_BATCH_MIN && num <= OVERLAND_BATCH_MAX) {
-                      const next = { ...settings, overlandBatchSize: num }
-                      onDebouncedSave(next)
-                    }
-                  }}
-                  onBlur={() => {
-                    let val = Number(overlandBatchSizeInput)
-                    if (isNaN(val) || val < OVERLAND_BATCH_MIN) val = OVERLAND_BATCH_MIN
-                    if (val > OVERLAND_BATCH_MAX) val = OVERLAND_BATCH_MAX
-                    if (val !== settings.overlandBatchSize || overlandBatchSizeInput !== val.toString()) {
-                      setOverlandBatchSizeInput(val.toString())
-                      const next = { ...settings, overlandBatchSize: val }
+              <>
+                <Divider tight />
+                <View style={styles.batch}>
+                  <NumericInput
+                    label="Batch size"
+                    value={overlandBatchSizeInput}
+                    onChange={handleBatchChange}
+                    onBlur={handleBatchBlur}
+                    unit="points"
+                    placeholder="50"
+                    hint={`${OVERLAND_BATCH_MIN} to ${OVERLAND_BATCH_MAX} points per request. Larger means fewer requests and bigger payloads.`}
+                    error={batchError}
+                    message={clampNote("batch")}
+                  />
+                </View>
+              </>
+            )}
+          </Card>
+
+          <SectionTitle style={styles.groupTop}>Sync only on</SectionTitle>
+          <Card rows>
+            <View accessibilityRole="radiogroup" style={styles.group}>
+              {SYNC_CONDITION_OPTIONS.map(({ value, label, sub }) => (
+                <React.Fragment key={value}>
+                  <RadioRow
+                    testID={`sync-condition-${value}`}
+                    label={label}
+                    sub={sub}
+                    selected={settings.syncCondition === value}
+                    onPress={() => {
+                      const next = { ...settings, syncCondition: value }
                       onSettingsChange(next)
                       onImmediateSave(next)
-                    }
-                  }}
-                  unit="points"
-                  placeholder="50"
-                  hint={`Points/upload (${OVERLAND_BATCH_MIN}-${OVERLAND_BATCH_MAX}). Larger = fewer requests, bigger payloads.`}
-                />
-              </View>
-            )}
-
-            {/* Sync Condition */}
-            <View style={styles.settingBlock}>
-              <Text style={[styles.blockLabel, { color: colors.text }]}>Sync only on</Text>
-              <View accessibilityRole="radiogroup">
-                {SYNC_CONDITION_OPTIONS.map(({ value, label, sub }) => (
-                  <React.Fragment key={value}>
-                    <RadioRow
-                      testID={`sync-condition-${value}`}
-                      label={label}
-                      sub={sub}
-                      selected={settings.syncCondition === value}
-                      onPress={() => {
-                        const next = { ...settings, syncCondition: value, syncPreset: "custom" as const }
-                        onSettingsChange(next)
-                        onImmediateSave(next)
-                      }}
-                    />
-                    {/* Belongs to its own row, not to the end of the group: VPN sits below it. */}
-                    {value === "wifi_ssid" && settings.syncCondition === "wifi_ssid" && (
-                      <View style={styles.ssidRow}>
-                        <TextField
-                          accessibilityLabel="Wi-Fi SSID"
-                          testID="sync-ssid-input"
-                          style={styles.ssidField}
-                          mono
-                          value={settings.syncSsid}
-                          onChangeText={(text) => {
-                            const next = { ...settings, syncSsid: text }
+                    }}
+                  />
+                  {/* Belongs to its own row, not to the end of the group: VPN sits below it. */}
+                  {value === "wifi_ssid" && settings.syncCondition === "wifi_ssid" && (
+                    <View style={[styles.reveal, offerCurrentSsid ? styles.revealButtonTail : styles.revealTail]}>
+                      <TextField
+                        label="Network name"
+                        testID="sync-ssid-input"
+                        mono
+                        value={ssidTyped}
+                        onChangeText={(text) => {
+                          const next = { ...settings, syncSsid: text }
+                          onSettingsChange(next)
+                          onDebouncedSave(next)
+                        }}
+                        placeholder="As shown in Wi-Fi settings"
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                        error={ssidTyped.trim() === "" ? "Nothing syncs until a network is named" : undefined}
+                      />
+                      {offerCurrentSsid && (
+                        <Button
+                          variant="secondary"
+                          title={`Use ${currentSsid}`}
+                          testID="sync-ssid-use"
+                          onPress={() => {
+                            const next = { ...settings, syncSsid: currentSsid }
                             onSettingsChange(next)
-                            onDebouncedSave(next)
+                            onImmediateSave(next)
                           }}
-                          placeholder="Enter Wi-Fi SSID"
-                          autoCapitalize="none"
-                          autoCorrect={false}
                         />
-                        {currentSsid !== "" && currentSsid.toLowerCase() !== settings.syncSsid.toLowerCase() && (
-                          <Pressable
-                            hitSlop={HIT_SLOP_MD}
-                            accessibilityRole="button"
-                            android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA }}
-                            style={[styles.ssidFillButton, { backgroundColor: colors.primary + "15" }]}
-                            onPress={() => {
-                              const next = { ...settings, syncSsid: currentSsid }
-                              onSettingsChange(next)
-                              onImmediateSave(next)
-                            }}
-                          >
-                            <Text style={[styles.ssidFillText, { color: colors.primary }]}>Use current</Text>
-                          </Pressable>
-                        )}
-                      </View>
-                    )}
-                  </React.Fragment>
-                ))}
-              </View>
+                      )}
+                    </View>
+                  )}
+                </React.Fragment>
+              ))}
             </View>
           </Card>
         </>
       )}
 
-      <SectionTitle style={styles.groupTop}>Quality filters</SectionTitle>
-      <Card rows style={styles.cardTail}>
-        <SettingRow label="Filter inaccurate locations" hint="Reject fixes the GPS chip reports as imprecise">
+      <SectionTitle style={styles.groupTop}>Accuracy filter</SectionTitle>
+      <Card rows>
+        <SettingRow label="Filter inaccurate locations" hint={filterHint}>
           <Toggle
             accessibilityLabel="Filter inaccurate locations"
             value={settings.filterInaccurateLocations}
-            onValueChange={(value) =>
-              onImmediateSave({
-                ...settings,
-                filterInaccurateLocations: value
-              })
-            }
+            onValueChange={(value) => {
+              const next = { ...settings, filterInaccurateLocations: value }
+              onSettingsChange(next)
+              onImmediateSave(next)
+            }}
           />
         </SettingRow>
 
         {settings.filterInaccurateLocations && (
-          <View style={styles.nestedSetting}>
+          <View style={styles.filterField}>
             <NumericInput
               label="Accuracy threshold"
               value={accuracyThresholdInput}
-              onChange={(val) => handleNumericChange("accuracyThreshold", val, 1)}
-              onBlur={() => handleNumericBlur("accuracyThreshold", 1)}
-              unit={shortDistanceUnit()}
+              onChange={(val) => handleNumericChange("accuracyThreshold", val)}
+              onBlur={() => handleNumericBlur("accuracyThreshold")}
+              unit={unit}
               placeholder="50"
-              hint="Based on the chip's own estimate, which can be optimistic"
+              hint={`At least 1 ${unit}. The chip's own estimate, often optimistic; lower drops more fixes.`}
+              error={wholeNumberError(accuracyThresholdInput, NUMERIC_MIN.accuracyThreshold, unit)}
+              message={clampNote("accuracyThreshold")}
             />
           </View>
         )}
@@ -374,73 +432,28 @@ const styles = StyleSheet.create({
     lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
-  override: {
-    fontSize: fontSizes.description,
-    ...fonts.medium,
-    lineHeight: lineHeights.description,
-    marginTop: -space.sm,
-    marginBottom: space.lg
-  },
-  section: {
-    marginBottom: space.xl
-  },
-  customParams: {
-    paddingLeft: size.iconColumn,
-    paddingBottom: space.lg,
-    gap: space.lg
+  group: {
+    marginTop: -space.sm
   },
   groupTop: {
     marginTop: space.xl
   },
-  cardTail: {
-    paddingBottom: space.lg
-  },
-  settingBlock: {
-    paddingTop: space.lg,
-    paddingBottom: space.lg
-  },
-  blockLabel: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold,
-    marginBottom: space.xs
-  },
-  blockHint: {
-    fontSize: fontSizes.description,
-    ...fonts.regular,
-    marginBottom: space.md,
-    lineHeight: lineHeights.description
-  },
-  nestedSetting: {
-    marginTop: space.md,
-    marginStart: space.lg
-  },
-  customSyncInput: {
-    marginTop: space.md
-  },
-  // Indents and spaces itself the way the custom preset parameters do. The row above already pays
-  // space.lg below it, so a top margin here would push the field nearer VPN than its own option.
-  ssidRow: {
-    flexDirection: "row",
-    alignItems: "center",
+  // The row above already pays space.lg below it; the field's own bottom margin is the card's tail.
+  reveal: {
     paddingLeft: size.iconColumn,
-    marginTop: -space.xs,
-    paddingBottom: space.lg,
-    gap: space.sm
+    marginTop: -space.xs
   },
-  ssidField: {
-    flex: 1
+  revealTail: {
+    paddingBottom: space.lg
   },
-  ssidFillButton: {
-    overflow: "hidden",
-    alignSelf: "flex-start",
-    justifyContent: "center",
-    minHeight: size.chip,
-    paddingHorizontal: space.md,
-    paddingVertical: space.sm,
-    borderRadius: radius.sm
+  // Button bakes marginVertical space.sm, which completes the 16 to the next row.
+  revealButtonTail: {
+    paddingBottom: space.sm
   },
-  ssidFillText: {
-    ...fonts.medium,
-    fontSize: fontSizes.caption
+  batch: {
+    paddingTop: space.lg
+  },
+  filterField: {
+    marginTop: -space.xs
   }
 })

--- a/apps/mobile/src/components/features/settings/__tests__/SyncIntervalPicker.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncIntervalPicker.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { render, fireEvent } from "@testing-library/react-native"
+import { render, fireEvent, act } from "@testing-library/react-native"
+import { SAVE_SUCCESS_DISPLAY_MS } from "../../../../constants"
 jest.mock("../../../../hooks/useTheme", () => ({
   useTheme: () => ({ colors: require("@colota/shared").lightColors })
 }))
@@ -95,5 +96,46 @@ describe("SyncIntervalPicker", () => {
     fireEvent(getByDisplayValue("-5"), "blur")
 
     expect(onClamp).toHaveBeenCalledWith(0)
+  })
+
+  it("prices every row, with Custom printing the interval it holds in the same units as the others", () => {
+    const { getByText } = renderPicker(90)
+
+    expect(getByText("Each fix is its own request · radio never idles")).toBeTruthy()
+    expect(getByText("One request every 15 min · the server hears you up to 15 min late")).toBeTruthy()
+    expect(getByText("Syncs every 90 s")).toBeTruthy()
+  })
+
+  it("draws no heading when the caller titles the group itself", () => {
+    const { queryByText } = render(
+      <SyncIntervalPicker value={300} onSelect={onSelect} onChange={onChange} onClamp={onClamp} />
+    )
+
+    expect(queryByText("Sync interval")).toBeNull()
+  })
+
+  it("rejects a decimal with an error instead of storing a rounded value", () => {
+    const { getByDisplayValue, getByText } = renderPicker(120)
+
+    fireEvent.changeText(getByDisplayValue("120"), "1.5")
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(getByText("A whole number")).toBeTruthy()
+  })
+
+  it("says what a blur clamped to, for as long as a save notice shows", () => {
+    jest.useFakeTimers()
+    const { getByDisplayValue, getByText, queryByText } = renderPicker(120)
+
+    fireEvent.changeText(getByDisplayValue("120"), "")
+    fireEvent(getByDisplayValue(""), "blur")
+
+    expect(onClamp).toHaveBeenCalledWith(1)
+    expect(getByText("Set to 1 s")).toBeTruthy()
+    act(() => {
+      jest.advanceTimersByTime(SAVE_SUCCESS_DISPLAY_MS)
+    })
+    expect(queryByText("Set to 1 s")).toBeNull()
+    jest.useRealTimers()
   })
 })

--- a/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/SyncStrategySettings.test.tsx
@@ -1,37 +1,24 @@
 import React from "react"
-import { render, fireEvent } from "@testing-library/react-native"
-import { DEFAULT_SETTINGS, TRACKING_PRESETS, Settings } from "../../../../types/global"
+import { render, fireEvent, act } from "@testing-library/react-native"
+import { DEFAULT_SETTINGS, TRACKING_PRESETS, Settings, SavedTrackingProfile } from "../../../../types/global"
+import { SAVE_SUCCESS_DISPLAY_MS } from "../../../../constants"
 
 // Mock barrel export (avoids transitive native module imports)
 jest.mock("../../../index", () => {
   const R = require("react")
-  const { View, Text, TextInput } = require("react-native")
+  const { View, Text, TextInput, Pressable } = require("react-native")
   return {
     ListItem: require("../../../../testing/componentStubs").ListItemStub,
     TextField: require("../../../../testing/componentStubs").TextFieldStub,
-    ChipGroup: function (props: any) {
-      const RN = require("react-native")
-      return R.createElement(
-        RN.View,
-        null,
-        props.options.map(function (o: any) {
-          return R.createElement(
-            RN.Pressable,
-            { key: o.value, testID: o.testID, onPress: () => props.onSelect(o.value) },
-            R.createElement(RN.Text, null, o.label)
-          )
-        })
-      )
-    },
     Button: function (props: any) {
-      return require("react").createElement(
-        require("react-native").Pressable,
+      return R.createElement(
+        Pressable,
         { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
-        require("react").createElement(require("react-native").Text, null, props.title)
+        R.createElement(Text, null, props.title)
       )
     },
     Toggle: function (props: any) {
-      return require("react").createElement(require("react-native").Switch, {
+      return R.createElement(require("react-native").Switch, {
         testID: props.testID,
         value: props.value,
         onValueChange: props.onValueChange,
@@ -41,15 +28,17 @@ jest.mock("../../../index", () => {
     },
     RadioRow: ({ testID, label, sub, selected, onPress }: any) =>
       R.createElement(
-        require("react-native").Pressable,
+        Pressable,
         { testID, onPress, accessibilityRole: "radio", accessibilityState: { checked: selected } },
         R.createElement(Text, null, label, selected ? " (selected)" : ""),
         sub ? R.createElement(Text, null, sub) : null
       ),
     SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
-    Card: ({ children }: any) => R.createElement(View, null, children),
-    Divider: () => R.createElement(View, null),
-    NumericInput: ({ label, value, onChange, onBlur, unit, hint, placeholder: ph }: any) =>
+    Card: ({ children, style }: any) => R.createElement(View, { testID: "card", style }, children),
+    Divider: () => R.createElement(View, { testID: "divider" }),
+    StateLine: ({ label, caption, testID }: any) =>
+      R.createElement(View, { testID }, R.createElement(Text, null, label), R.createElement(Text, null, caption)),
+    NumericInput: ({ label, value, onChange, onBlur, unit, hint, placeholder: ph, error, message }: any) =>
       R.createElement(
         View,
         null,
@@ -62,7 +51,9 @@ jest.mock("../../../index", () => {
           placeholder: ph,
           keyboardType: "numeric"
         }),
-        R.createElement(Text, null, unit)
+        R.createElement(Text, null, unit),
+        error ? R.createElement(Text, null, error) : null,
+        message ? R.createElement(Text, null, message) : null
       ),
     SettingRow: ({ label, hint, children }: any) =>
       R.createElement(
@@ -80,12 +71,12 @@ jest.mock("../SyncIntervalPicker", () => {
   const { View, Text, Pressable } = require("react-native")
   const { SYNC_INTERVAL_PRESETS } = require("../../../../constants")
   return {
-    SyncIntervalPicker: ({ label, hint, value, onSelect }: any) =>
+    SyncIntervalPicker: ({ label, hint, value, pullUp, onSelect, onChange }: any) =>
       R.createElement(
         View,
-        null,
-        R.createElement(Text, null, label),
-        R.createElement(Text, null, hint),
+        { testID: "sync-interval-picker", accessibilityValue: { text: pullUp ? "pulled" : "flush" } },
+        label ? R.createElement(Text, null, label) : null,
+        hint ? R.createElement(Text, null, hint) : null,
         SYNC_INTERVAL_PRESETS.map((seconds: number) =>
           R.createElement(
             Pressable,
@@ -97,10 +88,15 @@ jest.mock("../SyncIntervalPicker", () => {
             },
             R.createElement(Text, null, String(seconds))
           )
-        )
+        ),
+        R.createElement(Pressable, { testID: "sync-interval-typed", onPress: () => onChange(90) })
       )
   }
 })
+
+jest.mock("../../../../hooks/useTheme", () => ({
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
+}))
 
 jest.mock("../../../../utils/geo", () => ({
   shortDistanceUnit: () => "m",
@@ -108,22 +104,27 @@ jest.mock("../../../../utils/geo", () => ({
   metersToInput: (meters: number) => meters
 }))
 
-const mockColors = {
-  primary: "#0d9488",
-  primaryDark: "#115E59",
-  border: "#e5e7eb",
-  text: "#000",
-  textSecondary: "#6b7280",
-  textLight: "#9ca3af",
-  background: "#fff",
-  info: "#3b82f6",
-  card: "#fff",
-  backgroundElevated: "#f9fafb",
-  placeholder: "#9ca3af",
-  textOnPrimary: "#fff"
-} as any
+const mockGetCurrentSsid = jest.fn()
+jest.mock("../../../../services/NativeLocationService", () => ({
+  __esModule: true,
+  default: {
+    getCurrentSsid: (...args: unknown[]) => mockGetCurrentSsid(...args)
+  }
+}))
 
 import { SyncStrategySettings } from "../SyncStrategySettings"
+
+const charging: SavedTrackingProfile = {
+  id: 7,
+  name: "Charging",
+  interval: 5,
+  distance: 20,
+  syncInterval: 900,
+  priority: 1,
+  condition: { type: "charging" } as any,
+  activationDelay: 0,
+  deactivationDelay: 0
+} as SavedTrackingProfile
 
 describe("SyncStrategySettings", () => {
   let mockOnSettingsChange: jest.Mock
@@ -132,13 +133,19 @@ describe("SyncStrategySettings", () => {
   let baseSettings: Settings
 
   beforeEach(() => {
+    jest.useFakeTimers()
     mockOnSettingsChange = jest.fn()
     mockOnDebouncedSave = jest.fn()
     mockOnImmediateSave = jest.fn()
+    mockGetCurrentSsid.mockResolvedValue("")
     baseSettings = { ...DEFAULT_SETTINGS }
   })
 
-  function renderComponent(settingsOverride?: Partial<Settings>) {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function renderComponent(settingsOverride?: Partial<Settings>, activeProfile: SavedTrackingProfile | null = null) {
     const settings = { ...baseSettings, ...settingsOverride }
     return render(
       <SyncStrategySettings
@@ -146,43 +153,70 @@ describe("SyncStrategySettings", () => {
         onSettingsChange={mockOnSettingsChange}
         onDebouncedSave={mockOnDebouncedSave}
         onImmediateSave={mockOnImmediateSave}
-        colors={mockColors}
+        activeProfile={activeProfile}
       />
     )
   }
+
+  describe("groups", () => {
+    it("names each group by what it sets, with no heading inside a card", () => {
+      const { getByText, queryByText } = renderComponent()
+
+      expect(getByText("Recording")).toBeTruthy()
+      expect(getByText("Sync interval")).toBeTruthy()
+      expect(getByText("Sync only on")).toBeTruthy()
+      expect(getByText("Accuracy filter")).toBeTruthy()
+      expect(queryByText("Network settings")).toBeNull()
+    })
+
+    it("states the restart consequence once, as static text", () => {
+      const { getByText } = renderComponent()
+
+      expect(
+        getByText("How often a fix is recorded and when it syncs. Changes apply at once and restart tracking.")
+      ).toBeTruthy()
+    })
+
+    it("hides both sync groups offline and drops the sync clause from every preset", () => {
+      const { queryByText, getByText } = renderComponent({ isOfflineMode: true })
+
+      expect(queryByText("Sync interval")).toBeNull()
+      expect(queryByText("Sync only on")).toBeNull()
+      expect(getByText("Every 30 s after 2 m · moderate battery, fewer wake-ups")).toBeTruthy()
+    })
+  })
 
   describe("presets", () => {
     it("renders all three presets inline", () => {
       const { getByTestId } = renderComponent()
 
-      // Presets are rendered inline (no picker to open)
       expect(getByTestId("preset-instant")).toBeTruthy()
       expect(getByTestId("preset-balanced")).toBeTruthy()
       expect(getByTestId("preset-powersaver")).toBeTruthy()
     })
 
+    it("prices every preset on its row as fix rate, sync cadence and cost, so the trade reads before the tap", () => {
+      const { getByText } = renderComponent()
+
+      expect(getByText("Every 5 s, any movement · syncs each fix · most battery, finest track")).toBeTruthy()
+      expect(getByText("Every 30 s after 2 m · syncs every 5 min · moderate battery, fewer wake-ups")).toBeTruthy()
+      expect(getByText("Every 1 min after 2 m · syncs every 15 min · least battery, coarser track")).toBeTruthy()
+      expect(getByText("Power saver")).toBeTruthy()
+    })
+
     it("selecting a preset applies its config via onImmediateSave", () => {
       const { getByTestId } = renderComponent()
 
-      // Select balanced directly (inline)
       fireEvent.press(getByTestId("preset-balanced"))
 
-      expect(mockOnSettingsChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          syncPreset: "balanced",
-          interval: TRACKING_PRESETS.balanced.interval,
-          distance: TRACKING_PRESETS.balanced.distance,
-          syncInterval: TRACKING_PRESETS.balanced.syncInterval
-        })
-      )
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(
-        expect.objectContaining({
-          syncPreset: "balanced",
-          interval: TRACKING_PRESETS.balanced.interval,
-          distance: TRACKING_PRESETS.balanced.distance,
-          syncInterval: TRACKING_PRESETS.balanced.syncInterval
-        })
-      )
+      const expected = expect.objectContaining({
+        syncPreset: "balanced",
+        interval: TRACKING_PRESETS.balanced.interval,
+        distance: TRACKING_PRESETS.balanced.distance,
+        syncInterval: TRACKING_PRESETS.balanced.syncInterval
+      })
+      expect(mockOnSettingsChange).toHaveBeenCalledWith(expected)
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(expected)
     })
 
     it("selecting a preset in offline mode skips sync fields", () => {
@@ -192,20 +226,8 @@ describe("SyncStrategySettings", () => {
 
       const savedSettings = mockOnImmediateSave.mock.calls[0][0]
       expect(savedSettings.syncPreset).toBe("balanced")
-      expect(savedSettings.interval).toBe(TRACKING_PRESETS.balanced.interval)
-      expect(savedSettings.distance).toBe(TRACKING_PRESETS.balanced.distance)
-      // syncInterval and retryInterval should NOT be overwritten in offline mode
       expect(savedSettings.syncInterval).toBe(DEFAULT_SETTINGS.syncInterval)
       expect(savedSettings.retryInterval).toBe(DEFAULT_SETTINGS.retryInterval)
-    })
-  })
-
-  describe("the settings that apply to every preset", () => {
-    it("shows the network and quality groups without a disclosure", () => {
-      const { getByText } = renderComponent()
-
-      expect(getByText("Network settings")).toBeTruthy()
-      expect(getByText("Quality filters")).toBeTruthy()
     })
   })
 
@@ -218,237 +240,201 @@ describe("SyncStrategySettings", () => {
 
     it("opens the parameters it owns, and a named preset does not", () => {
       const custom = renderComponent({ syncPreset: "custom" })
-      expect(custom.getByText("Tracking interval")).toBeTruthy()
+      expect(custom.getByText("Interval")).toBeTruthy()
+      expect(custom.getByText("Movement threshold")).toBeTruthy()
 
       const named = renderComponent({ syncPreset: "balanced" })
-      expect(named.queryByText("Tracking interval")).toBeNull()
+      expect(named.queryByText("Movement threshold")).toBeNull()
     })
 
-    it("says what it holds, which is what the banner used to say", () => {
-      const { getByText } = renderComponent({ syncPreset: "custom", interval: 45, syncInterval: 600 })
+    it("prints its stored numbers and no cost adjective, since a guess for typed numbers would be dishonest", () => {
+      const { getByText } = renderComponent({ syncPreset: "custom", interval: 20, distance: 5, syncInterval: 90 })
 
-      expect(getByText("Track every 45s • Batch 10 min")).toBeTruthy()
-    })
-  })
-
-  describe("preset captions", () => {
-    it("carries the battery cost and the recommendation as words, not as filled badges", () => {
-      const { getByText } = renderComponent()
-
-      expect(getByText("Track every 5s • Send instantly • high battery")).toBeTruthy()
-      expect(getByText("Track every 30s • Batch 5 min • recommended")).toBeTruthy()
+      expect(getByText("Every 20 s after 5 m · syncs every 90 s")).toBeTruthy()
     })
   })
 
-  describe("sync interval", () => {
-    it("hands the picker its label and hint rather than drawing them itself", () => {
-      const { getByText } = renderComponent()
+  describe("typed fields", () => {
+    it("lands a second edit within the debounce on top of the first, instead of dropping it", () => {
+      const { getByDisplayValue } = renderComponent({ syncPreset: "custom", interval: 5, distance: 0 })
 
-      expect(getByText("Sync interval")).toBeTruthy()
-      expect(getByText("How often to upload data to server")).toBeTruthy()
+      fireEvent.changeText(getByDisplayValue("5"), "20")
+      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ interval: 20 }))
+      expect(mockOnDebouncedSave).toHaveBeenLastCalledWith(expect.objectContaining({ interval: 20 }))
     })
 
-    it("selecting a sync interval sets preset to custom", () => {
-      const { getByTestId } = renderComponent()
+    it("stores nothing for a cleared field, a decimal or a sign, and says why under the field", () => {
+      const { getByDisplayValue, getByText, queryByText } = renderComponent({
+        syncPreset: "custom",
+        interval: 5,
+        distance: 10
+      })
+
+      fireEvent.changeText(getByDisplayValue("10"), "")
+      expect(mockOnDebouncedSave).not.toHaveBeenCalled()
+      expect(queryByText("A whole number")).toBeNull()
+
+      fireEvent.changeText(getByDisplayValue(""), "1.5")
+      expect(mockOnDebouncedSave).not.toHaveBeenCalled()
+      expect(getByText("A whole number")).toBeTruthy()
+
+      fireEvent.changeText(getByDisplayValue("5"), "0")
+      expect(mockOnDebouncedSave).not.toHaveBeenCalled()
+      expect(getByText("At least 1 s")).toBeTruthy()
+    })
+
+    it("clamps an empty interval to 1 s on blur, saves at once and says so for a moment", () => {
+      const { getByDisplayValue, getByText, queryByText } = renderComponent({ syncPreset: "custom", interval: 5 })
+
+      fireEvent.changeText(getByDisplayValue("5"), "")
+      fireEvent(getByDisplayValue(""), "blur")
+
+      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
+      expect(getByDisplayValue("1")).toBeTruthy()
+      expect(getByText("Set to 1 s")).toBeTruthy()
+
+      act(() => {
+        jest.advanceTimersByTime(SAVE_SUCCESS_DISPLAY_MS)
+      })
+      expect(queryByText("Set to 1 s")).toBeNull()
+    })
+
+    it("leaves a valid value alone on blur", () => {
+      const { getByDisplayValue } = renderComponent({ syncPreset: "custom", interval: 5 })
+
+      fireEvent.changeText(getByDisplayValue("5"), "10")
+      fireEvent(getByDisplayValue("10"), "blur")
+
+      expect(mockOnImmediateSave).not.toHaveBeenCalled()
+    })
+
+    it("clamps a cleared movement threshold to 0 on blur and keeps the unit on the note", () => {
+      const { getByDisplayValue, getByText } = renderComponent({ syncPreset: "custom", interval: 5, distance: 10 })
+
+      fireEvent.changeText(getByDisplayValue("10"), "abc")
+      fireEvent(getByDisplayValue("abc"), "blur")
+
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ distance: 0 }))
+      expect(getByText("Set to 0 m")).toBeTruthy()
+    })
+
+    it("keeps the text you typed when the stored value already means it", () => {
+      const { getByDisplayValue, rerender } = renderComponent({ syncPreset: "custom", interval: 5 })
+
+      fireEvent.changeText(getByDisplayValue("5"), "020")
+      rerender(
+        <SyncStrategySettings
+          settings={{ ...baseSettings, syncPreset: "custom", interval: 20 }}
+          onSettingsChange={mockOnSettingsChange}
+          onDebouncedSave={mockOnDebouncedSave}
+          onImmediateSave={mockOnImmediateSave}
+        />
+      )
+
+      expect(getByDisplayValue("020")).toBeTruthy()
+    })
+  })
+
+  describe("what flips the preset to Custom", () => {
+    it("a sync interval row does, because a preset owns that value", () => {
+      const { getByTestId } = renderComponent({ syncPreset: "balanced" })
 
       fireEvent.press(getByTestId("sync-interval-300"))
 
       expect(mockOnSettingsChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          syncInterval: 300,
-          syncPreset: "custom"
-        })
+        expect.objectContaining({ syncInterval: 300, syncPreset: "custom" })
+      )
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(
+        expect.objectContaining({ syncInterval: 300, syncPreset: "custom" })
+      )
+    })
+
+    it("a typed sync interval does, through the debounced save", () => {
+      const { getByTestId } = renderComponent({ syncPreset: "balanced" })
+
+      fireEvent.press(getByTestId("sync-interval-typed"))
+
+      expect(mockOnSettingsChange).toHaveBeenCalledWith(
+        expect.objectContaining({ syncInterval: 90, syncPreset: "custom" })
       )
       expect(mockOnDebouncedSave).toHaveBeenCalledWith(
-        expect.objectContaining({
-          syncInterval: 300,
-          syncPreset: "custom"
-        })
+        expect.objectContaining({ syncInterval: 90, syncPreset: "custom" })
       )
     })
-  })
 
-  describe("filter inaccurate locations", () => {
-    it("shows accuracy threshold input when filter is enabled", () => {
-      const { getByText } = renderComponent({ filterInaccurateLocations: true })
-
-      expect(getByText("Accuracy threshold")).toBeTruthy()
-    })
-
-    it("hides accuracy threshold input when filter is disabled", () => {
-      const { queryByText } = renderComponent({ filterInaccurateLocations: false })
-
-      expect(queryByText("Accuracy threshold")).toBeNull()
-    })
-  })
-
-  describe("numeric input blur behavior", () => {
-    it("clamps interval to min 1 on blur when value is 0", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
-        syncPreset: "custom"
-      })
-
-      const intervalInput = getByDisplayValue("5")
-      fireEvent.changeText(intervalInput, "0")
-      fireEvent(intervalInput, "blur")
-
-      // Should clamp to 1 and call onSettingsChange + onImmediateSave
-      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
-    })
-
-    it("clamps interval to min 1 on blur when value is negative", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
-        syncPreset: "custom"
-      })
-
-      const intervalInput = getByDisplayValue("5")
-      fireEvent.changeText(intervalInput, "-3")
-      fireEvent(intervalInput, "blur")
-
-      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
-    })
-
-    it("clamps interval to min 1 on blur when value is NaN", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
-        syncPreset: "custom"
-      })
-
-      const intervalInput = getByDisplayValue("5")
-      fireEvent.changeText(intervalInput, "abc")
-      fireEvent(intervalInput, "blur")
-
-      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ interval: 1 }))
-    })
-
-    it("does not clamp interval on blur when value is valid", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
-        syncPreset: "custom"
-      })
-
-      const intervalInput = getByDisplayValue("5")
-      fireEvent.changeText(intervalInput, "10")
-      fireEvent(intervalInput, "blur")
-
-      // Valid value - onSettingsChange should only have been called from changeText (debounced save),
-      // not from blur (no clamping needed)
-      expect(mockOnImmediateSave).not.toHaveBeenCalled()
-    })
-
-    it("clamps distance to min 0 on blur when value is negative", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
-        distance: 10,
-        syncPreset: "custom"
-      })
-
-      const distanceInput = getByDisplayValue("10")
-      fireEvent.changeText(distanceInput, "-5")
-      fireEvent(distanceInput, "blur")
-
-      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ distance: 0 }))
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ distance: 0 }))
-    })
-
-    it("clamps distance to min 0 on blur when value is NaN", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
-        distance: 10,
-        syncPreset: "custom"
-      })
-
-      const distanceInput = getByDisplayValue("10")
-      fireEvent.changeText(distanceInput, "abc")
-      fireEvent(distanceInput, "blur")
-
-      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ distance: 0 }))
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ distance: 0 }))
-    })
-
-    it("clamps accuracy threshold to min 1 on blur when value is below", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
+    it("a sync condition, the accuracy threshold and the toggle do not", () => {
+      const { getByTestId, getByDisplayValue, getByLabelText } = renderComponent({
+        syncPreset: "balanced",
         filterInaccurateLocations: true,
-        accuracyThreshold: 100,
-        syncPreset: "custom"
+        accuracyThreshold: 100
       })
 
-      const thresholdInput = getByDisplayValue("100")
-      fireEvent.changeText(thresholdInput, "0")
-      fireEvent(thresholdInput, "blur")
+      fireEvent.press(getByTestId("sync-condition-vpn"))
+      expect(mockOnImmediateSave).toHaveBeenLastCalledWith(
+        expect.objectContaining({ syncCondition: "vpn", syncPreset: "balanced" })
+      )
 
-      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ accuracyThreshold: 1 }))
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ accuracyThreshold: 1 }))
-    })
+      fireEvent.changeText(getByDisplayValue("100"), "80")
+      expect(mockOnDebouncedSave).toHaveBeenLastCalledWith(
+        expect.objectContaining({ accuracyThreshold: 80, syncPreset: "balanced" })
+      )
 
-    it("does not clamp accuracy threshold on blur when value is valid", () => {
-      const { getByDisplayValue } = renderComponent({
-        interval: 5,
-        filterInaccurateLocations: true,
-        accuracyThreshold: 100,
-        syncPreset: "custom"
-      })
-
-      const thresholdInput = getByDisplayValue("100")
-      fireEvent.changeText(thresholdInput, "200")
-      fireEvent(thresholdInput, "blur")
-
-      expect(mockOnImmediateSave).not.toHaveBeenCalled()
+      fireEvent(getByLabelText("Filter inaccurate locations"), "valueChange", false)
+      expect(mockOnImmediateSave).toHaveBeenLastCalledWith(
+        expect.objectContaining({ filterInaccurateLocations: false, syncPreset: "balanced" })
+      )
     })
   })
 
   describe("profile override", () => {
-    it("says a profile is overriding these values, because the screen otherwise reads as authoritative", () => {
-      const { getByTestId, getByText } = render(
-        <SyncStrategySettings
-          settings={baseSettings}
-          onSettingsChange={mockOnSettingsChange}
-          onDebouncedSave={mockOnDebouncedSave}
-          onImmediateSave={mockOnImmediateSave}
-          activeProfileName="Charging"
-          colors={mockColors}
-        />
-      )
+    it("shows the values in force inside the two groups a profile overrides, and only those", () => {
+      const { getByTestId, getByText, queryByTestId } = renderComponent({}, charging)
 
-      expect(getByTestId("profile-override-notice")).toBeTruthy()
-      expect(getByText(/Charging is active/)).toBeTruthy()
+      expect(getByTestId("profile-override-recording")).toBeTruthy()
+      expect(getByText("In force: every 5 s after 20 m")).toBeTruthy()
+      expect(getByTestId("profile-override-sync")).toBeTruthy()
+      expect(getByText("In force: syncs every 15 min")).toBeTruthy()
+      expect(queryByTestId("profile-override-notice")).toBeNull()
     })
 
-    it("stays quiet when no profile is active, so the notice means something when it appears", () => {
+    it("keeps the rows below selectable, since they are the defaults the profile hands back", () => {
+      const { getByTestId } = renderComponent({}, charging)
+
+      fireEvent.press(getByTestId("preset-balanced"))
+
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ syncPreset: "balanced" }))
+    })
+
+    it("drops the pull under the title when a state line precedes the sync rows", () => {
+      const withProfile = renderComponent({}, charging)
+      expect(withProfile.getByTestId("sync-interval-picker").props.accessibilityValue.text).toBe("flush")
+
+      const without = renderComponent()
+      expect(without.getByTestId("sync-interval-picker").props.accessibilityValue.text).toBe("pulled")
+    })
+
+    it("stays quiet when no profile is active, so the line means something when it appears", () => {
       const { queryByTestId } = renderComponent()
 
-      expect(queryByTestId("profile-override-notice")).toBeNull()
+      expect(queryByTestId("profile-override-recording")).toBeNull()
+      expect(queryByTestId("profile-override-sync")).toBeNull()
     })
   })
 
   describe("sync condition", () => {
-    it("states what every option does without one being chosen, which the chips could not", () => {
+    it("states what every option costs without one being chosen", () => {
       const { getByText } = renderComponent({ syncCondition: "any" })
 
-      expect(getByText("Uploads over mobile data as well as Wi-Fi")).toBeTruthy()
-      expect(getByText("Uploads only while connected to any Wi-Fi")).toBeTruthy()
-      expect(getByText("Uploads only on one network you choose")).toBeTruthy()
-      expect(getByText("Uploads only while a VPN is active")).toBeTruthy()
+      expect(getByText("Mobile data and Wi-Fi · syncs never wait, counts against your data plan")).toBeTruthy()
+      expect(getByText("Wi-Fi or Ethernet")).toBeTruthy()
+      expect(getByText("Unmetered networks only · fixes wait on mobile data")).toBeTruthy()
+      expect(getByText("One network by name · fixes wait elsewhere")).toBeTruthy()
+      expect(getByText("Only while a VPN is up · fixes wait otherwise")).toBeTruthy()
     })
 
-    it("saves the choice and drops the preset to custom, because a preset does not carry it", () => {
-      const { getByTestId } = renderComponent({ syncCondition: "any", syncPreset: "balanced" })
-
-      fireEvent.press(getByTestId("sync-condition-vpn"))
-
-      expect(mockOnImmediateSave).toHaveBeenCalledWith(
-        expect.objectContaining({ syncCondition: "vpn", syncPreset: "custom" })
-      )
-    })
-
-    it("puts the SSID field under its own row, not at the end of the group below VPN", () => {
-      const { toJSON } = renderComponent({ syncCondition: "wifi_ssid" })
+    it("puts the network name under its own row, not at the end of the group below VPN", () => {
+      const { toJSON } = renderComponent({ syncCondition: "wifi_ssid", syncSsid: "Home" })
 
       const ids: string[] = []
       const walk = (node: any) => {
@@ -463,12 +449,99 @@ describe("SyncStrategySettings", () => {
       expect(ids.indexOf("sync-ssid-input")).toBeLessThan(ids.indexOf("sync-condition-vpn"))
     })
 
-    it("reveals the SSID field only for the one option that needs a network name", () => {
+    it("reveals the network name only for the one option that needs it", () => {
       const { queryByTestId } = renderComponent({ syncCondition: "wifi_any" })
       expect(queryByTestId("sync-ssid-input")).toBeNull()
 
-      const named = renderComponent({ syncCondition: "wifi_ssid" })
+      const named = renderComponent({ syncCondition: "wifi_ssid", syncSsid: "Home" })
       expect(named.queryByTestId("sync-ssid-input")).toBeTruthy()
+    })
+
+    it("marks a blank network name as an error, because nothing syncs until one is named", () => {
+      const blank = renderComponent({ syncCondition: "wifi_ssid", syncSsid: "" })
+      expect(blank.getByText("Nothing syncs until a network is named")).toBeTruthy()
+
+      const named = renderComponent({ syncCondition: "wifi_ssid", syncSsid: "Home" })
+      expect(named.queryByText("Nothing syncs until a network is named")).toBeNull()
+    })
+
+    it("offers the network the phone is on, named, only while it differs from the one typed", async () => {
+      mockGetCurrentSsid.mockResolvedValue("Colota-5G")
+      const { findByText, getByTestId } = renderComponent({ syncCondition: "wifi_ssid", syncSsid: "" })
+
+      expect(await findByText("Use Colota-5G")).toBeTruthy()
+      fireEvent.press(getByTestId("sync-ssid-use"))
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ syncSsid: "Colota-5G" }))
+
+      mockGetCurrentSsid.mockResolvedValue("home")
+      const same = renderComponent({ syncCondition: "wifi_ssid", syncSsid: "Home" })
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(same.queryByTestId("sync-ssid-use")).toBeNull()
+    })
+  })
+
+  describe("accuracy filter", () => {
+    it("carries the threshold in the hint in both states, so hiding the field loses nothing", () => {
+      const on = renderComponent({ filterInaccurateLocations: true, accuracyThreshold: 50 })
+      expect(on.getByText("Drops fixes the chip rates worse than 50 m. Stricter leaves gaps indoors.")).toBeTruthy()
+      expect(on.getByText("Accuracy threshold")).toBeTruthy()
+
+      const off = renderComponent({ filterInaccurateLocations: false, accuracyThreshold: 50 })
+      expect(off.getByText("Every fix is kept. When on, fixes worse than 50 m are dropped.")).toBeTruthy()
+      expect(off.queryByText("Accuracy threshold")).toBeNull()
+    })
+
+    it("moves the switch at once: local state first, then the immediate save", () => {
+      const calls: string[] = []
+      mockOnSettingsChange.mockImplementation(() => calls.push("local"))
+      mockOnImmediateSave.mockImplementation(() => calls.push("save"))
+      const { getByLabelText } = renderComponent({ filterInaccurateLocations: false })
+
+      fireEvent(getByLabelText("Filter inaccurate locations"), "valueChange", true)
+
+      expect(calls).toEqual(["local", "save"])
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ filterInaccurateLocations: true }))
+    })
+
+    it("clamps the threshold to 1 on blur when it is below", () => {
+      const { getByDisplayValue } = renderComponent({ filterInaccurateLocations: true, accuracyThreshold: 100 })
+
+      fireEvent.changeText(getByDisplayValue("100"), "0")
+      fireEvent(getByDisplayValue("0"), "blur")
+
+      expect(mockOnSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ accuracyThreshold: 1 }))
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(expect.objectContaining({ accuracyThreshold: 1 }))
+    })
+  })
+
+  describe("batch size", () => {
+    const overland = { apiTemplate: "overland" as const }
+
+    it("shows the range as an error while the number is outside it and stores nothing", () => {
+      const { getByDisplayValue, getByText } = renderComponent({ ...overland, overlandBatchSize: 50 })
+
+      fireEvent.changeText(getByDisplayValue("50"), "900")
+
+      expect(getByText("1 to 500")).toBeTruthy()
+      expect(mockOnDebouncedSave).not.toHaveBeenCalled()
+    })
+
+    it("clamps to the nearer bound on blur without touching the preset", () => {
+      const { getByDisplayValue, getByText } = renderComponent({
+        ...overland,
+        overlandBatchSize: 50,
+        syncPreset: "balanced"
+      })
+
+      fireEvent.changeText(getByDisplayValue("50"), "900")
+      fireEvent(getByDisplayValue("900"), "blur")
+
+      expect(mockOnImmediateSave).toHaveBeenCalledWith(
+        expect.objectContaining({ overlandBatchSize: 500, syncPreset: "balanced" })
+      )
+      expect(getByText("Set to 500 points")).toBeTruthy()
     })
   })
 })

--- a/apps/mobile/src/components/ui/NumericInput.tsx
+++ b/apps/mobile/src/components/ui/NumericInput.tsx
@@ -9,6 +9,7 @@ import { useTheme } from "../../hooks/useTheme"
 import { fontSizes, fonts, lineHeights } from "../../styles/typography"
 import { space } from "../../constants"
 import { TextField } from "./TextField"
+import { FieldMessage } from "./FieldMessage"
 
 interface NumericInputProps {
   label: string
@@ -19,6 +20,10 @@ interface NumericInputProps {
   placeholder?: string
   min?: number
   hint?: string
+  /** Shown under the box while the text would not be stored; the box takes the error ring. */
+  error?: string
+  /** A transient note under the box, such as the value a blur clamped to. */
+  message?: string
   testID?: string
 }
 
@@ -34,6 +39,8 @@ export function NumericInput({
   unit,
   placeholder = "0",
   hint,
+  error,
+  message,
   testID
 }: NumericInputProps) {
   const { colors } = useTheme()
@@ -54,9 +61,11 @@ export function NumericInput({
           onChangeText={onChange}
           onBlur={onBlur}
           placeholder={placeholder}
+          error={error}
         />
         <Text style={[styles.unit, { color: colors.textSecondary }]}>{unit}</Text>
       </View>
+      {message ? <FieldMessage>{message}</FieldMessage> : null}
     </View>
   )
 }

--- a/apps/mobile/src/components/ui/__tests__/NumericInput.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/NumericInput.test.tsx
@@ -84,4 +84,13 @@ describe("NumericInput", () => {
 
     expect(getByText("meters")).toBeTruthy()
   })
+
+  it("hands an error to the box and a message under it, so a clamp and a rejection read in place", () => {
+    const withError = renderInput({ error: "A whole number" })
+    expect(withError.getByText("A whole number")).toBeTruthy()
+    expect(withError.getByLabelText("Test label, A whole number")).toBeTruthy()
+
+    const withMessage = renderInput({ message: "Set to 1 s" })
+    expect(withMessage.getByText("Set to 1 s")).toBeTruthy()
+  })
 })

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -134,6 +134,13 @@ export const SYNC_INTERVAL_LABELS: Record<number, string> = {
   900: "15 min"
 }
 
+export const SYNC_INTERVAL_SUBS: Record<number, string> = {
+  0: "Each fix is its own request · radio never idles",
+  60: "One request a minute · fixes wait in between",
+  300: "One request every 5 min · fewer wake-ups",
+  900: "One request every 15 min · the server hears you up to 15 min late"
+}
+
 // Overland batch envelope (Dawarich + batch mode, Overland template)
 export const OVERLAND_BATCH_MIN = 1
 export const OVERLAND_BATCH_MAX = 500

--- a/apps/mobile/src/hooks/__tests__/useActiveProfile.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useActiveProfile.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from "@testing-library/react-native"
+
+jest.mock("../../utils/logger", () => ({
+  logger: { error: jest.fn() }
+}))
+
+const mockGetProfiles = jest.fn()
+jest.mock("../../services/NativeLocationService", () => ({
+  __esModule: true,
+  default: {
+    getProfiles: (...args: unknown[]) => mockGetProfiles(...args)
+  }
+}))
+
+import { useActiveProfile } from "../useActiveProfile"
+import { logger } from "../../utils/logger"
+
+const profiles = [
+  { id: 3, name: "Charging", interval: 5, distance: 20, syncInterval: 900 },
+  { id: 7, name: "Night", interval: 300, distance: 50, syncInterval: 3600 }
+]
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetProfiles.mockResolvedValue(profiles)
+})
+
+describe("useActiveProfile", () => {
+  it("resolves the profile behind the id, so a screen can print the values in force", async () => {
+    const { result } = renderHook(() => useActiveProfile(7))
+
+    await waitFor(() => expect(result.current?.name).toBe("Night"))
+  })
+
+  it("is null with no id and reads nothing, since nothing is in force", () => {
+    const { result } = renderHook(() => useActiveProfile(null))
+
+    expect(result.current).toBeNull()
+    expect(mockGetProfiles).not.toHaveBeenCalled()
+  })
+
+  it("is null when the id matches no saved profile, rather than showing a stale one", async () => {
+    const { result, rerender } = renderHook(({ id }: { id: number | null }) => useActiveProfile(id), {
+      initialProps: { id: 3 as number | null }
+    })
+    await waitFor(() => expect(result.current?.name).toBe("Charging"))
+
+    rerender({ id: 99 })
+
+    await waitFor(() => expect(result.current).toBeNull())
+  })
+
+  it("clears when the profile deactivates", async () => {
+    const { result, rerender } = renderHook(({ id }: { id: number | null }) => useActiveProfile(id), {
+      initialProps: { id: 3 as number | null }
+    })
+    await waitFor(() => expect(result.current?.name).toBe("Charging"))
+
+    rerender({ id: null })
+
+    expect(result.current).toBeNull()
+  })
+
+  it("only logs a failed read, because the line is background state", async () => {
+    mockGetProfiles.mockRejectedValue(new Error("db closed"))
+    const { result } = renderHook(() => useActiveProfile(3))
+
+    await waitFor(() => expect(logger.error).toHaveBeenCalled())
+    expect(result.current).toBeNull()
+  })
+})

--- a/apps/mobile/src/hooks/useActiveProfile.ts
+++ b/apps/mobile/src/hooks/useActiveProfile.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import { useEffect, useState } from "react"
+import NativeLocationService from "../services/NativeLocationService"
+import type { SavedTrackingProfile } from "../types/global"
+import { logger } from "../utils/logger"
+
+/** The profile behind `activeProfileId`, or null while none is active or the id matches no saved profile. */
+export function useActiveProfile(activeProfileId: number | null): SavedTrackingProfile | null {
+  const [profile, setProfile] = useState<SavedTrackingProfile | null>(null)
+
+  useEffect(() => {
+    if (activeProfileId === null) {
+      setProfile(null)
+      return
+    }
+    let cancelled = false
+    NativeLocationService.getProfiles()
+      .then((profiles) => {
+        if (!cancelled) setProfile(profiles.find((p) => p.id === activeProfileId) ?? null)
+      })
+      .catch((err) => logger.error("[useActiveProfile] Failed to resolve the active profile:", err))
+    return () => {
+      cancelled = true
+    }
+  }, [activeProfileId])
+
+  return profile
+}

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -7,8 +7,9 @@ import React, { useEffect, useLayoutEffect, useState, useCallback, useMemo } fro
 import { StyleSheet, View, DeviceEventEmitter, AppState, StatusBar, useWindowDimensions } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useFocusEffect, useIsFocused } from "@react-navigation/native"
-import { SavedTrackingProfile, ScreenProps } from "../types/global"
+import { ScreenProps } from "../types/global"
 import { useTheme } from "../hooks/useTheme"
+import { useActiveProfile } from "../hooks/useActiveProfile"
 import NativeLocationService from "../services/NativeLocationService"
 import { checkPermissions, ensurePermissions, PermissionStatus } from "../services/LocationServicePermission"
 import { useTracking, useCoords } from "../contexts/TrackingProvider"
@@ -52,7 +53,7 @@ export function DashboardScreen({ navigation }: ScreenProps) {
   const [stoppedByBattery, setStoppedByBattery] = useState(false)
   const [showTrack, setShowTrack] = useState<boolean | null>(null)
   const [hasTrack, setHasTrack] = useState(false)
-  const [activeProfile, setActiveProfile] = useState<SavedTrackingProfile | null>(null)
+  const activeProfile = useActiveProfile(activeProfileId)
   const [stackHeight, setStackHeight] = useState(0)
   const [bannerHeight, setBannerHeight] = useState(0)
   const [recentreSignal, setRecentreSignal] = useState(0)
@@ -105,22 +106,6 @@ export function DashboardScreen({ navigation }: ScreenProps) {
         setShowTrack(false)
       })
   }, [])
-
-  useEffect(() => {
-    if (activeProfileId === null) {
-      setActiveProfile(null)
-      return
-    }
-    let cancelled = false
-    NativeLocationService.getProfiles()
-      .then((profiles) => {
-        if (!cancelled) setActiveProfile(profiles.find((p) => p.id === activeProfileId) ?? null)
-      })
-      .catch((err) => logger.error("[Dashboard] Failed to resolve the active profile:", err))
-    return () => {
-      cancelled = true
-    }
-  }, [activeProfileId])
 
   useFocusEffect(
     useCallback(() => {

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -26,6 +26,7 @@ import {
 import { Check, Trash2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
+import { formatDuration } from "../utils/dashboardState"
 import {
   MS_TO_KMH,
   PROFILE_CONDITIONS,
@@ -38,9 +39,7 @@ import {
 import type { RootScreenProps } from "../types/navigation"
 
 function formatSyncDefault(seconds: number): string {
-  if (SYNC_INTERVAL_LABELS[seconds]) return SYNC_INTERVAL_LABELS[seconds]
-  if (seconds < 60) return `${seconds}s`
-  return `${Math.round(seconds / 60)} min`
+  return SYNC_INTERVAL_LABELS[seconds] ?? formatDuration(seconds)
 }
 
 export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Profile Editor">) {
@@ -290,7 +289,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                 onChangeText={(val) => handleNumericChange(setIntervalStr, "interval", val, 1)}
                 placeholder="5"
               />
-              <Text style={[styles.unit, { color: colors.textSecondary }]}>sec</Text>
+              <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
             </View>
           </SettingRow>
 
@@ -361,7 +360,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                   onChangeText={(val) => handleNumericChange(setActivationDelayStr, "activationDelay", val, 0)}
                   placeholder="60"
                 />
-                <Text style={[styles.unit, { color: colors.textSecondary }]}>sec</Text>
+                <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
               </View>
             </SettingRow>
           ) : (
@@ -380,7 +379,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                     onChangeText={(val) => handleNumericChange(setActivationDelayStr, "activationDelay", val, 0)}
                     placeholder="0"
                   />
-                  <Text style={[styles.unit, { color: colors.textSecondary }]}>sec</Text>
+                  <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
                 </View>
               </SettingRow>
 
@@ -400,7 +399,7 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
                     onChangeText={(val) => handleNumericChange(setDelayStr, "deactivationDelay", val, 0)}
                     placeholder="60"
                   />
-                  <Text style={[styles.unit, { color: colors.textSecondary }]}>sec</Text>
+                  <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
                 </View>
               </SettingRow>
             </>

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -33,7 +33,8 @@ import {
   MessageCircle,
   Star
 } from "lucide-react-native"
-import { formatDuration, getTimeFormat, getUnitSystem } from "../utils/geo"
+import { getTimeFormat, getUnitSystem } from "../utils/geo"
+import { trackingSummary } from "../utils/dashboardState"
 import { formatCount } from "../utils/format"
 import { ProfileService } from "../services/ProfileService"
 import { logger } from "../utils/logger"
@@ -98,12 +99,10 @@ export function SettingsScreen({ navigation }: Props) {
     return queueCount > 0 ? `${host} · ${formatCount(queueCount)} queued` : host
   }, [settings.isOfflineMode, settings.endpoint, queueCount, todayCount])
 
-  // The row names both, so it shows both: interval is the GPS cadence and syncInterval the upload
-  // one. The preset label stood in for numbers the row now carries.
-  const syncSummary = useMemo(() => {
-    const sync = settings.syncInterval <= 0 ? "syncs instantly" : `syncs every ${formatDuration(settings.syncInterval)}`
-    return `Every ${settings.interval}s · ${sync}`
-  }, [settings.interval, settings.syncInterval])
+  const syncSummary = useMemo(
+    () => trackingSummary(settings.interval, settings.distance, settings.syncInterval, settings.isOfflineMode),
+    [settings.interval, settings.distance, settings.syncInterval, settings.isOfflineMode]
+  )
 
   // Both getters read a module cache the Appearance screen refreshes on save, so this costs no
   // bridge call; the screen re-reads on focus, which is when a change can have happened.

--- a/apps/mobile/src/screens/TrackingSyncScreen.tsx
+++ b/apps/mobile/src/screens/TrackingSyncScreen.tsx
@@ -6,8 +6,8 @@
 import React, { useCallback } from "react"
 import { StyleSheet, ScrollView } from "react-native"
 import { ScreenProps, Settings } from "../types/global"
-import { useTheme } from "../hooks/useTheme"
 import { useAutoSave } from "../hooks/useAutoSave"
+import { useActiveProfile } from "../hooks/useActiveProfile"
 import { useTracking } from "../contexts/TrackingProvider"
 import { FloatingSaveIndicator } from "../components/ui/FloatingSaveIndicator"
 import { Container } from "../components"
@@ -15,8 +15,8 @@ import { SyncStrategySettings } from "../components/features/settings/SyncStrate
 import { space } from "../constants"
 
 export function TrackingSyncScreen({}: ScreenProps) {
-  const { settings, setSettings, updateSettingsLocal, restartTracking, activeProfileName } = useTracking()
-  const { colors } = useTheme()
+  const { settings, setSettings, updateSettingsLocal, restartTracking, activeProfileId } = useTracking()
+  const activeProfile = useActiveProfile(activeProfileId)
   const {
     saving,
     message: saveMessage,
@@ -57,8 +57,7 @@ export function TrackingSyncScreen({}: ScreenProps) {
           onSettingsChange={updateSettingsLocal}
           onDebouncedSave={handleDebouncedSave}
           onImmediateSave={handleImmediateSave}
-          activeProfileName={activeProfileName}
-          colors={colors}
+          activeProfile={activeProfile}
         />
       </ScrollView>
 

--- a/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/SettingsScreen.test.tsx
@@ -245,7 +245,7 @@ describe("SettingsScreen", () => {
 
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    expect(getByText("Every 30s · syncs every 5min")).toBeTruthy()
+    expect(getByText("Every 30 s, any movement · syncs every 5 min")).toBeTruthy()
   })
 
   it("says instantly rather than every 0s when nothing is batched", () => {
@@ -253,7 +253,7 @@ describe("SettingsScreen", () => {
 
     const { getByText } = render(<SettingsScreen {...mockProps} />)
 
-    expect(getByText("Every 5s · syncs instantly")).toBeTruthy()
+    expect(getByText("Every 5 s, any movement · syncs each fix")).toBeTruthy()
   })
 
   // --- Navigation ---

--- a/apps/mobile/src/screens/__tests__/TrackingSyncScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TrackingSyncScreen.test.tsx
@@ -1,0 +1,123 @@
+import React from "react"
+import { render, fireEvent, waitFor } from "@testing-library/react-native"
+const mockSetSettings = jest.fn()
+const mockUpdateSettingsLocal = jest.fn()
+const mockRestartTracking = jest.fn()
+let mockActiveProfileId: number | null = null
+
+jest.mock("../../contexts/TrackingProvider", () => ({
+  useTracking: () => ({
+    settings: require("../../types/global").DEFAULT_SETTINGS,
+    setSettings: mockSetSettings,
+    updateSettingsLocal: mockUpdateSettingsLocal,
+    restartTracking: mockRestartTracking,
+    activeProfileId: mockActiveProfileId
+  })
+}))
+
+const mockDebouncedSaveAndRestart = jest.fn()
+const mockImmediateSaveAndRestart = jest.fn()
+jest.mock("../../hooks/useAutoSave", () => ({
+  useAutoSave: () => ({
+    saving: false,
+    message: null,
+    isError: false,
+    debouncedSaveAndRestart: mockDebouncedSaveAndRestart,
+    immediateSaveAndRestart: mockImmediateSaveAndRestart
+  })
+}))
+
+const mockGetProfiles = jest.fn()
+jest.mock("../../services/NativeLocationService", () => ({
+  __esModule: true,
+  default: {
+    getProfiles: (...args: unknown[]) => mockGetProfiles(...args)
+  }
+}))
+
+jest.mock("../../utils/logger", () => ({ logger: { error: jest.fn() } }))
+
+jest.mock("../../components", () => {
+  const R = require("react")
+  const { View } = require("react-native")
+  return { Container: ({ children }: any) => R.createElement(View, null, children) }
+})
+
+jest.mock("../../components/ui/FloatingSaveIndicator", () => ({ FloatingSaveIndicator: () => null }))
+
+jest.mock("../../components/features/settings/SyncStrategySettings", () => {
+  const R = require("react")
+  const { View, Text, Pressable } = require("react-native")
+  const { DEFAULT_SETTINGS: base } = require("../../types/global")
+  return {
+    SyncStrategySettings: ({ onSettingsChange, onDebouncedSave, onImmediateSave, activeProfile }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, activeProfile ? `${activeProfile.name} is active` : "no profile"),
+        R.createElement(Pressable, {
+          testID: "type",
+          onPress: () => {
+            const next = { ...base, interval: 20 }
+            onSettingsChange(next)
+            onDebouncedSave(next)
+          }
+        }),
+        R.createElement(Pressable, {
+          testID: "preset",
+          onPress: () => onImmediateSave({ ...base, syncPreset: "balanced" })
+        })
+      )
+  }
+})
+
+import { TrackingSyncScreen } from "../TrackingSyncScreen"
+
+const mockProps = { navigation: {} as any, route: { params: undefined } as any }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockActiveProfileId = null
+  mockGetProfiles.mockResolvedValue([{ id: 4, name: "Charging", interval: 5, distance: 20, syncInterval: 900 }])
+})
+
+describe("TrackingSyncScreen", () => {
+  it("wires a typed edit to local state first, then the debounced save that restarts tracking", () => {
+    const { getByTestId } = render(<TrackingSyncScreen {...mockProps} />)
+
+    fireEvent.press(getByTestId("type"))
+
+    expect(mockUpdateSettingsLocal).toHaveBeenCalledWith(expect.objectContaining({ interval: 20 }))
+    expect(mockDebouncedSaveAndRestart).toHaveBeenCalledTimes(1)
+    const [save, restart] = mockDebouncedSaveAndRestart.mock.calls[0]
+    save()
+    restart()
+    expect(mockSetSettings).toHaveBeenCalledWith(expect.objectContaining({ interval: 20 }))
+    expect(mockRestartTracking).toHaveBeenCalledWith(expect.objectContaining({ interval: 20 }))
+  })
+
+  it("wires a discrete choice to the immediate save", () => {
+    const { getByTestId } = render(<TrackingSyncScreen {...mockProps} />)
+
+    fireEvent.press(getByTestId("preset"))
+
+    expect(mockImmediateSaveAndRestart).toHaveBeenCalledTimes(1)
+    const [save] = mockImmediateSaveAndRestart.mock.calls[0]
+    save()
+    expect(mockSetSettings).toHaveBeenCalledWith(expect.objectContaining({ syncPreset: "balanced" }))
+  })
+
+  it("resolves the active profile so the groups it overrides can show the values in force", async () => {
+    mockActiveProfileId = 4
+    const { findByText } = render(<TrackingSyncScreen {...mockProps} />)
+
+    expect(await findByText("Charging is active")).toBeTruthy()
+  })
+
+  it("hands over no profile while none is active", async () => {
+    const { getByText } = render(<TrackingSyncScreen {...mockProps} />)
+
+    await waitFor(() => expect(getByText("no profile")).toBeTruthy())
+    expect(mockGetProfiles).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/types/__tests__/defaults.test.ts
+++ b/apps/mobile/src/types/__tests__/defaults.test.ts
@@ -117,15 +117,12 @@ describe("TRACKING_PRESETS", () => {
     expect(TRACKING_PRESETS[name].label).toBeTruthy()
   })
 
-  it.each(presetNames)("%s description uses bullet separator for sync info", (name) => {
-    const parts = TRACKING_PRESETS[name].description.split(" • ")
-    expect(parts[0]).toBeTruthy()
-    expect(parts[0]).not.toContain("Send")
-    expect(parts[0]).not.toContain("Batch")
+  it.each(presetNames)("%s names its cost, which the row prints beside the numbers it prices", (name) => {
+    expect(TRACKING_PRESETS[name].cost).toMatch(/battery/)
   })
 
-  it.each(presetNames)("%s has valid batteryImpact", (name) => {
-    expect(["Low", "Medium", "High"]).toContain(TRACKING_PRESETS[name].batteryImpact)
+  it("labels read in sentence case, like every other row", () => {
+    expect(TRACKING_PRESETS.powersaver.label).toBe("Power saver")
   })
 
   it("instant has shortest interval", () => {

--- a/apps/mobile/src/types/global.ts
+++ b/apps/mobile/src/types/global.ts
@@ -255,16 +255,14 @@ export const API_TEMPLATES: Record<Exclude<ApiTemplateName, "custom">, ApiTempla
 // PRESETS
 // ============================================================================
 
-export type BatteryImpact = "Low" | "Medium" | "High"
-
 export interface TrackingPresetConfig {
   interval: number
   distance: number
   syncInterval: number
   retryInterval: number
   label: string
-  description: string
-  batteryImpact: BatteryImpact
+  /** What the preset costs, read beside the numbers it prices. */
+  cost: string
 }
 
 export const TRACKING_PRESETS = {
@@ -274,8 +272,7 @@ export const TRACKING_PRESETS = {
     syncInterval: 0,
     retryInterval: 30,
     label: "Instant",
-    description: "Track every 5s • Send instantly",
-    batteryImpact: "High"
+    cost: "most battery, finest track"
   },
   balanced: {
     interval: 30,
@@ -283,17 +280,15 @@ export const TRACKING_PRESETS = {
     syncInterval: 300,
     retryInterval: 300,
     label: "Balanced",
-    description: "Track every 30s • Batch 5 min",
-    batteryImpact: "Medium"
+    cost: "moderate battery, fewer wake-ups"
   },
   powersaver: {
     interval: 60,
     distance: 2,
     syncInterval: 900,
     retryInterval: 900,
-    label: "Power Saver",
-    description: "Track every 60s • Batch 15 min",
-    batteryImpact: "Low"
+    label: "Power saver",
+    cost: "least battery, coarser track"
   }
 } as const satisfies Record<string, TrackingPresetConfig>
 

--- a/apps/mobile/src/utils/__tests__/dashboardState.test.ts
+++ b/apps/mobile/src/utils/__tests__/dashboardState.test.ts
@@ -1,9 +1,13 @@
 import {
   describeState,
+  formatDuration,
   formatInterval,
   formatLastFix,
   intervalText,
   pickBannerCondition,
+  recordingSummary,
+  syncSummary,
+  trackingSummary,
   type StateInput
 } from "../dashboardState"
 import { formatDate, formatTime, loadDisplayPreferences } from "../geo"
@@ -225,6 +229,29 @@ describe("intervalText", () => {
 
   it("calls a zero sync interval instant, since every fix is sent as it lands", () => {
     expect(intervalText(5, 0)).toBe("Every 5 s · Instant sync")
+  })
+})
+
+describe("trackingSummary", () => {
+  it("prints a preset as fix rate, movement gate and sync cadence in one grammar", () => {
+    expect(trackingSummary(5, 0, 0, false)).toBe("Every 5 s, any movement · syncs each fix")
+    expect(trackingSummary(30, 2, 300, false)).toBe("Every 30 s after 2 m · syncs every 5 min")
+    expect(trackingSummary(60, 2, 900, false)).toBe("Every 1 min after 2 m · syncs every 15 min")
+  })
+
+  it("keeps a custom value in seconds when no unit divides it", () => {
+    expect(trackingSummary(20, 5, 90, false)).toBe("Every 20 s after 5 m · syncs every 90 s")
+  })
+
+  it("drops the sync clause offline, since nothing syncs", () => {
+    expect(trackingSummary(30, 2, 300, true)).toBe("Every 30 s after 2 m")
+  })
+
+  it("exposes the two halves so a caption can carry one of them", () => {
+    expect(recordingSummary(5, 20)).toBe("Every 5 s after 20 m")
+    expect(syncSummary(0)).toBe("syncs each fix")
+    expect(syncSummary(900)).toBe("syncs every 15 min")
+    expect(formatDuration(90)).toBe("90 s")
   })
 })
 

--- a/apps/mobile/src/utils/__tests__/settingsValidation.test.ts
+++ b/apps/mobile/src/utils/__tests__/settingsValidation.test.ts
@@ -1,4 +1,10 @@
-import { isEndpointAllowed, isPositiveInt, parsePositiveInt } from "../settingsValidation"
+import {
+  isEndpointAllowed,
+  isPositiveInt,
+  parsePositiveInt,
+  parseWholeNumber,
+  wholeNumberError
+} from "../settingsValidation"
 
 describe("isEndpointAllowed", () => {
   it("allows valid http and https URLs", () => {
@@ -52,5 +58,28 @@ describe("parsePositiveInt", () => {
 
   it("truncates floats via parseInt", () => {
     expect(parsePositiveInt("5.9", 99)).toBe(5)
+  })
+})
+
+describe("parseWholeNumber", () => {
+  it("accepts only digits, so a decimal, a sign, an exponent or nothing never reaches a setting", () => {
+    expect(parseWholeNumber("20")).toBe(20)
+    expect(parseWholeNumber("0")).toBe(0)
+    expect(parseWholeNumber("1.5")).toBeNull()
+    expect(parseWholeNumber("-3")).toBeNull()
+    expect(parseWholeNumber("1e3")).toBeNull()
+    expect(parseWholeNumber("")).toBeNull()
+  })
+})
+
+describe("wholeNumberError", () => {
+  it("stays silent on an empty field and on a valid value", () => {
+    expect(wholeNumberError("", 1, "s")).toBeUndefined()
+    expect(wholeNumberError("5", 1, "s")).toBeUndefined()
+  })
+
+  it("names the rule the text breaks, with the unit the field shows", () => {
+    expect(wholeNumberError("1.5", 1, "s")).toBe("A whole number")
+    expect(wholeNumberError("0", 1, "m")).toBe("At least 1 m")
   })
 })

--- a/apps/mobile/src/utils/dashboardState.ts
+++ b/apps/mobile/src/utils/dashboardState.ts
@@ -102,7 +102,7 @@ export function describeState(input: StateInput): StateDescription {
   }
 }
 
-function formatDuration(seconds: number): string {
+export function formatDuration(seconds: number): string {
   if (seconds >= 3600 && seconds % 3600 === 0) return `${seconds / 3600} h`
   if (seconds >= 60 && seconds % 60 === 0) return `${seconds / 60} min`
   return `${seconds} s`
@@ -110,6 +110,29 @@ function formatDuration(seconds: number): string {
 
 export function formatInterval(seconds: number): string {
   return `Every ${formatDuration(seconds)}`
+}
+
+/** "Every 30 s after 2 m", or ", any movement" when no distance gates a fix. */
+export function recordingSummary(intervalSeconds: number, distanceMeters: number): string {
+  const gate =
+    distanceMeters === 0 ? ", any movement" : ` after ${metersToInput(distanceMeters)} ${shortDistanceUnit()}`
+  return `${formatInterval(intervalSeconds)}${gate}`
+}
+
+/** "syncs each fix" or "syncs every 5 min", lower case so a caption can carry it. */
+export function syncSummary(syncIntervalSeconds: number): string {
+  return syncIntervalSeconds === 0 ? "syncs each fix" : `syncs every ${formatDuration(syncIntervalSeconds)}`
+}
+
+/** The one line a preset row, the Custom row and the Settings row all print for a configuration. */
+export function trackingSummary(
+  intervalSeconds: number,
+  distanceMeters: number,
+  syncIntervalSeconds: number,
+  isOfflineMode: boolean
+): string {
+  const recording = recordingSummary(intervalSeconds, distanceMeters)
+  return isOfflineMode ? recording : `${recording} · ${syncSummary(syncIntervalSeconds)}`
 }
 
 export function intervalText(intervalSeconds: number, syncIntervalSeconds: number): string {

--- a/apps/mobile/src/utils/settingsValidation.ts
+++ b/apps/mobile/src/utils/settingsValidation.ts
@@ -31,3 +31,17 @@ export function parsePositiveInt(str: string, fallback: number): number {
 export function isPositiveInt(str: string): boolean {
   return parseInt(str, 10) >= 1
 }
+
+/** The digits of a whole number, or null: decimals, signs, exponents and the empty string never reach a setting. */
+export function parseWholeNumber(text: string): number | null {
+  return /^\d+$/.test(text) ? Number(text) : null
+}
+
+/** The error a numeric field shows while its text is non-empty and would not be stored. */
+export function wholeNumberError(text: string, min: number, unit: string): string | undefined {
+  if (text === "") return undefined
+  const value = parseWholeNumber(text)
+  if (value === null) return "A whole number"
+  if (value < min) return `At least ${min} ${unit}`
+  return undefined
+}


### PR DESCRIPTION
Tracking & sync rebuilt on the settings grammar: four titled groups, a cost clause on every row, the active profile as a StateLine inside the groups it overrides, whole-number fields with inline errors and clamp notes, the network name as a real field. Fixes the lost second edit inside the debounce and the preset flipping to Custom on unrelated changes. Docs paths and the preset table follow.
