### PR TITLE
fix(connection): offline mode hides the server and its details

### DIFF
--- a/apps/docs/docs/configuration/server-settings.md
+++ b/apps/docs/docs/configuration/server-settings.md
@@ -21,7 +21,7 @@ Self-signed and private-CA certificates are supported via three trust paths (sys
 
 On **Android 17+**, connecting to another device on the local network (everything above except `localhost`) requires the **ACCESS_LOCAL_NETWORK** permission. Colota requests this when you use **Test connection**. See [Permissions](/docs/development/permissions#local-network-access) for details.
 
-**Test connection** sits under the field. It sends your latest recorded location to the address with your credentials, so it needs one recorded fix, and it is disabled with the reason until it has one, while Offline mode is on or while the address does not pass. The result stays under the button until the next test or an edit: **Reachable** with the HTTP status and the time, or **Not reachable** with the status or "No response" and the server's own sentence. Test saves nothing itself; the field does, when you leave it.
+**Test connection** sits under the field. It sends your latest recorded location to the address with your credentials, so it needs one recorded fix, and it is disabled with the reason until it has one or while the address does not pass. The result stays under the button until the next test or an edit: **Reachable** with the HTTP status and the time, or **Not reachable** with the status or "No response" and the server's own sentence. Test saves nothing itself; the field does, when you leave it.
 
 ### Multiple Backends
 
@@ -67,9 +67,9 @@ If no locations are queued, offline mode enables immediately.
 
 The UI simplifies to remove sync-related elements that don't apply:
 
-**Hidden or disabled in offline mode:**
+**Hidden in offline mode:**
 
-- Test connection is disabled with the reason; the Server endpoint field stays editable so an address can be prepared
+- Server endpoint, Test connection and the Server details rows (Request format, Authentication, Client certificate); the sync state line and the Offline mode switch stay
 - Sync interval, Sync only on (Any network / Wi-Fi or Ethernet / Specific Wi-Fi network / VPN)
 - Queue statistics (Queued / Sent counts)
 - Queue actions (Sync Now, Clear Sent History, Clear Queue)

--- a/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
+++ b/apps/mobile/src/components/features/settings/ConnectionSettings.tsx
@@ -192,11 +192,9 @@ export function ConnectionSettings({
     ? "Enter a server endpoint to test."
     : !draftPasses
       ? "Fix the address above to test."
-      : settings.isOfflineMode
-        ? "Turn off Offline mode to test."
-        : !hasFix
-          ? "Needs one recorded location to send. Start tracking first."
-          : null
+      : !hasFix
+        ? "Needs one recorded location to send. Start tracking first."
+        : null
 
   const handleTestEndpoint = useCallback(async () => {
     Keyboard.dismiss()
@@ -301,97 +299,107 @@ export function ConnectionSettings({
             onValueChange={handleOfflineModeChange}
           />
         </SettingRow>
-        <Divider tight />
 
-        <View style={styles.block}>
-          <View>
-            <TextField
-              label="Server endpoint"
-              testID="endpoint-input"
-              mono
-              value={draft}
-              onChangeText={handleDraftChange}
-              onBlur={() => {
-                commitDraft()
-              }}
-              placeholder={example}
-              autoCapitalize="none"
-              autoCorrect={false}
-              keyboardType="url"
-              error={validation.error}
-            />
-            {!validation.error && <FieldMessage>{helper}</FieldMessage>}
-            {validation.warnings.map((warning) => (
-              <FieldMessage key={warning} variant="warning">
-                {warning}
-              </FieldMessage>
-            ))}
-          </View>
+        {/* A standalone tracker never sends, so the server and its details leave the screen with the toggle. */}
+        {!settings.isOfflineMode && (
+          <>
+            <Divider tight />
 
-          <View>
-            <Button
-              icon={Radio}
-              title="Test connection"
-              onPress={handleTestEndpoint}
-              disabled={testBlocker !== null}
-              loading={test?.kind === "testing"}
-              testID="test-connection-btn"
-            />
-            <FieldMessage>
-              {testBlocker ?? "Sends your latest recorded location to this endpoint with your credentials."}
-            </FieldMessage>
-          </View>
+            <View style={styles.block}>
+              <View>
+                <TextField
+                  label="Server endpoint"
+                  testID="endpoint-input"
+                  mono
+                  value={draft}
+                  onChangeText={handleDraftChange}
+                  onBlur={() => {
+                    commitDraft()
+                  }}
+                  placeholder={example}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="url"
+                  error={validation.error}
+                />
+                {!validation.error && <FieldMessage>{helper}</FieldMessage>}
+                {validation.warnings.map((warning) => (
+                  <FieldMessage key={warning} variant="warning">
+                    {warning}
+                  </FieldMessage>
+                ))}
+              </View>
 
-          {test?.kind === "testing" && (
-            <StateLine
-              icon={<ActivityIndicator size="small" color={colors.textLight} />}
-              iconColor={colors.textLight}
-              label="Testing"
-              caption="Sending your latest location"
-              testID="test-result"
-            />
-          )}
-          {test?.kind === "done" && (
-            <View>
-              <StateLine
-                icon={test.ok ? CircleCheckBig : CircleAlert}
-                iconColor={test.ok ? colors.success : colors.error}
-                label={test.ok ? "Reachable" : "Not reachable"}
-                caption={`${test.status > 0 ? `HTTP ${test.status}` : "No response"} · ${formatTime(Math.floor(test.at / 1000))}`}
-                testID="test-result"
-              />
-              {!test.ok && test.message ? <FieldMessage variant="error">{test.message}</FieldMessage> : null}
+              <View>
+                <Button
+                  icon={Radio}
+                  title="Test connection"
+                  onPress={handleTestEndpoint}
+                  disabled={testBlocker !== null}
+                  loading={test?.kind === "testing"}
+                  testID="test-connection-btn"
+                />
+                <FieldMessage>
+                  {testBlocker ?? "Sends your latest recorded location to this endpoint with your credentials."}
+                </FieldMessage>
+              </View>
+
+              {test?.kind === "testing" && (
+                <StateLine
+                  icon={<ActivityIndicator size="small" color={colors.textLight} />}
+                  iconColor={colors.textLight}
+                  label="Testing"
+                  caption="Sending your latest location"
+                  testID="test-result"
+                />
+              )}
+              {test?.kind === "done" && (
+                <View>
+                  <StateLine
+                    icon={test.ok ? CircleCheckBig : CircleAlert}
+                    iconColor={test.ok ? colors.success : colors.error}
+                    label={test.ok ? "Reachable" : "Not reachable"}
+                    caption={`${test.status > 0 ? `HTTP ${test.status}` : "No response"} · ${formatTime(Math.floor(test.at / 1000))}`}
+                    testID="test-result"
+                  />
+                  {!test.ok && test.message ? <FieldMessage variant="error">{test.message}</FieldMessage> : null}
+                </View>
+              )}
             </View>
-          )}
-        </View>
+          </>
+        )}
       </Card>
 
-      <SectionTitle style={styles.groupTop}>Server details</SectionTitle>
-      <Card rows>
-        <ListItem
-          testID="nav-request-format"
-          icon={Braces}
-          label="Request format"
-          sub={requestSummary}
-          onPress={() => navigation.navigate("Request Format")}
-        />
-        <Divider tight inset />
-        <ListItem
-          testID="nav-auth-settings"
-          icon={KeyRound}
-          label="Authentication"
-          sub={authSummary}
-          onPress={() => navigation.navigate("Auth Settings")}
-        />
-        <Divider tight inset />
-        <ListItem
-          testID="nav-mtls-settings"
-          icon={ShieldCheck}
-          label="Client certificate"
-          sub={certificateSummary}
-          onPress={() => navigation.navigate("mTLS Settings")}
-        />
-      </Card>
+      {!settings.isOfflineMode && (
+        <>
+          <SectionTitle style={styles.groupTop}>Server details</SectionTitle>
+          <Card rows>
+            <ListItem
+              testID="nav-request-format"
+              icon={Braces}
+              label="Request format"
+              sub={requestSummary}
+              onPress={() => navigation.navigate("Request Format")}
+            />
+            <Divider tight inset />
+            <ListItem
+              testID="nav-auth-settings"
+              icon={KeyRound}
+              label="Authentication"
+              sub={authSummary}
+              onPress={() => navigation.navigate("Auth Settings")}
+            />
+            <Divider tight inset />
+            <ListItem
+              testID="nav-mtls-settings"
+              icon={ShieldCheck}
+              label="Client certificate"
+              sub={certificateSummary}
+              onPress={() => navigation.navigate("mTLS Settings")}
+            />
+          </Card>
+        </>
+      )}
     </View>
   )
 }

--- a/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
+++ b/apps/mobile/src/components/features/settings/__tests__/ConnectionSettings.test.tsx
@@ -134,12 +134,15 @@ describe("ConnectionSettings", () => {
       expect(getByText("Server endpoint")).toBeTruthy()
     })
 
-    it("keeps the field editable under offline mode and disables Test with the reason, rather than hiding either", () => {
-      const { getByText, getByTestId } = renderComponent({ isOfflineMode: true })
+    it("drops the server and its details under offline mode, since a standalone tracker never sends", () => {
+      const { getByText, queryByTestId, queryByText } = renderComponent({ isOfflineMode: true })
 
-      expect(getByTestId("endpoint-input")).toBeTruthy()
-      expect(getByTestId("test-connection-btn").props.accessibilityState.disabled).toBe(true)
-      expect(getByText("Turn off Offline mode to test.")).toBeTruthy()
+      expect(getByText("Synced")).toBeTruthy()
+      expect(getByText("Offline mode")).toBeTruthy()
+      expect(queryByTestId("endpoint-input")).toBeNull()
+      expect(queryByTestId("test-connection-btn")).toBeNull()
+      expect(queryByText("Server details")).toBeNull()
+      expect(queryByTestId("nav-auth-settings")).toBeNull()
     })
 
     it("shows the template's endpoint shape as the persistent helper", () => {


### PR DESCRIPTION
Offline mode hides the server block and the Server details card on Connection; only the state line and the toggle remain, for people who use Colota purely offline.
