### PR TITLE
refactor(profiles): a profile reads as a rule and the list says which one is in force

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -246,7 +246,7 @@ The stationary condition is decided by the fixes and never by a timer. `evaluate
 
 ### ProfileHelper
 
-Database access layer for tracking profiles and trip events. Maintains a `TimedCache` of enabled profiles (30s TTL) and provides CRUD operations plus trip event logging.
+Database access layer for tracking profiles and trip events. Maintains a `TimedCache` of enabled profiles (30s TTL) ordered by priority then id, so equal priorities go to the older profile, and provides CRUD operations plus trip event logging.
 
 ### ConditionMonitor
 
@@ -309,8 +309,8 @@ For backups, two `internal` methods support the export/import flow without expos
 | `GeofenceScreen` | Pause zones as rows over a map. Create geofence opens the editor on an empty draft; deletion happens there |
 | `GeofenceEditorScreen` | Every property of a zone: name, radius, location, record pause, WiFi pause, motionless pause and timeout, stationary heartbeat |
 | `PlaceZoneScreen` | Picks a zone coordinate on a map with the radius drawn live, returning it to the editor with `popTo` and `merge` |
-| `TrackingProfilesScreen` | List and manage condition-based tracking profiles |
-| `ProfileEditorScreen` | Create/edit a profile's name, condition, GPS settings, priority, and deactivation delay |
+| `TrackingProfilesScreen` | One card: a state line naming the profile in force (or what applies instead), then a row per profile in evaluation order reading as a rule, each with its enabled switch |
+| `ProfileEditorScreen` | The rule as a live sentence, then Condition, Profile (name, priority), Tracking while active and Switching, with inline validation and a Save button |
 | `LocationHistoryScreen` | One day at a time: a day header (chevrons, title opening the calendar dialog, ledger caption) over Map, Trips and Data lenses. Map docks a card over the track: the trip rows as legend, the tapped point (split, delete, note) or the empty day's next step. Trips is one card of trip rows; long-press turns the header into a contextual action bar for export, merge and delete. Data is a frozen-time table whose row tap opens the point on the map. Export of the day and the summary live in the header |
 | `TripDetailScreen` | A trip stepper (swatch, name, date and times) over the trip's map, where a tapped point docks its card for split and note; a ledger of distance, duration, speed, points and elevation, then the speed and elevation charts; export and delete in the header |
 | `LocationSummaryScreen` | A period stepper (week or month) over a ledger of distance, trips, active days and average, and the period's days as rows that open the day in Location History; each period is read from the daily stats on its own, since a year or all time would walk every row |

--- a/apps/docs/docs/guides/tracking-profiles.md
+++ b/apps/docs/docs/guides/tracking-profiles.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
-Tracking profiles automatically adjust GPS interval, distance filter, and sync settings when conditions like charging, car mode, or speed thresholds are met.
+A tracking profile is a rule: while a condition holds, such as charging, Android Auto or a speed, Colota records and syncs with that profile's interval, movement threshold and sync interval instead of the Tracking & sync values.
 
 <ScreenshotGallery screenshots={[ { src: "/img/screenshots/TrackingProfiles.png", label: "Tracking profiles" }, ]} />
 
@@ -20,23 +20,27 @@ Tracking profiles automatically adjust GPS interval, distance filter, and sync s
 ## Setup
 
 1. Go to **Settings** → **Tracking profiles**
-2. Tap **Create Profile**
-3. Enter a name and select a condition trigger
-4. Configure the GPS interval, distance filter, and sync interval
-5. Set a priority (higher priority profiles take precedence when multiple conditions match)
-6. Tap **Create Profile** to save
+2. Tap **Create profile** in the app bar
+3. Pick the condition; each row says what watching it costs, and a speed condition asks for the speed
+4. Optionally name it (blank saves as the condition's name) and set a priority
+5. Set the tracking interval, movement threshold and sync interval; each field says which Tracking & sync value it replaces
+6. Tap **Create profile**
 
-Tap a profile in the list to edit it.
+The editor's first line reads the rule back as you build it, for example "When charging, track every 5 s, any movement and sync each fix." Tap a profile in the list to edit it; Delete is at the bottom of the editor.
+
+## The list
+
+The list opens with a line that says which profile is in force and its values, "No profile active · Tracking & sync applies: …" while tracking runs without one, or "Profiles apply while tracking runs" while tracking is off. Below it every profile is one row in evaluation order, reading as a sentence: condition, then what it records, then how it syncs, for example "When charging · Every 5 s, any movement · syncs each fix". The row in force opens with "Active". The switch beside a row enables or disables it without opening it; a disabled profile is never in force.
 
 ## Condition Types
 
-| Condition       | Trigger                                                   |
-| --------------- | --------------------------------------------------------- |
-| **Charging**    | Phone is plugged in to a power source                     |
-| **Car Mode**    | Android Auto is connected                                 |
-| **Speed Above** | Average speed exceeds the configured threshold (km/h)     |
-| **Speed Below** | Average speed drops below the configured threshold (km/h) |
-| **Stationary**  | Device not moving for approximately 60 seconds            |
+| Condition | Trigger | Cost |
+| --- | --- | --- |
+| **Charging** | Phone is plugged in to a power source | Nothing to watch |
+| **Android Auto** | Android Auto is connected | Nothing to watch |
+| **Speed above** | Average speed exceeds the speed you set (km/h or mph) | Fixes keep flowing to measure it, even below the movement threshold |
+| **Speed below** | Average speed drops below the speed you set (km/h or mph) | Fixes keep flowing to measure it, even below the movement threshold |
+| **Stationary** | Still for the activation delay (60 s by default) | Fixes keep flowing to measure it; movement threshold not used |
 
 Speed conditions use a rolling average of the last 5 GPS readings to avoid triggering on momentary speed spikes. The stationary condition uses a fixed speed threshold (0.3 m/s) that has to hold across 60 seconds of fixes, so unlike speed-below it does not flap on GPS noise near zero. The window is measured over the fixes themselves, so a stretch with no fixes at all is not counted as stillness and the profile waits for the stream instead of switching on.
 
@@ -62,20 +66,20 @@ Your distance filter does not have that effect: whenever a speed or stationary p
 
 Each profile overrides the default tracking configuration with:
 
-- **GPS Interval** - How often to request a location fix (seconds)
-- **Distance Filter** - Minimum movement required between updates (meters)
-- **Sync Interval** - How often to sync with the server (Instant, 1 min, 5 min, 15 min, or Custom)
-- **Priority** - Determines which profile wins when multiple conditions match simultaneously (higher = wins)
+- **Tracking interval** - How often to request a location fix (seconds)
+- **Movement threshold** - Minimum movement required between updates (meters or feet)
+- **Sync interval** - How often to sync with the server (Instant, 1 min, 5 min, 15 min, or Custom)
+- **Priority** - Determines which profile wins when multiple conditions match simultaneously (higher wins; equal numbers go to the older profile)
 - **Activation Delay** - How long the condition must keep matching before the profile is applied (seconds, default 0 = immediate). Prevents activating on brief spikes, e.g. a momentary speed reading. For the Stationary condition it instead sets how long the device must be still before the profile activates (default 60s).
 - **Deactivation Delay** - How long to wait after the condition stops matching before reverting to default settings (seconds). Prevents rapid toggling when conditions fluctuate.
 
-When creating a new profile, GPS interval, distance filter, and sync interval are pre-filled with your current values from main Settings. Each field also shows a hint with the default value for reference.
+When creating a new profile, the tracking interval, movement threshold and sync interval are pre-filled with your current Tracking & sync values, and each field says which value it replaces. The values a profile hands back to are the ones the service loaded when tracking started; a Tracking & sync change applies at the next restart.
 
 **Choosing delay values:** together the two delays make a profile "sticky" - hard to switch on by accident, hard to switch off by accident. Clean on/off signals like Charging and Android Auto want activation 0 (switch the instant you plug in or connect) plus a small deactivation delay so a brief disconnect or cable wiggle does not drop you. Noisy signals like speed want both: an activation delay to ignore short spikes (a Driving profile won't trigger from one GPS glitch while you walk) and a longer deactivation delay to ride through red lights, traffic and tunnels without flapping. Rule of thumb: if a profile keeps flickering on and off, raise the delays; if it reacts too slowly, lower them. Tracking never stops during either wait - you stay on your defaults through an activation delay, and on the profile through a deactivation delay.
 
 ## Priority
 
-When multiple conditions match at the same time, the profile with the highest priority wins.
+When multiple conditions match at the same time, the profile with the highest priority wins; equal priorities go to the older profile. The list shows profiles in that order, so it is the order they are checked in.
 
 :::tip[Combining Profiles]
 
@@ -88,8 +92,8 @@ If you use both a Speed Below and a Stationary profile, give Stationary the high
 | Profile | Condition | Interval | Distance | Priority | Activation | Deactivation | Use case |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Stationary | Stationary | 1800s | 0m | 40 | 60s | n/a | Heartbeat while not moving |
-| Driving | Car Mode | 10s | 1m | 30 | 0s | 30s | Detailed route while driving |
-| Walking | Speed Below 8 km/h | 60s | 2m | 20 | 20s | 45s | Battery-friendly on foot |
+| Driving | Android Auto | 10s | 1m | 30 | 0s | 30s | Detailed route while driving |
+| Walking | Speed below 8 km/h | 60s | 2m | 20 | 20s | 45s | Battery-friendly on foot |
 | Charging | Charging | 15s | 0m | 10 | 0s | 30s | High accuracy while plugged in |
 
 Note that Stationary has the highest priority so it takes over from Walking when you stop. Charging has the lowest priority so a more specific profile (e.g. Driving) wins when both match.
@@ -107,9 +111,13 @@ Note that Stationary has the highest priority so it takes over from Walking when
 
 ## Active Profile Indicators
 
-When a profile is active, Colota shows it in two places:
+When a profile is active, Colota shows it in four places:
 
 - **Notification** - The foreground notification title changes from "Colota Tracking" to "Colota · ProfileName" (e.g., "Colota · Charging")
-- **Dashboard** - An info card appears on the map showing the active profile name. When inside a pause zone, the pause card shows which profile will resume on exit (e.g., "Profile 'Charging' resumes on exit").
+- **Dashboard** - The state line reads "Tracking · ProfileName"
+- **Tracking profiles** - The list's first line names it with the values in force, and its row opens with "Active"
+- **Tracking & sync** - A line above the Recording and Sync interval groups names it with the values in force
 
-Both indicators disappear automatically when the profile deactivates (after the deactivation delay) or when tracking stops.
+All of them clear when the profile deactivates (after the deactivation delay) or when tracking stops.
+
+A blank name saves as the condition's name, so two untouched charging profiles are both called "Charging"; a setup link import replaces a profile by name, so give profiles you share distinct names.

--- a/apps/mobile/android/app/src/main/java/com/colota/data/ProfileHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/data/ProfileHelper.kt
@@ -56,7 +56,7 @@ class ProfileHelper(private val context: Context) {
                 ),
                 "enabled = 1",
                 null, null, null,
-                "priority DESC"
+                "priority DESC, id ASC"
             ).use { cursor ->
                 val idIdx = cursor.getColumnIndexOrThrow("id")
                 val nameIdx = cursor.getColumnIndexOrThrow("name")
@@ -98,7 +98,7 @@ class ProfileHelper(private val context: Context) {
             dbHelper.readableDatabase.query(
                 DatabaseHelper.TABLE_PROFILES,
                 null, null, null, null, null,
-                "priority DESC"
+                "priority DESC, id ASC"
             ).use { cursor ->
                 val idIdx = cursor.getColumnIndexOrThrow("id")
                 val nameIdx = cursor.getColumnIndexOrThrow("name")

--- a/apps/mobile/android/app/src/test/java/com/Colota/data/ProfileHelperTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/data/ProfileHelperTest.kt
@@ -110,6 +110,17 @@ class ProfileHelperTest {
     }
 
     @Test
+    fun `getEnabledProfiles asks for priority then id, so equal priorities go to the older profile`() {
+        val cursor = mockCursorWithProfiles(emptyList())
+        val order = slot<String>()
+        every { mockDb.query(any(), any(), eq("enabled = 1"), any(), any(), any(), capture(order)) } returns cursor
+
+        ProfileHelper(mockk(relaxed = true)).getEnabledProfiles()
+
+        assertEquals("priority DESC, id ASC", order.captured)
+    }
+
+    @Test
     fun `getEnabledProfiles returns profiles from database`() {
         val cursor = mockCursorWithProfiles(listOf(
             mapOf(

--- a/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
+++ b/apps/mobile/src/components/features/settings/SyncStrategySettings.tsx
@@ -31,7 +31,8 @@ import { SyncIntervalPicker } from "./SyncIntervalPicker"
 import { useTheme } from "../../../hooks/useTheme"
 import { useTimeout } from "../../../hooks/useTimeout"
 import { shortDistanceUnit, inputToMeters, metersToInput } from "../../../utils/geo"
-import { recordingSummary, syncSummary, trackingSummary } from "../../../utils/dashboardState"
+import { syncSummary, trackingSummary } from "../../../utils/dashboardState"
+import { recordingClause } from "../../../utils/profileRow"
 import { parseWholeNumber, wholeNumberError } from "../../../utils/settingsValidation"
 import { isOverlandFormat } from "../../../utils/apiPayload"
 import NativeLocationService from "../../../services/NativeLocationService"
@@ -233,7 +234,7 @@ export function SyncStrategySettings({
               icon={UserRoundPen}
               iconColor={colors.textSecondary}
               label={`${activeProfile.name} is active`}
-              caption={`In force: ${lowerFirst(recordingSummary(activeProfile.interval, activeProfile.distance))}`}
+              caption={`In force: ${lowerFirst(recordingClause(activeProfile))}`}
               testID="profile-override-recording"
             />
             <Divider tight />

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -16,7 +16,13 @@ type ListItemProps = {
   label: string
   sub?: string
   icon?: IconComponent
+  /** Tints the leading icon; the default is `textLight`, or `textDisabled` while disabled. */
+  iconColor?: string
   trailingIcon?: IconComponent
+  /** A control of its own beside the body, behind a hairline: the row opens, the control allows. Replaces the chevron. */
+  trailing?: React.ReactNode
+  /** The sub wraps once when 2, for a row that must carry a full sentence beside a control. */
+  subLines?: 1 | 2
   onPress: () => void
   testID?: string
   accessibilityRole?: "button" | "link"
@@ -29,7 +35,10 @@ export function ListItem({
   label,
   sub,
   icon: Icon,
+  iconColor,
   trailingIcon: TrailingIcon = ChevronRight,
+  trailing,
+  subLines = 1,
   onPress,
   testID,
   accessibilityRole = "button",
@@ -38,7 +47,7 @@ export function ListItem({
   expanded
 }: ListItemProps) {
   const { colors } = useTheme()
-  return (
+  const body = (
     <Pressable
       testID={testID}
       accessibilityRole={accessibilityRole}
@@ -48,11 +57,11 @@ export function ListItem({
       android_ripple={disabled ? undefined : { color: colors.text + STATE_LAYER_ALPHA }}
       disabled={disabled}
       onPress={onPress}
-      style={styles.row}
+      style={[styles.row, trailing !== undefined && styles.body]}
     >
       {Icon && (
         <View style={styles.icon}>
-          <Icon size={size.icon.md} color={disabled ? colors.textDisabled : colors.textLight} />
+          <Icon size={size.icon.md} color={disabled ? colors.textDisabled : (iconColor ?? colors.textLight)} />
         </View>
       )}
       <View style={styles.content}>
@@ -60,14 +69,24 @@ export function ListItem({
         {sub ? (
           <Text
             style={[styles.sub, { color: disabled ? colors.textDisabled : colors.textSecondary }]}
-            numberOfLines={1}
+            numberOfLines={subLines}
           >
             {sub}
           </Text>
         ) : null}
       </View>
-      <TrailingIcon size={size.icon.md} color={disabled ? colors.textDisabled : colors.textLight} />
+      {trailing === undefined && (
+        <TrailingIcon size={size.icon.md} color={disabled ? colors.textDisabled : colors.textLight} />
+      )}
     </Pressable>
+  )
+  if (trailing === undefined) return body
+  return (
+    <View style={styles.split}>
+      {body}
+      <View style={[styles.rule, { backgroundColor: colors.divider }]} />
+      {trailing}
+    </View>
   )
 }
 
@@ -79,6 +98,23 @@ const styles = StyleSheet.create({
     paddingVertical: space.lg,
     marginHorizontal: -space.lg,
     paddingHorizontal: space.lg
+  },
+  // The body keeps the row's inset on its start edge only; the control after the rule sits at the card's own inset.
+  split: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginEnd: -space.lg,
+    paddingEnd: space.lg
+  },
+  body: {
+    flex: 1,
+    marginEnd: 0,
+    paddingEnd: 0
+  },
+  rule: {
+    width: StyleSheet.hairlineWidth,
+    height: size.iconButton,
+    marginHorizontal: space.md
   },
   icon: {
     marginEnd: space.lg

--- a/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
+++ b/apps/mobile/src/components/ui/__tests__/ListItem.test.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { render } from "@testing-library/react-native"
-import { StyleSheet } from "react-native"
-import { space } from "../../../constants"
+import { render, fireEvent } from "@testing-library/react-native"
+import { StyleSheet, Switch } from "react-native"
+import { lightColors } from "@colota/shared"
+import { size, space } from "../../../constants"
 
 jest.mock("../../../hooks/useTheme", () => ({
   useTheme: () => ({ colors: require("@colota/shared").lightColors })
@@ -48,5 +49,57 @@ describe("ListItem", () => {
     expect(style.marginHorizontal).toBe(-space.lg)
     expect(style.paddingHorizontal).toBe(space.lg)
     expect(style.marginHorizontal + style.paddingHorizontal).toBe(0)
+  })
+
+  it("seats a trailing control outside the body behind a hairline, so the row opens and the control allows", () => {
+    const onPress = jest.fn()
+    const onValueChange = jest.fn()
+    const { getByTestId, getByRole, UNSAFE_getAllByType } = render(
+      <ListItem
+        label="Driving"
+        sub="When charging"
+        onPress={onPress}
+        testID="row"
+        trailing={<Switch testID="use" value onValueChange={onValueChange} />}
+      />
+    )
+
+    fireEvent.press(getByTestId("row"))
+    expect(onPress).toHaveBeenCalledTimes(1)
+    fireEvent(getByRole("switch"), "valueChange", false)
+    expect(onValueChange).toHaveBeenCalledWith(false)
+    expect(onPress).toHaveBeenCalledTimes(1)
+
+    const { View } = require("react-native")
+    const rule = UNSAFE_getAllByType(View).find(
+      (v: any) => StyleSheet.flatten(v.props.style)?.width === StyleSheet.hairlineWidth
+    )
+    expect(StyleSheet.flatten(rule?.props.style).height).toBe(size.iconButton)
+    expect(StyleSheet.flatten(rule?.props.style).backgroundColor).toBe(lightColors.divider)
+  })
+
+  it("tints the leading glyph on request and lets the sub wrap once when asked", () => {
+    const Icon = (props: any) => {
+      const { Text } = require("react-native")
+      return (
+        <Text testID="glyph" {...props}>
+          i
+        </Text>
+      )
+    }
+    const { getByTestId, getByText } = render(
+      <ListItem
+        label="Driving"
+        sub="Active · when charging"
+        icon={Icon}
+        iconColor="#123456"
+        subLines={2}
+        onPress={jest.fn()}
+        testID="row"
+      />
+    )
+
+    expect(getByTestId("glyph").props.color).toBe("#123456")
+    expect(getByText("Active · when charging").props.numberOfLines).toBe(2)
   })
 })

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -69,12 +69,10 @@ export const GEOFENCE_ZOOM_PADDING = [80, 80, 80, 80] as const
 export const MAP_ANIMATION_DURATION_MS = 400
 export const LOADING_INDICATOR_DELAY_MS = 200
 
-// Profiles
-export const MS_TO_KMH = 3.6
-
 // Doze batches motion sensors past this; longer Stationary intervals risk missed trip starts.
 export const STATIONARY_MAX_INTERVAL_SECONDS = 60
 
+/** `label` names the condition, `listLabel` opens a row's sentence, `description` says what watching it costs. */
 export const PROFILE_CONDITIONS: {
   type: ProfileConditionType
   label: string
@@ -82,40 +80,46 @@ export const PROFILE_CONDITIONS: {
   icon: typeof Zap
   description: string
 }[] = [
-  { type: "charging", label: "Charging", listLabel: "When charging", icon: Zap, description: "Phone is plugged in" },
+  {
+    type: "charging",
+    label: "Charging",
+    listLabel: "When charging",
+    icon: Zap,
+    description: "Phone is plugged in · costs nothing to watch"
+  },
   {
     type: "android_auto",
-    label: "Car Mode",
-    listLabel: "Android Auto / Car mode",
+    label: "Android Auto",
+    listLabel: "On Android Auto",
     icon: Car,
-    description: "Android Auto connected"
+    description: "Android Auto is connected · costs nothing to watch"
   },
   {
     type: "speed_above",
-    label: "Speed Above",
+    label: "Speed above",
     listLabel: "Speed above",
     icon: ArrowUp,
-    description: "Moving faster than threshold"
+    description:
+      "Average of the last 5 fixes is faster than the speed below · fixes keep flowing to measure it, even below the movement threshold"
   },
   {
     type: "speed_below",
-    label: "Speed Below",
+    label: "Speed below",
     listLabel: "Speed below",
     icon: ArrowDown,
-    description: "Moving slower than threshold"
+    description:
+      "Average of the last 5 fixes is slower than the speed below · fixes keep flowing to measure it, even below the movement threshold"
   },
   {
     type: "stationary",
     label: "Stationary",
     listLabel: "When stationary",
     icon: Pause,
-    description: "Not moving for ~60 seconds"
+    description:
+      "Still for the activation delay · records a point every interval, movement threshold not used · fixes keep flowing to measure it"
   }
 ]
 
-// Per-condition default switch delays (seconds). Stationary enters via a stillness window
-// (activation) and exits instantly via the hardware motion sensor (deactivation 0); every
-// other condition is the inverse. Single source of truth for both the editor and import.
 export function defaultProfileDelays(conditionType: ProfileConditionType): {
   activationDelay: number
   deactivationDelay: number

--- a/apps/mobile/src/screens/ProfileEditorScreen.tsx
+++ b/apps/mobile/src/screens/ProfileEditorScreen.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useLayoutEffect, useCallback } from "react"
 import { View, Text, StyleSheet, ScrollView } from "react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
+import { useTimeout } from "../hooks/useTimeout"
 import { ProfileService } from "../services/ProfileService"
 import { showAlert, showConfirm } from "../services/modalService"
 import { TrackingProfile, ProfileConditionType } from "../types/global"
@@ -18,6 +19,7 @@ import {
   Container,
   Divider,
   FieldMessage,
+  NumericInput,
   RadioRow,
   SectionTitle,
   SettingRow,
@@ -25,11 +27,13 @@ import {
 } from "../components"
 import { Check, Trash2 } from "lucide-react-native"
 import { logger } from "../utils/logger"
-import { shortDistanceUnit, inputToMeters, metersToInput } from "../utils/geo"
+import { shortDistanceUnit, inputToMeters, metersToInput, getSpeedUnit, speedToInput, inputToSpeed } from "../utils/geo"
 import { formatDuration } from "../utils/dashboardState"
+import { conditionOf, profileSentence } from "../utils/profileRow"
+import { parseWholeNumber, wholeNumberError } from "../utils/settingsValidation"
 import {
-  MS_TO_KMH,
   PROFILE_CONDITIONS,
+  SAVE_SUCCESS_DISPLAY_MS,
   SYNC_INTERVAL_LABELS,
   STATIONARY_MAX_INTERVAL_SECONDS,
   defaultProfileDelays,
@@ -38,35 +42,43 @@ import {
 } from "../constants"
 import type { RootScreenProps } from "../types/navigation"
 
-function formatSyncDefault(seconds: number): string {
-  return SYNC_INTERVAL_LABELS[seconds] ?? formatDuration(seconds)
-}
+type Draft = Omit<TrackingProfile, "id" | "createdAt">
+type NumericKey = "interval" | "distance" | "activationDelay" | "deactivationDelay" | "speed"
+
+const DEFAULT_SPEED_INPUT = 30
+const DEFAULT_PRIORITY = 10
+
+const isSpeedType = (type: ProfileConditionType) => type === "speed_above" || type === "speed_below"
 
 export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Profile Editor">) {
   const { colors } = useTheme()
   const { settings } = useTracking()
   const profileId = route?.params?.profileId as number | undefined
   const isEditing = !!profileId
+  const distanceUnit = shortDistanceUnit()
+  const speedUnit = getSpeedUnit().unit
 
-  const [profile, setProfile] = useState<Omit<TrackingProfile, "id" | "createdAt">>({
+  const [profile, setProfile] = useState<Draft>({
     name: "",
     interval: settings.interval,
     distance: settings.distance,
     syncInterval: settings.syncInterval,
-    priority: 10,
+    priority: DEFAULT_PRIORITY,
     condition: { type: "charging" },
     ...defaultProfileDelays("charging"),
     enabled: true
   })
-  const [speedKmh, setSpeedKmh] = useState("30")
   const [saving, setSaving] = useState(false)
-
-  // String representations for numeric inputs
-  const [intervalStr, setIntervalStr] = useState(String(settings.interval))
-  const [distanceStr, setDistanceStr] = useState(String(metersToInput(settings.distance)))
-  const [priorityStr, setPriorityStr] = useState("10")
-  const [activationDelayStr, setActivationDelayStr] = useState("0")
-  const [delayStr, setDelayStr] = useState("60")
+  const [text, setText] = useState({
+    interval: String(settings.interval),
+    distance: String(metersToInput(settings.distance)),
+    speed: String(DEFAULT_SPEED_INPUT),
+    priority: String(DEFAULT_PRIORITY),
+    activationDelay: String(defaultProfileDelays("charging").activationDelay),
+    deactivationDelay: String(defaultProfileDelays("charging").deactivationDelay)
+  })
+  const [note, setNote] = useState<{ key: NumericKey; text: string } | null>(null)
+  const noteTimer = useTimeout()
 
   useLayoutEffect(() => {
     navigation.setOptions({ headerTitle: isEditing ? "Edit profile" : "New profile" })
@@ -74,31 +86,31 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 
   useEffect(() => {
     if (!profileId) return
-
     ProfileService.getProfiles()
       .then((profiles) => {
         const existing = profiles.find((p) => p.id === profileId)
-        if (existing) {
-          setProfile({
-            name: existing.name,
-            interval: existing.interval,
-            distance: existing.distance,
-            syncInterval: existing.syncInterval,
-            priority: existing.priority,
-            condition: existing.condition,
-            activationDelay: existing.activationDelay,
-            deactivationDelay: existing.deactivationDelay,
-            enabled: existing.enabled
-          })
-          setIntervalStr(String(existing.interval))
-          setDistanceStr(String(metersToInput(existing.distance)))
-          setPriorityStr(String(existing.priority))
-          setActivationDelayStr(String(existing.activationDelay))
-          setDelayStr(String(existing.deactivationDelay))
-          if (existing.condition.speedThreshold) {
-            setSpeedKmh((existing.condition.speedThreshold * MS_TO_KMH).toFixed(0))
-          }
-        }
+        if (!existing) return
+        setProfile({
+          name: existing.name,
+          interval: existing.interval,
+          distance: existing.distance,
+          syncInterval: existing.syncInterval,
+          priority: existing.priority,
+          condition: existing.condition,
+          activationDelay: existing.activationDelay,
+          deactivationDelay: existing.deactivationDelay,
+          enabled: existing.enabled
+        })
+        setText({
+          interval: String(existing.interval),
+          distance: String(metersToInput(existing.distance)),
+          speed: String(
+            existing.condition.speedThreshold ? speedToInput(existing.condition.speedThreshold) : DEFAULT_SPEED_INPUT
+          ),
+          priority: String(existing.priority),
+          activationDelay: String(existing.activationDelay),
+          deactivationDelay: String(existing.deactivationDelay)
+        })
       })
       .catch((err) => {
         logger.error("[ProfileEditor] Failed to load profile:", err)
@@ -107,59 +119,87 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
       })
   }, [profileId, navigation])
 
-  const handleNumericChange = useCallback(
-    (setter: (v: string) => void, field: keyof typeof profile, value: string, min = 0) => {
-      setter(value)
-      const num = Number(value)
-      if (!isNaN(num) && num >= min) {
-        const stored = field === "distance" ? inputToMeters(num) : num
-        setProfile((prev) => ({ ...prev, [field]: stored }))
-      }
-    },
-    []
-  )
+  const type = profile.condition.type
+  const isSpeed = isSpeedType(type)
+  const isStationary = type === "stationary"
+  const conditionLabel = conditionOf(profile).label
 
-  const setConditionType = useCallback(
-    (type: ProfileConditionType) => {
-      const isSpeed = type === "speed_above" || type === "speed_below"
-      const isStationary = type === "stationary"
-      const { activationDelay: defaultActivation, deactivationDelay: defaultDeactivation } = defaultProfileDelays(type)
-      setProfile((prev) => ({
-        ...prev,
-        // A distance filter is ignored for a stationary profile; store 0 so UI, DB and runtime agree.
-        distance: isStationary ? 0 : prev.distance,
-        deactivationDelay: prev.condition.type !== type ? defaultDeactivation : prev.deactivationDelay,
-        activationDelay: prev.condition.type !== type ? defaultActivation : prev.activationDelay,
-        condition: {
-          type,
-          ...(isSpeed ? { speedThreshold: Number(speedKmh) / MS_TO_KMH } : {})
-        }
-      }))
-      if (isStationary) setDistanceStr("0")
-      if (profile.condition.type !== type) {
-        setDelayStr(String(defaultDeactivation))
-        setActivationDelayStr(String(defaultActivation))
-      }
-    },
-    [speedKmh, profile.condition.type]
-  )
-
-  const handleSpeedChange = useCallback((val: string) => {
-    setSpeedKmh(val)
-    const num = Number(val)
-    if (!isNaN(num) && num > 0) {
-      setProfile((prev) => ({
-        ...prev,
-        condition: { ...prev.condition, speedThreshold: num / MS_TO_KMH }
-      }))
-    }
+  const store = useCallback((key: NumericKey, value: number) => {
+    setProfile((prev) => {
+      if (key === "speed") return { ...prev, condition: { ...prev.condition, speedThreshold: inputToSpeed(value) } }
+      if (key === "distance") return { ...prev, distance: inputToMeters(value) }
+      return { ...prev, [key]: value }
+    })
   }, [])
+
+  const minOf = (key: NumericKey) => (key === "interval" || key === "speed" ? 1 : 0)
+  const unitOf = (key: NumericKey) => (key === "distance" ? distanceUnit : key === "speed" ? speedUnit : "s")
+
+  const handleNumeric = (key: NumericKey, value: string) => {
+    setText((prev) => ({ ...prev, [key]: value }))
+    setNote(null)
+    const num = parseWholeNumber(value)
+    if (num !== null && num >= minOf(key)) store(key, num)
+  }
+
+  // An empty or below-minimum box clamps to the minimum on blur and says so, the Tracking & sync rule.
+  const handleBlur = (key: NumericKey) => {
+    const min = minOf(key)
+    const num = parseWholeNumber(text[key])
+    if (num !== null && num >= min) return
+    setText((prev) => ({ ...prev, [key]: String(min) }))
+    setNote({ key, text: `Set to ${min} ${unitOf(key)}` })
+    noteTimer.set(() => setNote(null), SAVE_SUCCESS_DISPLAY_MS)
+    store(key, min)
+  }
+
+  const errorOf = (key: NumericKey) => wholeNumberError(text[key], minOf(key), unitOf(key))
+  const noteOf = (key: NumericKey) => (note?.key === key ? note.text : undefined)
+
+  const priorityError = text.priority !== "" && parseWholeNumber(text.priority) === null ? "A whole number" : undefined
+  const handlePriority = (value: string) => {
+    setText((prev) => ({ ...prev, priority: value }))
+    const num = parseWholeNumber(value)
+    if (num !== null) setProfile((prev) => ({ ...prev, priority: num }))
+  }
+  const handlePriorityBlur = () => {
+    if (parseWholeNumber(text.priority) === null) setText((prev) => ({ ...prev, priority: String(profile.priority) }))
+  }
+
+  const setConditionType = (next: ProfileConditionType) => {
+    if (next === type) return
+    const previousDefaults = defaultProfileDelays(type)
+    const nextDefaults = defaultProfileDelays(next)
+    const keepDelays =
+      profile.activationDelay !== previousDefaults.activationDelay ||
+      profile.deactivationDelay !== previousDefaults.deactivationDelay
+    const delays = keepDelays
+      ? { activationDelay: profile.activationDelay, deactivationDelay: profile.deactivationDelay }
+      : nextDefaults
+    const speedThreshold = isSpeedType(next)
+      ? (profile.condition.speedThreshold ?? inputToSpeed(parseWholeNumber(text.speed) ?? DEFAULT_SPEED_INPUT))
+      : undefined
+    setProfile((prev) => ({
+      ...prev,
+      ...delays,
+      // A distance filter is ignored for a stationary profile; store 0 so UI, DB and runtime agree.
+      distance: next === "stationary" ? 0 : prev.distance,
+      condition: { type: next, ...(speedThreshold !== undefined ? { speedThreshold } : {}) }
+    }))
+    setText((prev) => ({
+      ...prev,
+      distance: next === "stationary" ? "0" : prev.distance,
+      activationDelay: String(delays.activationDelay),
+      deactivationDelay: String(delays.deactivationDelay),
+      speed: speedThreshold !== undefined ? String(speedToInput(speedThreshold)) : prev.speed
+    }))
+  }
 
   const handleDelete = useCallback(async () => {
     if (!profileId) return
     const confirmed = await showConfirm({
       title: "Delete profile",
-      message: `Delete "${profile.name}"?`,
+      message: `Delete "${profile.name || conditionLabel}"?`,
       confirmText: "Delete",
       destructive: true
     })
@@ -171,29 +211,24 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
       logger.error("[ProfileEditor] Delete failed:", err)
       showAlert("Error", "Failed to delete profile.", "error")
     }
-  }, [profileId, profile.name, navigation])
+  }, [profileId, profile.name, conditionLabel, navigation])
+
+  const hasFieldError =
+    !!priorityError ||
+    !!errorOf("interval") ||
+    (!isStationary && !!errorOf("distance")) ||
+    (isSpeed && !!errorOf("speed")) ||
+    !!errorOf("activationDelay") ||
+    (!isStationary && !!errorOf("deactivationDelay"))
 
   const handleSave = useCallback(async () => {
-    if (!profile.name.trim()) {
-      showAlert("Missing Name", "Please enter a profile name.", "warning")
-      return
-    }
-    if (profile.interval < 1) {
-      showAlert("Invalid Interval", "Tracking interval must be at least 1 second.", "warning")
-      return
-    }
-    const isSpeed = profile.condition.type === "speed_above" || profile.condition.type === "speed_below"
-    if (isSpeed && (!profile.condition.speedThreshold || profile.condition.speedThreshold <= 0)) {
-      showAlert("Missing Speed", "Speed conditions require a positive speed threshold.", "warning")
-      return
-    }
-
+    const next: Draft = { ...profile, name: profile.name.trim() || conditionLabel }
     setSaving(true)
     try {
       if (isEditing && profileId) {
-        await ProfileService.updateProfile({ id: profileId, ...profile })
+        await ProfileService.updateProfile({ id: profileId, ...next })
       } else {
-        await ProfileService.createProfile(profile)
+        await ProfileService.createProfile(next)
       }
       navigation.goBack()
     } catch (err) {
@@ -202,9 +237,9 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
     } finally {
       setSaving(false)
     }
-  }, [profile, isEditing, profileId, navigation])
+  }, [profile, conditionLabel, isEditing, profileId, navigation])
 
-  const isSpeed = profile.condition.type === "speed_above" || profile.condition.type === "speed_below"
+  const syncDefault = SYNC_INTERVAL_LABELS[settings.syncInterval] ?? formatDuration(settings.syncInterval)
 
   return (
     <Container>
@@ -213,205 +248,181 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {/* Name & Priority */}
-        <SectionTitle>Profile</SectionTitle>
+        <Text style={[styles.intro, { color: colors.textSecondary }]} testID="profile-sentence">
+          {profileSentence(profile, settings.isOfflineMode)}
+        </Text>
+
+        <SectionTitle>Condition</SectionTitle>
+        <Card rows>
+          <View accessibilityRole="radiogroup" style={styles.group}>
+            {PROFILE_CONDITIONS.map((opt) => (
+              <React.Fragment key={opt.type}>
+                <RadioRow
+                  testID={`condition-${opt.type}`}
+                  icon={opt.icon}
+                  label={opt.label}
+                  sub={opt.description}
+                  selected={type === opt.type}
+                  onPress={() => setConditionType(opt.type)}
+                />
+                {isSpeedType(opt.type) && type === opt.type && (
+                  <View style={styles.reveal}>
+                    <NumericInput
+                      label="Speed"
+                      testID="speed-input"
+                      value={text.speed}
+                      onChange={(v) => handleNumeric("speed", v)}
+                      onBlur={() => handleBlur("speed")}
+                      unit={speedUnit}
+                      placeholder={String(DEFAULT_SPEED_INPUT)}
+                      hint={`At least 1 ${speedUnit}. Applies while your average speed is ${opt.type === "speed_above" ? "above" : "below"} it.`}
+                      error={errorOf("speed")}
+                      message={noteOf("speed")}
+                    />
+                  </View>
+                )}
+              </React.Fragment>
+            ))}
+          </View>
+        </Card>
+
+        <SectionTitle style={styles.groupTop}>Profile</SectionTitle>
         <Card rows style={styles.cardTop}>
-          <View style={styles.inputGroup}>
+          <View style={styles.field}>
             <TextField
-              testID="profile-name-input"
+              testID="name-input"
               label="Name"
-              placeholder="e.g. Driving, Cycling..."
+              placeholder={conditionLabel}
               value={profile.name}
               onChangeText={(val) => setProfile((prev) => ({ ...prev, name: val }))}
             />
+            <FieldMessage>
+              Shown on the Dashboard and in the notification while active. Blank uses the condition&apos;s name.
+            </FieldMessage>
           </View>
-
           <Divider tight />
-
-          <SettingRow label="Priority" hint="Higher number wins when multiple profiles match">
+          <SettingRow
+            label="Priority"
+            hint="Higher wins when two profiles match at once. Equal numbers go to the older profile."
+          >
             <TextField
               accessibilityLabel="Priority"
+              testID="priority-input"
               figure
               style={styles.numInput}
               keyboardType="numeric"
-              value={priorityStr}
-              onChangeText={(val) => handleNumericChange(setPriorityStr, "priority", val, 0)}
-              placeholder="10"
+              value={text.priority}
+              onChangeText={handlePriority}
+              onBlur={handlePriorityBlur}
+              placeholder={String(DEFAULT_PRIORITY)}
+              error={priorityError}
             />
           </SettingRow>
         </Card>
 
-        {/* Condition */}
-        <SectionTitle style={styles.sectionGap}>Activation condition</SectionTitle>
-        <Card rows style={isSpeed && styles.cardTail}>
-          {PROFILE_CONDITIONS.map((opt, i) => (
-            <React.Fragment key={opt.type}>
-              {i > 0 && <Divider tight />}
-              <RadioRow
-                icon={opt.icon}
-                label={opt.label}
-                sub={opt.description}
-                selected={profile.condition.type === opt.type}
-                onPress={() => setConditionType(opt.type)}
-              />
-            </React.Fragment>
-          ))}
-
-          {isSpeed && (
-            <>
-              <Divider tight />
-              <View style={styles.inputGroup}>
-                <TextField
-                  testID="speed-threshold-input"
-                  label="Speed Threshold (km/h)"
-                  figure
-                  placeholder="30"
-                  value={speedKmh}
-                  onChangeText={handleSpeedChange}
-                  keyboardType="numeric"
-                />
-              </View>
-            </>
-          )}
-        </Card>
-
-        {/* Tracking Settings */}
-        <SectionTitle style={styles.sectionGap}>Tracking settings</SectionTitle>
-        <Card rows style={styles.cardTail}>
-          <SettingRow label="Tracking interval" hint={`Default: ${settings.interval}s`}>
-            <View style={styles.inputWithUnit}>
-              <TextField
-                accessibilityLabel="Tracking interval"
-                figure
-                style={styles.numInput}
-                keyboardType="numeric"
-                value={intervalStr}
-                onChangeText={(val) => handleNumericChange(setIntervalStr, "interval", val, 1)}
-                placeholder="5"
-              />
-              <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
-            </View>
-          </SettingRow>
-
-          {profile.condition.type === "stationary" && profile.interval > STATIONARY_MAX_INTERVAL_SECONDS && (
-            <FieldMessage variant="warning">
-              The device may miss the first {Math.floor(profile.interval / 60)} minutes of a trip when you start moving
-              with the specified interval!
+        <SectionTitle style={styles.groupTop}>Tracking while active</SectionTitle>
+        <Card rows style={styles.cardTop}>
+          <NumericInput
+            label="Tracking interval"
+            testID="interval-input"
+            value={text.interval}
+            onChange={(v) => handleNumeric("interval", v)}
+            onBlur={() => handleBlur("interval")}
+            unit="s"
+            placeholder={String(settings.interval)}
+            hint={`At least 1 s. Replaces the ${formatDuration(settings.interval)} from Tracking & sync while this profile is active. Shorter keeps the GPS awake more of the time and records more points.`}
+            error={errorOf("interval")}
+            message={noteOf("interval")}
+          />
+          {isStationary && profile.interval > STATIONARY_MAX_INTERVAL_SECONDS && (
+            <FieldMessage variant="warning" style={styles.warning}>
+              Longer than {STATIONARY_MAX_INTERVAL_SECONDS} s may leave the first {formatDuration(profile.interval)} of
+              a trip unrecorded
             </FieldMessage>
           )}
-
-          <Divider tight />
-
-          {profile.condition.type === "stationary" ? (
-            <FieldMessage>
-              Movement threshold does not apply to a stationary profile - a point is recorded at every interval.
-            </FieldMessage>
-          ) : (
+          {isStationary ? (
             <SettingRow
+              disabled
               label="Movement threshold"
-              hint={`Default: ${metersToInput(settings.distance)} ${shortDistanceUnit()}`}
+              hint="Not used while still · a point is recorded every interval"
             >
-              <View style={styles.inputWithUnit}>
-                <TextField
-                  accessibilityLabel="Movement threshold"
-                  figure
-                  style={styles.numInput}
-                  keyboardType="numeric"
-                  value={distanceStr}
-                  onChangeText={(val) => handleNumericChange(setDistanceStr, "distance", val, 0)}
-                  placeholder="0"
-                />
-                <Text style={[styles.unit, { color: colors.textSecondary }]}>{shortDistanceUnit()}</Text>
-              </View>
+              <Text style={[styles.figure, { color: colors.textDisabled }]}>0 {distanceUnit}</Text>
             </SettingRow>
+          ) : (
+            <NumericInput
+              label="Movement threshold"
+              testID="distance-input"
+              value={text.distance}
+              onChange={(v) => handleNumeric("distance", v)}
+              onBlur={() => handleBlur("distance")}
+              unit={distanceUnit}
+              placeholder={String(metersToInput(settings.distance))}
+              hint={`At least 0 ${distanceUnit}. Replaces the ${metersToInput(settings.distance)} ${distanceUnit} from Tracking & sync. 0 records any movement, larger skips small drift.`}
+              error={errorOf("distance")}
+              message={noteOf("distance")}
+            />
           )}
-
           {!settings.isOfflineMode && (
             <>
               <Divider tight />
-
-              <SyncIntervalPicker
-                label="Sync interval"
-                hint={`Default: ${formatSyncDefault(settings.syncInterval)}`}
-                value={profile.syncInterval}
-                min={0}
-                onSelect={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
-                onChange={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
-                onClamp={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
-              />
-            </>
-          )}
-        </Card>
-
-        <SectionTitle style={styles.sectionGap}>Switching</SectionTitle>
-        <Card rows>
-          {profile.condition.type === "stationary" ? (
-            <SettingRow
-              label="Activation delay"
-              hint="How long the device must be still before this profile activates. Resumes instantly via the hardware motion sensor when you move again."
-            >
-              <View style={styles.inputWithUnit}>
-                <TextField
-                  accessibilityLabel="Activation delay"
-                  figure
-                  style={styles.numInput}
-                  keyboardType="numeric"
-                  value={activationDelayStr}
-                  onChangeText={(val) => handleNumericChange(setActivationDelayStr, "activationDelay", val, 0)}
-                  placeholder="60"
+              <View style={styles.pickerTop}>
+                <SyncIntervalPicker
+                  label="Sync interval"
+                  hint={`Replaces the ${syncDefault} from Tracking & sync while this profile is active · shorter means more wake-ups`}
+                  value={profile.syncInterval}
+                  min={0}
+                  pullUp={false}
+                  onSelect={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
+                  onChange={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
+                  onClamp={(seconds) => setProfile((prev) => ({ ...prev, syncInterval: seconds }))}
                 />
-                <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
               </View>
-            </SettingRow>
-          ) : (
-            <>
-              <SettingRow
-                label="Activation delay"
-                hint="How long the condition must hold before this profile takes over. Avoids switching on brief, temporary changes. 0 = instant."
-              >
-                <View style={styles.inputWithUnit}>
-                  <TextField
-                    accessibilityLabel="Activation delay"
-                    figure
-                    style={styles.numInput}
-                    keyboardType="numeric"
-                    value={activationDelayStr}
-                    onChangeText={(val) => handleNumericChange(setActivationDelayStr, "activationDelay", val, 0)}
-                    placeholder="0"
-                  />
-                  <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
-                </View>
-              </SettingRow>
-
-              <Divider tight />
-
-              <SettingRow
-                label="Deactivation delay"
-                hint="How long after the condition stops before reverting to your defaults. Prevents rapid back-and-forth switching."
-              >
-                <View style={styles.inputWithUnit}>
-                  <TextField
-                    accessibilityLabel="Deactivation delay"
-                    figure
-                    style={styles.numInput}
-                    keyboardType="numeric"
-                    value={delayStr}
-                    onChangeText={(val) => handleNumericChange(setDelayStr, "deactivationDelay", val, 0)}
-                    placeholder="60"
-                  />
-                  <Text style={[styles.unit, { color: colors.textSecondary }]}>s</Text>
-                </View>
-              </SettingRow>
             </>
           )}
         </Card>
 
-        {/* Save Button */}
+        <SectionTitle style={styles.groupTop}>Switching</SectionTitle>
+        <Card rows style={styles.cardTop}>
+          <NumericInput
+            label="Activation delay"
+            testID="activation-delay-input"
+            value={text.activationDelay}
+            onChange={(v) => handleNumeric("activationDelay", v)}
+            onBlur={() => handleBlur("activationDelay")}
+            unit="s"
+            placeholder={String(defaultProfileDelays(type).activationDelay)}
+            hint={
+              isStationary
+                ? "At least 0 s. How long every fix must read as still first; 0 switches at the first still fix. Moving again ends the profile at once through the motion sensor."
+                : "At least 0 s. How long the condition must hold first. 0 switches at once, longer ignores a brief plug or unplug."
+            }
+            error={errorOf("activationDelay")}
+            message={noteOf("activationDelay")}
+          />
+          {!isStationary && (
+            <NumericInput
+              label="Deactivation delay"
+              testID="deactivation-delay-input"
+              value={text.deactivationDelay}
+              onChange={(v) => handleNumeric("deactivationDelay", v)}
+              onBlur={() => handleBlur("deactivationDelay")}
+              unit="s"
+              placeholder={String(defaultProfileDelays(type).deactivationDelay)}
+              hint="At least 0 s. How long after the condition ends before Tracking & sync applies again. Longer rides out a brief gap so the profile does not flap."
+              error={errorOf("deactivationDelay")}
+              message={noteOf("deactivationDelay")}
+            />
+          )}
+        </Card>
+
         <Button
+          testID="save-profile-btn"
           title={isEditing ? "Save changes" : "Create profile"}
           icon={Check}
           loading={saving}
+          disabled={hasFieldError}
           onPress={handleSave}
+          style={styles.save}
         />
         {isEditing && (
           <Button
@@ -428,16 +439,17 @@ export function ProfileEditorScreen({ navigation, route }: RootScreenProps<"Prof
 }
 
 const styles = StyleSheet.create({
-  cardTop: { paddingTop: space.lg },
-  cardTail: { paddingBottom: space.lg },
   scrollContent: { paddingHorizontal: space.lg, paddingTop: space.lg, paddingBottom: space.xxl },
-  inputGroup: { marginBottom: space.xs },
+  intro: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: lineHeights.body, marginBottom: space.lg },
+  group: { marginTop: -space.sm },
+  groupTop: { marginTop: space.xl },
+  cardTop: { paddingTop: space.lg },
+  // The row above already pays space.lg below it; the field's own bottom margin is the card's tail.
+  reveal: { paddingLeft: size.iconColumn, marginTop: -space.xs },
+  field: { paddingBottom: space.lg },
   numInput: { width: size.numericField },
-  inputWithUnit: { flexDirection: "row", alignItems: "center", gap: space.sm },
-  unit: { fontSize: fontSizes.body, ...fonts.medium, minWidth: 28 },
-  syncLabelRow: { marginBottom: space.sm },
-  settingLabel: { fontSize: fontSizes.label, ...fonts.semiBold, marginBottom: space.xxs },
-  settingHint: { fontSize: fontSizes.description, ...fonts.regular, lineHeight: lineHeights.description }, // ~3 per row with gap
-  customSyncInput: { marginTop: space.md },
-  sectionGap: { marginTop: space.xl }
+  figure: { fontSize: fontSizes.input, ...fonts.medium, fontVariant: ["tabular-nums"] },
+  warning: { marginTop: -space.sm, marginBottom: space.lg },
+  pickerTop: { paddingTop: space.lg },
+  save: { marginTop: space.xl }
 })

--- a/apps/mobile/src/screens/TrackingProfilesScreen.tsx
+++ b/apps/mobile/src/screens/TrackingProfilesScreen.tsx
@@ -3,49 +3,31 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useEffect, useCallback } from "react"
-import { View, Text, StyleSheet, FlatList, Pressable, Share } from "react-native"
+import React, { useState, useEffect, useCallback, useLayoutEffect } from "react"
+import { View, Text, StyleSheet, ScrollView, Share } from "react-native"
+import { Plus, Share2, UserRoundPen } from "lucide-react-native"
 import { useTheme } from "../hooks/useTheme"
 import { useTracking } from "../contexts/TrackingProvider"
+import { useActiveProfile } from "../hooks/useActiveProfile"
 import { ProfileService } from "../services/ProfileService"
-import { showAlert, showConfirm } from "../services/modalService"
+import { showAlert } from "../services/modalService"
 import { SavedTrackingProfile, ScreenProps } from "../types/global"
 import { fontSizes, fonts, lineHeights } from "../styles/typography"
-import { Button, Card, Container, EmptyState, IconButton, SectionTitle, Toggle } from "../components"
-import { Plus, X, Zap, Share2 } from "lucide-react-native"
+import { Card, Container, Divider, EmptyState, HeaderAction, ListItem, StateLine, Toggle } from "../components"
 import { logger } from "../utils/logger"
 import { buildProfilesLink } from "../utils/setupLink"
-import { HIT_SLOP_MD, MS_TO_KMH, PROFILE_CONDITIONS, size, space, STATE_LAYER_ALPHA } from "../constants"
-import { radius } from "@colota/shared"
-
-function formatCondition(profile: SavedTrackingProfile): string {
-  const condition = PROFILE_CONDITIONS.find((c) => c.type === profile.condition.type)
-  const label = condition?.listLabel || profile.condition.type
-  if (profile.condition.type === "speed_above" || profile.condition.type === "speed_below") {
-    const kmh = ((profile.condition.speedThreshold ?? 0) * MS_TO_KMH).toFixed(0)
-    return `${label} ${kmh} km/h`
-  }
-  return label
-}
-
-function formatSettings(profile: SavedTrackingProfile, isOfflineMode?: boolean): string {
-  const parts = [`${profile.interval}s interval`]
-  if (profile.distance > 0) parts.push(`${profile.distance}m threshold`)
-  if (!isOfflineMode) {
-    parts.push(profile.syncInterval === 0 ? "instant sync" : `${profile.syncInterval}s sync`)
-  }
-  return parts.join(" \u2022 ")
-}
+import { conditionOf, describeProfileState, profileRowSub } from "../utils/profileRow"
+import { space } from "../constants"
 
 export function TrackingProfilesScreen({ navigation }: ScreenProps) {
   const { colors } = useTheme()
-  const { settings, activeProfileName } = useTracking()
+  const { settings, activeProfileId, tracking } = useTracking()
+  const activeProfile = useActiveProfile(activeProfileId)
   const [profiles, setProfiles] = useState<SavedTrackingProfile[]>([])
 
   const loadProfiles = useCallback(async () => {
     try {
-      const data = await ProfileService.getProfiles()
-      setProfiles(data)
+      setProfiles(await ProfileService.getProfiles())
     } catch (err) {
       logger.error("[TrackingProfilesScreen] Failed to load profiles:", err)
     }
@@ -55,18 +37,12 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
     loadProfiles()
   }, [loadProfiles])
 
-  // Reload when returning from editor
-  useEffect(() => {
-    const unsubscribe = navigation.addListener("focus", () => {
-      loadProfiles()
-    })
-    return unsubscribe
-  }, [navigation, loadProfiles])
+  useEffect(() => navigation.addListener("focus", loadProfiles), [navigation, loadProfiles])
 
   const toggleEnabled = useCallback(
-    async (id: number, value: boolean) => {
+    async (id: number, enabled: boolean) => {
       try {
-        await ProfileService.updateProfile({ id, enabled: value })
+        await ProfileService.updateProfile({ id, enabled })
         await loadProfiles()
       } catch {
         showAlert("Error", "Failed to update profile.", "error")
@@ -85,166 +61,110 @@ export function TrackingProfilesScreen({ navigation }: ScreenProps) {
     }
   }, [profiles])
 
-  const handleDelete = useCallback(
-    async (item: SavedTrackingProfile) => {
-      const confirmed = await showConfirm({
-        title: "Delete profile",
-        message: `Delete "${item.name}"?`,
-        confirmText: "Delete",
-        destructive: true
-      })
-
-      if (!confirmed) return
-
-      try {
-        await ProfileService.deleteProfile(item.id)
-        await loadProfiles()
-      } catch {
-        showAlert("Error", "Failed to delete profile.", "error")
-      }
-    },
-    [loadProfiles]
+  const openEditor = useCallback(
+    (profileId?: number) => navigation.navigate("Profile Editor", profileId === undefined ? {} : { profileId }),
+    [navigation]
   )
 
-  const renderItem = useCallback(
-    ({ item }: { item: SavedTrackingProfile }) => {
-      const condition = PROFILE_CONDITIONS.find((c) => c.type === item.condition.type)
-      const ConditionIcon = condition?.icon || Zap
-      const isActive = activeProfileName === item.name
-
-      return (
-        <Card style={[styles.card, isActive && { backgroundColor: colors.primaryContainer }]}>
-          <Pressable
-            accessibilityRole="button"
-            android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
-            style={styles.row}
-            onPress={() => navigation.navigate("Profile Editor", { profileId: item.id })}
-          >
-            <View style={[styles.iconWrap, { backgroundColor: colors.primary + "15" }]}>
-              <ConditionIcon size={size.icon.md} color={colors.primary} />
-            </View>
-
-            <View style={styles.info}>
-              <View style={styles.nameRow}>
-                <Text style={[styles.name, { color: colors.text }]}>{item.name}</Text>
-                {isActive && (
-                  <View style={[styles.activeBadge, { backgroundColor: colors.well }]}>
-                    <View style={[styles.activeDot, { backgroundColor: colors.success }]} />
-                    <Text style={[styles.activeBadgeText, { color: colors.textSecondary }]}>Active</Text>
-                  </View>
-                )}
-                <View style={[styles.priorityBadge, { backgroundColor: colors.well }]}>
-                  <Text style={[styles.priorityText, { color: colors.textSecondary }]}>P{item.priority}</Text>
-                </View>
-              </View>
-              <Text style={[styles.condition, { color: colors.textSecondary }]}>{formatCondition(item)}</Text>
-              <Text style={[styles.settings, { color: colors.textLight }]}>
-                {formatSettings(item, settings.isOfflineMode)}
-              </Text>
-            </View>
-
-            <View style={styles.actions}>
-              <Toggle
-                accessibilityLabel={`Enable ${item.name}`}
-                testID={`toggle-profile-${item.id}`}
-                value={item.enabled}
-                onValueChange={(val) => toggleEnabled(item.id, val)}
-              />
-
-              <IconButton
-                icon={X}
-                tone="danger"
-                testID={`delete-profile-${item.id}`}
-                accessibilityLabel={`Delete ${item.name}`}
-                onPress={() => handleDelete(item)}
-              />
-            </View>
-          </Pressable>
-        </Card>
-      )
-    },
-    [colors, activeProfileName, settings.isOfflineMode, toggleEnabled, handleDelete, navigation]
+  const hasProfiles = profiles.length > 0
+  const renderHeaderActions = useCallback(
+    () => (
+      <View style={styles.headerRow}>
+        {hasProfiles && (
+          <HeaderAction
+            icon={Share2}
+            label="Share all profiles"
+            onPress={handleShareProfiles}
+            testID="share-profiles-btn"
+          />
+        )}
+        <HeaderAction icon={Plus} label="Create profile" onPress={() => openEditor()} testID="add-profile-btn" />
+      </View>
+    ),
+    [hasProfiles, handleShareProfiles, openEditor]
   )
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerRight: renderHeaderActions })
+  }, [navigation, renderHeaderActions])
+
+  const state = describeProfileState(activeProfile, settings, tracking)
 
   return (
     <Container>
-      <FlatList
-        data={profiles}
-        keyExtractor={(item) => item.id.toString()}
-        contentContainerStyle={styles.list}
-        showsVerticalScrollIndicator={false}
-        ListHeaderComponent={
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        {hasProfiles ? (
           <>
-            <View style={styles.header}>
-              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-                Auto-switch GPS settings based on charging, Android Auto, or speed
-              </Text>
-            </View>
-
-            <Button title="Create profile" icon={Plus} onPress={() => navigation.navigate("Profile Editor", {})} />
-
-            {profiles.length > 0 && (
-              <View style={styles.activeHeader}>
-                <SectionTitle>Profiles ({profiles.length})</SectionTitle>
-                <Pressable
-                  testID="share-profiles-btn"
-                  accessibilityRole="button"
-                  accessibilityLabel="Share all profiles"
-                  onPress={handleShareProfiles}
-                  hitSlop={HIT_SLOP_MD}
-                  android_ripple={{ color: colors.primary + STATE_LAYER_ALPHA, borderless: true }}
-                  style={styles.shareBtn}
-                >
-                  <Share2 size={size.icon.md} color={colors.textSecondary} />
-                </Pressable>
-              </View>
-            )}
+            <Text style={[styles.intro, { color: colors.textSecondary }]}>
+              Checked top to bottom while tracking runs. The first profile whose condition holds replaces the Tracking &
+              sync values.
+            </Text>
+            <Card rows>
+              <StateLine
+                icon={state.icon}
+                iconColor={state.tone === "success" ? colors.success : colors.textSecondary}
+                label={state.label}
+                caption={state.caption}
+                testID="profile-state"
+              />
+              <Divider tight />
+              {profiles.map((profile, i) => {
+                const inForce = tracking && profile.id === activeProfileId
+                return (
+                  <React.Fragment key={profile.id}>
+                    {i > 0 && <Divider tight inset />}
+                    <ListItem
+                      testID={`profile-${profile.id}`}
+                      icon={conditionOf(profile).icon}
+                      iconColor={inForce ? colors.success : undefined}
+                      label={profile.name}
+                      sub={profileRowSub(profile, inForce, settings.isOfflineMode)}
+                      subLines={2}
+                      onPress={() => openEditor(profile.id)}
+                      trailing={
+                        <Toggle
+                          accessibilityLabel={`Use ${profile.name}`}
+                          testID={`profile-toggle-${profile.id}`}
+                          value={profile.enabled}
+                          onValueChange={(enabled) => toggleEnabled(profile.id, enabled)}
+                        />
+                      }
+                    />
+                  </React.Fragment>
+                )
+              })}
+            </Card>
           </>
-        }
-        ListEmptyComponent={
+        ) : (
           <EmptyState
+            icon={UserRoundPen}
             title="No profiles yet"
-            hint="Create a profile to switch tracking settings automatically when charging, on Android Auto, or by speed"
+            hint="A profile changes how you track while a condition holds, such as charging or driving"
+            action={{ label: "Create profile", onPress: () => openEditor() }}
+            style={styles.empty}
           />
-        }
-        renderItem={renderItem}
-      />
+        )}
+      </ScrollView>
     </Container>
   )
 }
 
 const styles = StyleSheet.create({
-  list: { padding: space.lg, paddingBottom: space.xxl },
-  header: { marginBottom: space.xl },
-  subtitle: { fontSize: fontSizes.body, ...fonts.regular, lineHeight: lineHeights.body },
-  card: { marginBottom: space.md },
-  row: { flexDirection: "row", alignItems: "center" },
-  iconWrap: {
-    width: 36,
-    height: 36,
-    borderRadius: radius.md,
-    alignItems: "center",
-    justifyContent: "center",
-    marginEnd: space.md
+  headerRow: {
+    flexDirection: "row"
   },
-  info: { flex: 1, marginEnd: space.md },
-  nameRow: { flexDirection: "row", alignItems: "center", gap: space.sm, marginBottom: space.xxs },
-  name: { fontSize: fontSizes.input, ...fonts.semiBold },
-  activeBadge: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: space.xs,
-    paddingHorizontal: space.sm,
-    paddingVertical: space.xxs,
-    borderRadius: radius.xs
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.xxl
   },
-  activeDot: { width: 6, height: 6, borderRadius: radius.pill },
-  activeBadgeText: { fontSize: fontSizes.micro, ...fonts.semiBold },
-  priorityBadge: { paddingHorizontal: space.sm, paddingVertical: space.xxs, borderRadius: radius.xs },
-  priorityText: { fontSize: fontSizes.micro, ...fonts.semiBold },
-  condition: { fontSize: fontSizes.description, ...fonts.medium, marginBottom: space.xxs },
-  settings: { fontSize: fontSizes.small, ...fonts.regular },
-  actions: { alignItems: "center", gap: space.sm },
-  activeHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  shareBtn: { padding: space.xs, marginBottom: space.md }
+  intro: {
+    fontSize: fontSizes.body,
+    ...fonts.regular,
+    lineHeight: lineHeights.body,
+    marginBottom: space.lg
+  },
+  empty: {
+    paddingHorizontal: 0
+  }
 })

--- a/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/ProfileEditorScreen.test.tsx
@@ -1,8 +1,7 @@
 import React from "react"
-import { render, fireEvent, waitFor } from "@testing-library/react-native"
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native"
 import { TrackingProfile } from "../../types/global"
-
-// --- Mocks ---
+import { SAVE_SUCCESS_DISPLAY_MS } from "../../constants"
 
 const mockProfiles: TrackingProfile[] = [
   {
@@ -35,7 +34,6 @@ jest.mock("../../services/ProfileService", () => ({
 
 const mockShowAlert = jest.fn()
 const mockShowConfirm = jest.fn()
-
 jest.mock("../../services/modalService", () => ({
   showAlert: (...args: any[]) => mockShowAlert(...args),
   showConfirm: (...args: any[]) => mockShowConfirm(...args)
@@ -45,18 +43,15 @@ jest.mock("../../utils/geo", () => ({
   ...jest.requireActual("../../utils/geo"),
   shortDistanceUnit: () => "m",
   metersToInput: (v: number) => v,
-  inputToMeters: (v: number) => v
+  inputToMeters: (v: number) => v,
+  getSpeedUnit: () => ({ factor: 3.6, unit: "km/h" }),
+  speedToInput: (mps: number) => Math.round(mps * 3.6),
+  inputToSpeed: (v: number) => v / 3.6
 }))
 
+let mockSettings = { isOfflineMode: false, interval: 5, distance: 0, syncInterval: 0 }
 jest.mock("../../contexts/TrackingProvider", () => ({
-  useTracking: () => ({
-    settings: {
-      isOfflineMode: false,
-      interval: 5,
-      distance: 0,
-      syncInterval: 0
-    }
-  })
+  useTracking: () => ({ settings: mockSettings })
 }))
 
 jest.mock("../../components/features/settings/SyncIntervalPicker", () => {
@@ -87,86 +82,46 @@ jest.mock("../../components/features/settings/SyncIntervalPicker", () => {
 })
 
 jest.mock("../../hooks/useTheme", () => ({
-  useTheme: () => ({
-    colors: {
-      primary: "#0d9488",
-      border: "#e5e7eb",
-      text: "#000",
-      textSecondary: "#6b7280",
-      textLight: "#9ca3af",
-      background: "#fff",
-      info: "#3b82f6",
-      success: "#22c55e",
-      error: "#ef4444",
-      card: "#fff",
-      backgroundElevated: "#f9fafb",
-      placeholder: "#9ca3af",
-      textOnPrimary: "#fff"
-    }
-  })
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
 }))
 
 jest.mock("../../components", () => {
   const R = require("react")
-  const { View, Text } = require("react-native")
+  const { View, Text, Pressable, TextInput } = require("react-native")
   return {
     TextField: require("../../testing/componentStubs").TextFieldStub,
-    RadioRow: function (props: any) {
-      const RN = require("react-native")
-      return R.createElement(
-        RN.Pressable,
-        { testID: props.testID, onPress: props.onPress, accessibilityState: { checked: props.selected } },
-        R.createElement(RN.Text, null, props.label),
-        props.sub ? R.createElement(RN.Text, null, props.sub) : null
-      )
-    },
-    ChipGroup: function (props: any) {
-      const RN = require("react-native")
-      return R.createElement(
-        RN.View,
-        null,
-        props.options.map(function (o: any) {
-          return R.createElement(
-            RN.Pressable,
-            { key: o.value, testID: o.testID, onPress: () => props.onSelect(o.value) },
-            R.createElement(RN.Text, null, o.label)
-          )
-        })
-      )
-    },
-    Button: function (props: any) {
-      return require("react").createElement(
-        require("react-native").Pressable,
-        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
-        require("react").createElement(require("react-native").Text, null, props.title)
-      )
-    },
-    Toggle: function (props: any) {
-      return require("react").createElement(require("react-native").Switch, {
-        testID: props.testID,
-        value: props.value,
-        onValueChange: props.onValueChange,
-        disabled: props.disabled,
-        accessibilityLabel: props.accessibilityLabel
-      })
-    },
+    RadioRow: ({ testID, label, sub, selected, onPress }: any) =>
+      R.createElement(
+        Pressable,
+        { testID, onPress, accessibilityRole: "radio", accessibilityState: { checked: selected } },
+        R.createElement(Text, null, label),
+        sub ? R.createElement(Text, null, sub) : null
+      ),
+    Button: ({ title, onPress, disabled, testID }: any) =>
+      R.createElement(
+        Pressable,
+        { testID, onPress, disabled, accessibilityRole: "button", accessibilityState: { disabled } },
+        R.createElement(Text, null, title)
+      ),
     Container: ({ children }: any) => R.createElement(View, null, children),
     SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
     Card: ({ children }: any) => R.createElement(View, null, children),
-    NumericInput: ({ label, value, onChange, onBlur, unit, hint }: any) =>
+    NumericInput: ({ label, value, onChange, onBlur, unit, hint, error, message, testID }: any) =>
       R.createElement(
         View,
         null,
         R.createElement(Text, null, label),
         hint ? R.createElement(Text, null, hint) : null,
-        R.createElement(require("react-native").TextInput, { value, onChangeText: onChange, onBlur }),
-        unit ? R.createElement(Text, null, unit) : null
+        R.createElement(TextInput, { testID, value, onChangeText: onChange, onBlur }),
+        unit ? R.createElement(Text, null, unit) : null,
+        error ? R.createElement(Text, null, error) : null,
+        message ? R.createElement(Text, null, message) : null
       ),
     Divider: () => R.createElement(View, null),
-    SettingRow: ({ label, hint, children }: any) =>
+    SettingRow: ({ label, hint, children, disabled }: any) =>
       R.createElement(
         View,
-        null,
+        { accessibilityState: { disabled: !!disabled } },
         R.createElement(Text, null, label),
         hint && R.createElement(Text, null, hint),
         children
@@ -175,381 +130,227 @@ jest.mock("../../components", () => {
   }
 })
 
-const mockGoBack = jest.fn()
+jest.mock("../../utils/logger", () => ({ logger: { error: jest.fn() } }))
 
+const mockGoBack = jest.fn()
 const mockSetOptions = jest.fn()
-const mockNavigation = {
-  goBack: mockGoBack,
-  setOptions: mockSetOptions
-}
+const mockNavigation = { goBack: mockGoBack, setOptions: mockSetOptions }
 
 import { ProfileEditorScreen } from "../ProfileEditorScreen"
 
 describe("ProfileEditorScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockSettings = { isOfflineMode: false, interval: 5, distance: 0, syncInterval: 0 }
     mockGetProfiles.mockResolvedValue(mockProfiles)
   })
 
-  function renderNewProfile() {
-    return render(<ProfileEditorScreen navigation={mockNavigation as any} route={{ params: {} } as any} />)
-  }
+  const renderNew = () =>
+    render(<ProfileEditorScreen navigation={mockNavigation as any} route={{ params: {} } as any} />)
+  const renderEdit = (profileId = 1) =>
+    render(<ProfileEditorScreen navigation={mockNavigation as any} route={{ params: { profileId } } as any} />)
 
-  function renderEditProfile(profileId = 1) {
-    return render(<ProfileEditorScreen navigation={mockNavigation as any} route={{ params: { profileId } } as any} />)
-  }
+  describe("the sentence", () => {
+    it("reads the draft back as the rule and follows every edit", () => {
+      const { getByTestId } = renderNew()
 
-  // --- New Profile Mode ---
+      expect(getByTestId("profile-sentence").props.children).toBe(
+        "When charging, track every 5 s, any movement and sync each fix."
+      )
 
-  it("names the new profile in the header rather than in the body", () => {
-    renderNewProfile()
-    // New versus edit is carried by the header title, not by a second title in the body.
-    expect(mockSetOptions).toHaveBeenCalledWith({ headerTitle: "New profile" })
-  })
+      fireEvent.press(getByTestId("condition-speed_above"))
+      fireEvent.changeText(getByTestId("speed-input"), "50")
+      fireEvent.changeText(getByTestId("interval-input"), "2")
+      fireEvent.changeText(getByTestId("distance-input"), "10")
+      fireEvent.press(getByTestId("sync-interval-60"))
 
-  it("shows Create Profile button for new profile", () => {
-    const { getByText } = renderNewProfile()
-    expect(getByText("Create profile")).toBeTruthy()
-  })
+      expect(getByTestId("profile-sentence").props.children).toBe(
+        "When faster than 50 km/h, track every 2 s after 10 m and sync every 1 min."
+      )
+    })
 
-  it("shows all condition options", () => {
-    const { getByText } = renderNewProfile()
+    it("drops the sync clause in offline mode and hides the sync picker", () => {
+      mockSettings = { ...mockSettings, isOfflineMode: true }
+      const { getByTestId, queryByText } = renderNew()
 
-    expect(getByText("Charging")).toBeTruthy()
-    expect(getByText("Car Mode")).toBeTruthy()
-    expect(getByText("Speed Above")).toBeTruthy()
-    expect(getByText("Speed Below")).toBeTruthy()
-  })
-
-  it("hands the sync interval to the shared picker rather than drawing its own", () => {
-    const { getByTestId } = renderNewProfile()
-
-    expect(getByTestId("sync-interval-0")).toBeTruthy()
-    expect(getByTestId("sync-interval-60")).toBeTruthy()
-    expect(getByTestId("sync-interval-300")).toBeTruthy()
-    expect(getByTestId("sync-interval-900")).toBeTruthy()
-  })
-
-  it("pre-fills fields with main settings values", () => {
-    const { getByDisplayValue, getAllByDisplayValue } = renderNewProfile()
-
-    expect(getByDisplayValue("5")).toBeTruthy() // interval from settings
-    // distance from settings is 0; activation delay also defaults to 0
-    expect(getAllByDisplayValue("0").length).toBeGreaterThan(0)
-  })
-
-  it("shows default hints from main settings", () => {
-    const { getByText } = renderNewProfile()
-
-    expect(getByText("Default: 5s")).toBeTruthy()
-    expect(getByText("Default: 0 m")).toBeTruthy()
-    expect(getByText("Default: Instant")).toBeTruthy()
-  })
-
-  // --- Validation ---
-
-  it("shows alert when saving with empty name", async () => {
-    const { getByText } = renderNewProfile()
-
-    fireEvent.press(getByText("Create profile"))
-
-    await waitFor(() => {
-      expect(mockShowAlert).toHaveBeenCalledWith("Missing Name", "Please enter a profile name.", "warning")
+      expect(getByTestId("profile-sentence").props.children).toBe("When charging, track every 5 s, any movement.")
+      expect(queryByText("Sync interval")).toBeNull()
     })
   })
 
-  it("saves with speed condition when threshold is valid", async () => {
-    const { getByText, getByDisplayValue } = renderNewProfile()
+  describe("condition", () => {
+    it("comes first, in sentence case, with what watching it costs on each row", () => {
+      const { getByText, getAllByText, getByTestId } = renderNew()
 
-    const nameInput = getByDisplayValue("")
-    fireEvent.changeText(nameInput, "Speed Test")
+      expect(getByText("Android Auto")).toBeTruthy()
+      expect(getByText("Speed above")).toBeTruthy()
+      expect(getByText("Phone is plugged in · costs nothing to watch")).toBeTruthy()
+      expect(getAllByText(/fixes keep flowing to measure it, even below the movement threshold/)).toHaveLength(2)
+      expect(getByTestId("condition-charging").props.accessibilityState.checked).toBe(true)
+    })
 
-    // Select speed_above condition - defaults to 30 km/h threshold
-    fireEvent.press(getByText("Speed Above"))
+    it("reveals the speed field under a speed condition only, in the user's unit", () => {
+      const { getByTestId, queryByTestId, getByText } = renderNew()
+      expect(queryByTestId("speed-input")).toBeNull()
 
-    fireEvent.press(getByText("Create profile"))
+      fireEvent.press(getByTestId("condition-speed_below"))
 
-    await waitFor(() => {
-      expect(mockCreateProfile).toHaveBeenCalled()
+      expect(getByTestId("speed-input").props.value).toBe("30")
+      expect(getByText("At least 1 km/h. Applies while your average speed is below it.")).toBeTruthy()
+      expect(getByText("km/h")).toBeTruthy()
+    })
+
+    it("keeps delays the user changed across a condition switch and resets untouched ones", () => {
+      const { getByTestId } = renderNew()
+
+      fireEvent.press(getByTestId("condition-stationary"))
+      expect(getByTestId("activation-delay-input").props.value).toBe("60")
+
+      fireEvent.changeText(getByTestId("activation-delay-input"), "90")
+      fireEvent.press(getByTestId("condition-charging"))
+      expect(getByTestId("activation-delay-input").props.value).toBe("90")
+    })
+  })
+
+  describe("stationary", () => {
+    it("blocks the movement threshold with the reason instead of hiding it, and drops the deactivation delay", () => {
+      const { getByTestId, getByText, queryByTestId } = renderNew()
+
+      fireEvent.press(getByTestId("condition-stationary"))
+
+      expect(getByText("Not used while still · a point is recorded every interval")).toBeTruthy()
+      expect(getByText("0 m")).toBeTruthy()
+      expect(queryByTestId("distance-input")).toBeNull()
+      expect(queryByTestId("deactivation-delay-input")).toBeNull()
+      expect(getByText(/How long every fix must read as still first/)).toBeTruthy()
+    })
+
+    it("warns above 60 s without blocking Save", () => {
+      const { getByTestId, getByText, queryByText } = renderNew()
+      fireEvent.press(getByTestId("condition-stationary"))
+      expect(queryByText(/may leave the first/)).toBeNull()
+
+      fireEvent.changeText(getByTestId("interval-input"), "300")
+
+      expect(getByText("Longer than 60 s may leave the first 5 min of a trip unrecorded")).toBeTruthy()
+      expect(getByTestId("save-profile-btn").props.accessibilityState.disabled).toBe(false)
+    })
+  })
+
+  describe("override fields", () => {
+    it("name the Tracking & sync value they replace instead of a bare default", () => {
+      mockSettings = { isOfflineMode: false, interval: 30, distance: 2, syncInterval: 300 }
+      const { getByText } = renderNew()
+
+      expect(getByText(/^At least 1 s\. Replaces the 30 s from Tracking & sync/)).toBeTruthy()
+      expect(getByText(/^At least 0 m\. Replaces the 2 m from Tracking & sync/)).toBeTruthy()
+      expect(getByText(/^Replaces the 5 min from Tracking & sync/)).toBeTruthy()
+    })
+
+    it("rejects a decimal on the field and disables Save until it is fixed", () => {
+      const { getByTestId, getByText, queryByText } = renderNew()
+
+      fireEvent.changeText(getByTestId("interval-input"), "1.5")
+
+      expect(getByText("A whole number")).toBeTruthy()
+      expect(getByTestId("save-profile-btn").props.accessibilityState.disabled).toBe(true)
+
+      fireEvent.changeText(getByTestId("interval-input"), "15")
+      expect(queryByText("A whole number")).toBeNull()
+      expect(getByTestId("save-profile-btn").props.accessibilityState.disabled).toBe(false)
+    })
+
+    it("clamps an emptied interval to 1 s on blur and says so for a moment", () => {
+      jest.useFakeTimers()
+      const { getByTestId, getByText, queryByText } = renderNew()
+
+      fireEvent.changeText(getByTestId("interval-input"), "")
+      fireEvent(getByTestId("interval-input"), "blur")
+
+      expect(getByTestId("interval-input").props.value).toBe("1")
+      expect(getByText("Set to 1 s")).toBeTruthy()
+      act(() => {
+        jest.advanceTimersByTime(SAVE_SUCCESS_DISPLAY_MS)
+      })
+      expect(queryByText("Set to 1 s")).toBeNull()
+      jest.useRealTimers()
+    })
+
+    it("restores the stored priority when its box is left empty, and flags a non-number", () => {
+      const { getByTestId, getByText, queryByText } = renderNew()
+
+      fireEvent.changeText(getByTestId("priority-input"), "x")
+      expect(getByText("A whole number")).toBeTruthy()
+      expect(getByTestId("save-profile-btn").props.accessibilityState.disabled).toBe(true)
+
+      fireEvent.changeText(getByTestId("priority-input"), "")
+      fireEvent(getByTestId("priority-input"), "blur")
+      expect(getByTestId("priority-input").props.value).toBe("10")
+      expect(queryByText("A whole number")).toBeNull()
+    })
+  })
+
+  describe("save and delete", () => {
+    it("creates a profile with the condition's name when the name is blank, four taps from Create", async () => {
+      const { getByTestId } = renderNew()
+
+      fireEvent.press(getByTestId("save-profile-btn"))
+
+      await waitFor(() => expect(mockCreateProfile).toHaveBeenCalledWith(expect.objectContaining({ name: "Charging" })))
+      expect(mockShowAlert).not.toHaveBeenCalled()
       expect(mockGoBack).toHaveBeenCalled()
     })
-  })
 
-  // --- Successful save ---
+    it("stores a speed in m/s from the display unit", async () => {
+      const { getByTestId } = renderNew()
 
-  it("creates profile and navigates back on valid save", async () => {
-    const { getByText, getByDisplayValue } = renderNewProfile()
+      fireEvent.press(getByTestId("condition-speed_above"))
+      fireEvent.changeText(getByTestId("speed-input"), "50")
+      fireEvent.press(getByTestId("save-profile-btn"))
 
-    const nameInput = getByDisplayValue("")
-    fireEvent.changeText(nameInput, "My Profile")
-
-    fireEvent.press(getByText("Create profile"))
-
-    await waitFor(() => {
-      expect(mockCreateProfile).toHaveBeenCalled()
-      expect(mockGoBack).toHaveBeenCalled()
-    })
-  })
-
-  it("does not call createProfile when validation fails", async () => {
-    const { getByText } = renderNewProfile()
-
-    // Try to save with empty name
-    fireEvent.press(getByText("Create profile"))
-
-    await waitFor(() => {
-      expect(mockShowAlert).toHaveBeenCalled()
+      await waitFor(() =>
+        expect(mockCreateProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ condition: { type: "speed_above", speedThreshold: expect.closeTo(13.89, 1) } })
+        )
+      )
     })
 
-    expect(mockCreateProfile).not.toHaveBeenCalled()
-  })
+    it("loads an existing profile into every field and saves through updateProfile", async () => {
+      const { findByTestId, getByTestId } = renderEdit()
 
-  // --- Edit Mode ---
-
-  it("names the edited profile in the header rather than in the body", async () => {
-    renderEditProfile()
-
-    await waitFor(() => {
+      expect((await findByTestId("name-input")).props.value).toBe("Existing Profile")
+      expect(getByTestId("speed-input").props.value).toBe("50")
+      expect(getByTestId("interval-input").props.value).toBe("10")
+      expect(getByTestId("activation-delay-input").props.value).toBe("12")
       expect(mockSetOptions).toHaveBeenCalledWith({ headerTitle: "Edit profile" })
-    })
-  })
 
-  it("shows Save Changes button when editing", async () => {
-    const { getByText } = renderEditProfile()
-
-    await waitFor(() => {
-      expect(getByText("Save changes")).toBeTruthy()
-    })
-  })
-
-  it("loads existing profile data", async () => {
-    const { getByDisplayValue } = renderEditProfile()
-
-    await waitFor(() => {
-      expect(getByDisplayValue("Existing Profile")).toBeTruthy()
-      expect(getByDisplayValue("15")).toBeTruthy() // priority
-      expect(getByDisplayValue("10")).toBeTruthy() // interval
-    })
-  })
-
-  it("loads speed threshold in km/h", async () => {
-    const { getByDisplayValue } = renderEditProfile()
-
-    // 13.89 m/s * 3.6 = 50 km/h
-    await waitFor(() => {
-      expect(getByDisplayValue("50")).toBeTruthy()
-    })
-  })
-
-  it("calls updateProfile when saving in edit mode", async () => {
-    const { getByText } = renderEditProfile()
-
-    await waitFor(() => {
-      expect(getByText("Save changes")).toBeTruthy()
+      fireEvent.press(getByTestId("save-profile-btn"))
+      await waitFor(() =>
+        expect(mockUpdateProfile).toHaveBeenCalledWith(expect.objectContaining({ id: 1, priority: 15 }))
+      )
     })
 
-    fireEvent.press(getByText("Save changes"))
+    it("shows an error and goes back when the profile cannot load", async () => {
+      mockGetProfiles.mockRejectedValueOnce(new Error("db"))
+      renderEdit()
 
-    await waitFor(() => {
-      expect(mockUpdateProfile).toHaveBeenCalled()
+      await waitFor(() => expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to load profile data.", "error"))
       expect(mockGoBack).toHaveBeenCalled()
     })
-  })
 
-  it("shows error and navigates back on load failure", async () => {
-    mockGetProfiles.mockRejectedValueOnce(new Error("DB Error"))
+    it("offers Delete only while editing and confirms before deleting", async () => {
+      const draft = renderNew()
+      expect(draft.queryByTestId("delete-profile-btn")).toBeNull()
 
-    renderEditProfile()
-
-    await waitFor(() => {
-      expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to load profile data.", "error")
-      expect(mockGoBack).toHaveBeenCalled()
-    })
-  })
-
-  it("shows error when save fails", async () => {
-    mockCreateProfile.mockRejectedValueOnce(new Error("Save failed"))
-
-    const { getByText, getByDisplayValue } = renderNewProfile()
-
-    const nameInput = getByDisplayValue("")
-    fireEvent.changeText(nameInput, "Fail Profile")
-
-    fireEvent.press(getByText("Create profile"))
-
-    await waitFor(() => {
-      expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to save profile.", "error")
-    })
-  })
-
-  // --- Speed condition visibility ---
-
-  it("shows speed threshold input only for speed conditions", () => {
-    const { getByText, queryByText } = renderNewProfile()
-
-    // Default is charging - no speed input
-    expect(queryByText("Speed Threshold (km/h)")).toBeNull()
-
-    // Select Speed Above
-    fireEvent.press(getByText("Speed Above"))
-    expect(getByText("Speed Threshold (km/h)")).toBeTruthy()
-
-    // Switch back to charging
-    fireEvent.press(getByText("Charging"))
-    expect(queryByText("Speed Threshold (km/h)")).toBeNull()
-  })
-
-  // --- Activation delay ---
-
-  it("shows activation delay for all conditions, and deactivation delay only for non-stationary", () => {
-    const { getByText, queryByText } = renderNewProfile()
-
-    // Charging: both delays
-    expect(getByText("Activation delay")).toBeTruthy()
-    expect(getByText("Deactivation delay")).toBeTruthy()
-
-    // Stationary: activation delay only (deactivation is instant via the motion sensor)
-    fireEvent.press(getByText("Stationary"))
-    expect(getByText("Activation delay")).toBeTruthy()
-    expect(queryByText("Deactivation delay")).toBeNull()
-  })
-
-  it("hides the movement threshold for a stationary profile and shows a note instead", () => {
-    const { getByText, queryByText } = renderNewProfile()
-
-    // Default (charging): the field is shown
-    expect(getByText("Movement threshold")).toBeTruthy()
-
-    // Stationary: field hidden (the distance filter is forced to 0), note shown instead
-    fireEvent.press(getByText("Stationary"))
-    expect(queryByText("Movement threshold")).toBeNull()
-    expect(getByText(/Movement threshold does not apply/)).toBeTruthy()
-  })
-
-  it("defaults stationary activation delay to 60", () => {
-    const { getByText, getByDisplayValue } = renderNewProfile()
-
-    fireEvent.press(getByText("Stationary"))
-    expect(getByDisplayValue("60")).toBeTruthy()
-  })
-
-  it("loads existing activation delay in edit mode", async () => {
-    const { getByDisplayValue } = renderEditProfile()
-
-    await waitFor(() => {
-      expect(getByDisplayValue("12")).toBeTruthy()
-    })
-  })
-
-  // --- Numeric input ---
-
-  it("updates interval via numeric input", () => {
-    const { getByDisplayValue } = renderNewProfile()
-
-    const intervalInput = getByDisplayValue("5")
-    fireEvent.changeText(intervalInput, "15")
-
-    expect(getByDisplayValue("15")).toBeTruthy()
-  })
-
-  it("updates priority via numeric input", () => {
-    const { getByDisplayValue } = renderNewProfile()
-
-    const priorityInput = getByDisplayValue("10")
-    fireEvent.changeText(priorityInput, "25")
-
-    expect(getByDisplayValue("25")).toBeTruthy()
-  })
-
-  // --- Stationary interval warning ---
-
-  describe("stationary interval warning", () => {
-    it("does not show the warning while interval is at or below 60s", () => {
-      const { getByText, queryByText, getByDisplayValue } = renderNewProfile()
-
-      fireEvent.press(getByText("Stationary"))
-      const intervalInput = getByDisplayValue("5")
-      fireEvent.changeText(intervalInput, "60")
-
-      expect(queryByText(/may miss the first \d+ minutes of a trip/)).toBeNull()
-    })
-
-    it("shows a warning when the interval exceeds 60s", () => {
-      const { getByText, getByDisplayValue } = renderNewProfile()
-
-      fireEvent.press(getByText("Stationary"))
-      const intervalInput = getByDisplayValue("5")
-      fireEvent.changeText(intervalInput, "600")
-
-      expect(getByText(/may miss the first \d+ minutes of a trip/)).toBeTruthy()
-    })
-
-    it("does not show the warning for non-stationary conditions even with large intervals", () => {
-      const { queryByText, getByDisplayValue } = renderNewProfile()
-
-      const intervalInput = getByDisplayValue("5")
-      fireEvent.changeText(intervalInput, "3600")
-
-      expect(queryByText(/may miss the first \d+ minutes of a trip/)).toBeNull()
-    })
-
-    it("loads an existing Stationary profile with interval > 60 unchanged", async () => {
-      mockGetProfiles.mockResolvedValueOnce([
-        {
-          id: 1,
-          name: "Old Stationary",
-          interval: 3600,
-          distance: 0,
-          syncInterval: 0,
-          priority: 10,
-          condition: { type: "stationary" },
-          activationDelay: 0,
-          deactivationDelay: 0,
-          enabled: true
-        }
-      ])
-
-      const { getByDisplayValue, getByText } = renderEditProfile()
-
-      await waitFor(() => {
-        expect(getByDisplayValue("3600")).toBeTruthy()
-      })
-      expect(getByText(/may miss the first \d+ minutes of a trip/)).toBeTruthy()
-    })
-  })
-
-  describe("delete", () => {
-    it("offers Delete only while editing, since a draft has nothing to remove", async () => {
-      const { queryByTestId } = renderNewProfile()
-
-      await waitFor(() => expect(queryByTestId("delete-profile-btn")).toBeNull())
-    })
-
-    it("confirms before deleting, then leaves the screen", async () => {
-      // The list could delete a profile and the editor could not, so a profile opened for editing
-      // had to be backed out of and found again.
-      mockShowConfirm.mockResolvedValue(true)
-      const { getByTestId } = renderEditProfile(1)
-
-      await waitFor(() => expect(getByTestId("delete-profile-btn")).toBeTruthy())
-      fireEvent.press(getByTestId("delete-profile-btn"))
-
-      await waitFor(() => {
-        expect(mockDeleteProfile).toHaveBeenCalledWith(1)
-        expect(mockGoBack).toHaveBeenCalled()
-      })
-    })
-
-    it("deletes nothing when the confirm is dismissed", async () => {
-      mockShowConfirm.mockResolvedValue(false)
-      const { getByTestId } = renderEditProfile(1)
-
-      await waitFor(() => expect(getByTestId("delete-profile-btn")).toBeTruthy())
-      fireEvent.press(getByTestId("delete-profile-btn"))
-
+      mockShowConfirm.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+      const { findByTestId } = renderEdit()
+      fireEvent.press(await findByTestId("delete-profile-btn"))
       await waitFor(() => expect(mockShowConfirm).toHaveBeenCalled())
       expect(mockDeleteProfile).not.toHaveBeenCalled()
-      expect(mockGoBack).not.toHaveBeenCalled()
+
+      fireEvent.press(await findByTestId("delete-profile-btn"))
+      await waitFor(() => expect(mockDeleteProfile).toHaveBeenCalledWith(1))
+      expect(mockGoBack).toHaveBeenCalled()
     })
   })
 })

--- a/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/TrackingProfilesScreen.test.tsx
@@ -1,369 +1,273 @@
 import React from "react"
 import { render, fireEvent, waitFor } from "@testing-library/react-native"
-import { Share, StyleSheet, View as RNView } from "react-native"
+import { Share } from "react-native"
 import { lightColors } from "@colota/shared"
 import { TrackingProfile } from "../../types/global"
 
-// --- Mocks ---
-
 const mockProfiles: TrackingProfile[] = [
   {
+    id: 2,
+    name: "Driving",
+    interval: 2,
+    distance: 10,
+    syncInterval: 60,
+    priority: 20,
+    condition: { type: "speed_above", speedThreshold: 13.89 },
+    activationDelay: 15,
+    deactivationDelay: 30,
+    enabled: true
+  },
+  {
     id: 1,
-    name: "Charging",
-    interval: 10,
+    name: "Commute",
+    interval: 5,
     distance: 0,
     syncInterval: 0,
     priority: 10,
     condition: { type: "charging" },
     activationDelay: 0,
     deactivationDelay: 60,
-    enabled: true
-  },
-  {
-    id: 2,
-    name: "Driving",
-    interval: 3,
-    distance: 5,
-    syncInterval: 60,
-    priority: 20,
-    condition: { type: "speed_above", speedThreshold: 13.89 },
-    activationDelay: 15,
-    deactivationDelay: 30,
     enabled: false
   }
 ]
 
 const mockGetProfiles = jest.fn().mockResolvedValue(mockProfiles)
 const mockUpdateProfile = jest.fn().mockResolvedValue(true)
-const mockDeleteProfile = jest.fn().mockResolvedValue(true)
 
 jest.mock("../../services/ProfileService", () => ({
   ProfileService: {
     getProfiles: () => mockGetProfiles(),
-    updateProfile: (update: any) => mockUpdateProfile(update),
-    deleteProfile: (id: number) => mockDeleteProfile(id)
+    updateProfile: (update: any) => mockUpdateProfile(update)
   }
 }))
 
 const mockShowAlert = jest.fn()
-const mockShowConfirm = jest.fn().mockResolvedValue(true)
-
 jest.mock("../../services/modalService", () => ({
-  showAlert: (...args: any[]) => mockShowAlert(...args),
-  showConfirm: (...args: any[]) => mockShowConfirm(...args)
+  showAlert: (...args: any[]) => mockShowAlert(...args)
 }))
 
-let mockActiveProfileName: string | null = null
-
+let mockActiveProfileId: number | null = null
+let mockTracking = true
 jest.mock("../../contexts/TrackingProvider", () => ({
   useTracking: () => ({
-    activeProfileName: mockActiveProfileName,
-    settings: { isOfflineMode: false }
+    activeProfileId: mockActiveProfileId,
+    tracking: mockTracking,
+    settings: { isOfflineMode: false, interval: 30, distance: 2, syncInterval: 300 }
   })
+}))
+
+jest.mock("../../hooks/useActiveProfile", () => ({
+  useActiveProfile: (id: number | null) => (id === null ? null : (mockProfiles.find((p) => p.id === id) ?? null))
 }))
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({ colors: jest.requireActual("@colota/shared").lightColors })
 }))
 
+jest.mock("../../utils/geo", () => ({
+  ...jest.requireActual("../../utils/geo"),
+  shortDistanceUnit: () => "m",
+  metersToInput: (v: number) => v,
+  getSpeedUnit: () => ({ factor: 3.6, unit: "km/h" }),
+  speedToInput: (mps: number) => Math.round(mps * 3.6)
+}))
+
 jest.mock("../../components", () => {
   const R = require("react")
-  const { View, Text } = require("react-native")
+  const { View, Text, Pressable } = require("react-native")
   return {
-    EmptyState: require("../../testing/componentStubs").EmptyStateStub,
-    IconButton: require("../../testing/componentStubs").IconButtonStub,
-    Button: function (props: any) {
-      return require("react").createElement(
-        require("react-native").Pressable,
-        { testID: props.testID, onPress: props.onPress, disabled: props.disabled, accessibilityRole: "button" },
-        require("react").createElement(require("react-native").Text, null, props.title)
-      )
-    },
+    EmptyState: ({ title, hint, action }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, title),
+        R.createElement(Text, null, hint),
+        action &&
+          R.createElement(
+            Pressable,
+            { testID: "empty-action", onPress: action.onPress },
+            R.createElement(Text, null, action.label)
+          )
+      ),
+    HeaderAction: ({ label, onPress, testID }: any) =>
+      R.createElement(Pressable, { testID, onPress, accessibilityRole: "button", accessibilityLabel: label }),
     Toggle: function (props: any) {
-      return require("react").createElement(require("react-native").Switch, {
+      return R.createElement(require("react-native").Switch, {
         testID: props.testID,
         value: props.value,
         onValueChange: props.onValueChange,
-        disabled: props.disabled,
         accessibilityLabel: props.accessibilityLabel
       })
     },
+    ListItem: ({ label, sub, onPress, testID, icon, iconColor, trailing }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(
+          Pressable,
+          { testID, onPress, accessibilityRole: "button", accessibilityLabel: `${label}, ${sub}` },
+          R.createElement(Text, null, label),
+          R.createElement(Text, null, sub),
+          R.createElement(Text, { testID: `${testID}-glyph`, style: { color: iconColor } }, icon?.displayName ?? "icon")
+        ),
+        trailing
+      ),
+    StateLine: ({ label, caption, iconColor, testID }: any) =>
+      R.createElement(
+        View,
+        { testID, accessibilityValue: { text: iconColor } },
+        R.createElement(Text, null, label),
+        R.createElement(Text, null, caption)
+      ),
     Container: ({ children }: any) => R.createElement(View, null, children),
-    SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
-    Card: ({ children, style }: any) => R.createElement(View, { style }, children)
+    Card: ({ children }: any) => R.createElement(View, { testID: "profiles-card" }, children),
+    Divider: () => R.createElement(View, null)
   }
 })
 
-const mockNavigate = jest.fn()
-const mockAddListener = jest.fn().mockReturnValue(jest.fn())
-
-const mockNavigation = {
-  navigate: mockNavigate,
-  addListener: mockAddListener
-}
+jest.mock("../../utils/logger", () => ({ logger: { error: jest.fn() } }))
 
 import { TrackingProfilesScreen } from "../TrackingProfilesScreen"
+
+const mockNavigate = jest.fn()
+const mockAddListener = jest.fn().mockReturnValue(jest.fn())
+const mockSetOptions = jest.fn()
+const mockNavigation = { navigate: mockNavigate, addListener: mockAddListener, setOptions: mockSetOptions }
+const headerRight = () => render(mockSetOptions.mock.calls.at(-1)[0].headerRight())
 
 describe("TrackingProfilesScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockActiveProfileName = null
+    mockActiveProfileId = null
+    mockTracking = true
     mockGetProfiles.mockResolvedValue(mockProfiles)
-    mockShowConfirm.mockResolvedValue(true)
   })
 
   function renderScreen() {
     return render(<TrackingProfilesScreen navigation={mockNavigation as any} />)
   }
 
-  it("marks the active profile with a fill, because a border that comes and goes clips the card", async () => {
-    mockActiveProfileName = "Charging"
+  describe("the state line", () => {
+    it("names the profile in force with its values and tints its glyph", async () => {
+      mockActiveProfileId = 2
+      const { findByText, getByText, getByTestId } = renderScreen()
 
-    const { UNSAFE_getAllByType, findByText } = renderScreen()
-    await findByText("Active")
+      expect(await findByText("Driving is active")).toBeTruthy()
+      expect(getByText("In force: every 2 s after 10 m · syncs every 1 min")).toBeTruthy()
+      expect(getByTestId("profile-state").props.accessibilityValue.text).toBe(lightColors.success)
+    })
 
-    const filled = UNSAFE_getAllByType(RNView).filter(
-      (v) => StyleSheet.flatten(v.props.style)?.backgroundColor === lightColors.primaryContainer
-    )
+    it("gives the default a meaning while tracking runs with no profile", async () => {
+      const { findByText, getByText } = renderScreen()
 
-    expect(filled).toHaveLength(1)
-    expect(StyleSheet.flatten(filled[0].props.style).borderWidth).toBeUndefined()
-  })
+      expect(await findByText("No profile active")).toBeTruthy()
+      expect(getByText("Tracking & sync applies: every 30 s after 2 m · syncs every 5 min")).toBeTruthy()
+    })
 
-  it("renders profile list", async () => {
-    const { getByText } = renderScreen()
+    it("says profiles wait for tracking instead of inventing a state", async () => {
+      mockTracking = false
+      mockActiveProfileId = 2
+      const { findByText, queryByText } = renderScreen()
 
-    await waitFor(() => {
-      expect(getByText("Charging")).toBeTruthy()
-      expect(getByText("Driving")).toBeTruthy()
+      expect(await findByText("Profiles apply while tracking runs")).toBeTruthy()
+      expect(queryByText(/^Active · /)).toBeNull()
     })
   })
 
-  it("shows profile condition text", async () => {
-    const { getByText } = renderScreen()
+  describe("the rows", () => {
+    it("reads each profile as a sentence in priority order, with its switch", async () => {
+      const { findByText, getByText, getByTestId } = renderScreen()
 
-    await waitFor(() => {
-      expect(getByText("When charging")).toBeTruthy()
-      expect(getByText(/Speed above 50 km\/h/)).toBeTruthy()
+      expect(await findByText("Speed above 50 km/h · Every 2 s after 10 m · syncs every 1 min")).toBeTruthy()
+      expect(getByText("When charging · Every 5 s, any movement · syncs each fix")).toBeTruthy()
+      expect(getByTestId("profile-toggle-2").props.value).toBe(true)
+      expect(getByTestId("profile-toggle-1").props.value).toBe(false)
+      expect(getByTestId("profile-toggle-1").props.accessibilityLabel).toBe("Use Commute")
+    })
+
+    it("opens the row in force with Active and tints its glyph, and no other", async () => {
+      mockActiveProfileId = 2
+      const { findByText, getByTestId, queryByText } = renderScreen()
+
+      expect(await findByText("Active · speed above 50 km/h · Every 2 s after 10 m · syncs every 1 min")).toBeTruthy()
+      expect(getByTestId("profile-2-glyph").props.style.color).toBe(lightColors.success)
+      expect(getByTestId("profile-1-glyph").props.style.color).toBeUndefined()
+      expect(queryByText(/Active · when charging/)).toBeNull()
+    })
+
+    it("opens the editor from the row body", async () => {
+      const { findByTestId } = renderScreen()
+
+      fireEvent.press(await findByTestId("profile-1"))
+
+      expect(mockNavigate).toHaveBeenCalledWith("Profile Editor", { profileId: 1 })
+    })
+
+    it("flips a profile's switch and reloads, and says when that fails", async () => {
+      const { findByTestId } = renderScreen()
+
+      fireEvent(await findByTestId("profile-toggle-1"), "valueChange", true)
+
+      await waitFor(() => expect(mockUpdateProfile).toHaveBeenCalledWith({ id: 1, enabled: true }))
+      expect(mockGetProfiles).toHaveBeenCalledTimes(2)
+
+      mockUpdateProfile.mockRejectedValueOnce(new Error("db"))
+      fireEvent(await findByTestId("profile-toggle-2"), "valueChange", false)
+      await waitFor(() => expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to update profile.", "error"))
+    })
+
+    it("reloads on focus, so an edit shows on the way back", () => {
+      renderScreen()
+      expect(mockAddListener).toHaveBeenCalledWith("focus", expect.any(Function))
     })
   })
 
-  it("shows profile settings summary", async () => {
-    const { getByText } = renderScreen()
+  describe("the app bar", () => {
+    it("holds Share before Create, and Share only with profiles", async () => {
+      const { findByTestId } = renderScreen()
+      await findByTestId("profile-1")
 
-    await waitFor(() => {
-      expect(getByText(/10s interval/)).toBeTruthy()
-      expect(getByText(/3s interval/)).toBeTruthy()
-    })
-  })
+      const bar = headerRight()
+      expect(bar.getByLabelText("Share all profiles")).toBeTruthy()
+      expect(bar.getByLabelText("Create profile")).toBeTruthy()
 
-  it("shows priority badges", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("P10")).toBeTruthy()
-      expect(getByText("P20")).toBeTruthy()
-    })
-  })
-
-  it("shows empty state when no profiles", async () => {
-    mockGetProfiles.mockResolvedValue([])
-
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("No profiles yet")).toBeTruthy()
-    })
-  })
-
-  it("navigates to editor when pressing Create Profile", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Create profile")).toBeTruthy()
+      mockGetProfiles.mockResolvedValue([])
+      const empty = renderScreen()
+      await empty.findByText("No profiles yet")
+      expect(headerRight().queryByLabelText("Share all profiles")).toBeNull()
     })
 
-    fireEvent.press(getByText("Create profile"))
+    it("shares a setup link with every profile and no database fields", async () => {
+      const shareSpy = jest.spyOn(Share, "share").mockResolvedValue({ action: "sharedAction", activityType: undefined })
+      const { findByTestId } = renderScreen()
+      await findByTestId("profile-1")
 
-    expect(mockNavigate).toHaveBeenCalledWith("Profile Editor", {})
-  })
+      fireEvent.press(headerRight().getByLabelText("Share all profiles"))
 
-  it("navigates to editor with profileId when pressing a profile", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Charging")).toBeTruthy()
-    })
-
-    fireEvent.press(getByText("Charging"))
-
-    expect(mockNavigate).toHaveBeenCalledWith("Profile Editor", { profileId: 1 })
-  })
-
-  it("shows confirmation dialog before deleting", async () => {
-    const { getByText, getByTestId } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Charging")).toBeTruthy()
-    })
-
-    fireEvent.press(getByTestId("delete-profile-1"))
-
-    await waitFor(() => {
-      expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Delete profile" }))
-    })
-
-    await waitFor(() => {
-      expect(mockDeleteProfile).toHaveBeenCalledWith(1)
-    })
-  })
-
-  it("shows section title with profile count", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Profiles (2)")).toBeTruthy()
-    })
-  })
-
-  it("shows error when toggle fails", async () => {
-    mockUpdateProfile.mockRejectedValueOnce(new Error("Network error"))
-
-    const { getByText, getByTestId } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Driving")).toBeTruthy()
-    })
-
-    fireEvent(getByTestId("toggle-profile-2"), "onValueChange", true)
-
-    await waitFor(() => {
-      expect(mockShowAlert).toHaveBeenCalledWith("Error", expect.any(String), "error")
-    })
-  })
-
-  it("reloads profiles on focus", () => {
-    renderScreen()
-
-    // Verify navigation focus listener is registered
-    expect(mockAddListener).toHaveBeenCalledWith("focus", expect.any(Function))
-  })
-
-  it("shows Active badge when profile matches activeProfileName from context", async () => {
-    mockActiveProfileName = "Charging"
-
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Active")).toBeTruthy()
-    })
-  })
-
-  it("does not show Active badge when no profile is active", async () => {
-    mockActiveProfileName = null
-
-    const { queryByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(queryByText("Active")).toBeNull()
-    })
-  })
-
-  describe("share profiles", () => {
-    let shareSpy: jest.SpyInstance
-
-    beforeEach(() => {
-      shareSpy = jest.spyOn(Share, "share").mockResolvedValue({ action: "sharedAction", activityType: undefined })
-    })
-
-    afterEach(() => {
+      await waitFor(() => expect(shareSpy).toHaveBeenCalledWith({ message: expect.stringContaining("colota://setup") }))
+      const link: string = shareSpy.mock.calls[0][0].message as string
+      expect(decodeURIComponent(link.split("config=")[1])).not.toMatch(/"id"/)
       shareSpy.mockRestore()
     })
 
-    it("does not render the share button when there are no profiles", async () => {
-      mockGetProfiles.mockResolvedValue([])
-      const { queryByTestId, getByText } = renderScreen()
+    it("opens the editor on an empty draft from Create", async () => {
+      const { findByTestId } = renderScreen()
+      await findByTestId("profile-1")
 
-      await waitFor(() => {
-        expect(getByText("No profiles yet")).toBeTruthy()
-      })
+      fireEvent.press(headerRight().getByLabelText("Create profile"))
 
-      expect(queryByTestId("share-profiles-btn")).toBeNull()
+      expect(mockNavigate).toHaveBeenCalledWith("Profile Editor", {})
     })
+  })
 
-    it("renders the share button when at least one profile exists", async () => {
-      const { getByTestId } = renderScreen()
+  it("shows the empty state with one action and no card or caption", async () => {
+    mockGetProfiles.mockResolvedValue([])
+    const { findByText, queryByTestId, queryByText, getByTestId } = renderScreen()
 
-      await waitFor(() => {
-        expect(getByTestId("share-profiles-btn")).toBeTruthy()
-      })
-    })
-
-    it("opens the share sheet with a colota://setup link on press", async () => {
-      const { getByTestId } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByTestId("share-profiles-btn")).toBeTruthy()
-      })
-
-      fireEvent.press(getByTestId("share-profiles-btn"))
-
-      await waitFor(() => {
-        expect(shareSpy).toHaveBeenCalledTimes(1)
-      })
-
-      const arg = shareSpy.mock.calls[0][0]
-      expect(arg.message).toMatch(/^colota:\/\/setup\?config=/)
-    })
-
-    it("encodes profiles without id or createdAt fields", async () => {
-      const { getByTestId } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByTestId("share-profiles-btn")).toBeTruthy()
-      })
-
-      fireEvent.press(getByTestId("share-profiles-btn"))
-
-      await waitFor(() => {
-        expect(shareSpy).toHaveBeenCalledTimes(1)
-      })
-
-      const link = shareSpy.mock.calls[0][0].message as string
-      const encoded = link.split("config=")[1]
-      const decoded = JSON.parse(atob(encoded))
-
-      expect(decoded.profiles).toHaveLength(2)
-      expect(decoded.profiles[0]).not.toHaveProperty("id")
-      expect(decoded.profiles[0]).not.toHaveProperty("createdAt")
-      expect(decoded.profiles[0]).toEqual({
-        name: "Charging",
-        interval: 10,
-        distance: 0,
-        syncInterval: 0,
-        priority: 10,
-        condition: { type: "charging" },
-        activationDelay: 0,
-        deactivationDelay: 60,
-        enabled: true
-      })
-      expect(decoded.profiles[1].condition).toEqual({ type: "speed_above", speedThreshold: 13.89 })
-    })
-
-    it("shows an error alert when sharing fails", async () => {
-      shareSpy.mockRejectedValueOnce(new Error("share failed"))
-
-      const { getByTestId } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByTestId("share-profiles-btn")).toBeTruthy()
-      })
-
-      fireEvent.press(getByTestId("share-profiles-btn"))
-
-      await waitFor(() => {
-        expect(mockShowAlert).toHaveBeenCalledWith("Error", "Failed to share profiles.", "error")
-      })
-    })
+    expect(await findByText("No profiles yet")).toBeTruthy()
+    expect(queryByTestId("profiles-card")).toBeNull()
+    expect(queryByText(/Checked top to bottom/)).toBeNull()
+    fireEvent.press(getByTestId("empty-action"))
+    expect(mockNavigate).toHaveBeenCalledWith("Profile Editor", {})
   })
 })

--- a/apps/mobile/src/utils/__tests__/geo.test.ts
+++ b/apps/mobile/src/utils/__tests__/geo.test.ts
@@ -9,6 +9,8 @@ import {
   inputToMeters,
   metersToInput,
   getSpeedUnit,
+  speedToInput,
+  inputToSpeed,
   loadDisplayPreferences,
   getUnitSystem,
   getTimeFormat
@@ -301,5 +303,19 @@ describe("formatTime", () => {
     await setPreferences("", "12h")
     const result = formatTime(1700000000)
     expect(result).toMatch(/am|pm/i)
+  })
+})
+
+describe("speedToInput / inputToSpeed", () => {
+  it("round-trips a stored speed through the display unit, so 13.9 m/s reads 50 km/h and 31 mph", async () => {
+    mockGetSetting.mockImplementation((key: string) => Promise.resolve(key === "unitSystem" ? "metric" : ""))
+    await loadDisplayPreferences()
+    expect(speedToInput(13.89)).toBe(50)
+    expect(inputToSpeed(50)).toBeCloseTo(13.89, 2)
+
+    mockGetSetting.mockImplementation((key: string) => Promise.resolve(key === "unitSystem" ? "imperial" : ""))
+    await loadDisplayPreferences()
+    expect(speedToInput(13.89)).toBe(31)
+    expect(inputToSpeed(31)).toBeCloseTo(13.86, 2)
   })
 })

--- a/apps/mobile/src/utils/__tests__/profileRow.test.ts
+++ b/apps/mobile/src/utils/__tests__/profileRow.test.ts
@@ -1,0 +1,132 @@
+import { conditionText, describeProfileState, profileRowSub, profileSentence, recordingClause } from "../profileRow"
+import { loadDisplayPreferences } from "../geo"
+import type { SavedTrackingProfile } from "../../types/global"
+
+const mockGetSetting = jest.fn()
+jest.mock("../../services/NativeLocationService", () => ({
+  __esModule: true,
+  default: { getSetting: (...args: string[]) => mockGetSetting(...args) }
+}))
+
+const units = async (system: "metric" | "imperial") => {
+  mockGetSetting.mockImplementation((key: string) => Promise.resolve(key === "unitSystem" ? system : ""))
+  await loadDisplayPreferences()
+}
+
+beforeAll(() => units("metric"))
+
+const profile = (overrides: Partial<SavedTrackingProfile>): SavedTrackingProfile => ({
+  id: 1,
+  name: "Commute",
+  interval: 5,
+  distance: 0,
+  syncInterval: 0,
+  priority: 10,
+  condition: { type: "charging" },
+  activationDelay: 0,
+  deactivationDelay: 60,
+  enabled: true,
+  ...overrides
+})
+const commute = profile({})
+const driving = profile({
+  id: 2,
+  name: "Driving",
+  interval: 2,
+  distance: 10,
+  syncInterval: 60,
+  condition: { type: "speed_above", speedThreshold: 13.89 }
+})
+const resting = profile({
+  id: 3,
+  name: "Resting",
+  interval: 60,
+  distance: 0,
+  syncInterval: 300,
+  condition: { type: "stationary" }
+})
+const car = profile({
+  id: 4,
+  name: "Car",
+  interval: 10,
+  distance: 5,
+  syncInterval: 300,
+  condition: { type: "android_auto" }
+})
+const settings = { interval: 30, distance: 2, syncInterval: 300, isOfflineMode: false }
+
+describe("profileRowSub", () => {
+  it("reads as one sentence: condition, recording, sync", () => {
+    expect(profileRowSub(commute, false, false)).toBe("When charging · Every 5 s, any movement · syncs each fix")
+    expect(profileRowSub(driving, false, false)).toBe("Speed above 50 km/h · Every 2 s after 10 m · syncs every 1 min")
+    expect(profileRowSub(car, false, false)).toBe("On Android Auto · Every 10 s after 5 m · syncs every 5 min")
+  })
+
+  it("opens with Active and lower-cases the condition for the row in force", () => {
+    expect(profileRowSub(commute, true, false)).toBe(
+      "Active · when charging · Every 5 s, any movement · syncs each fix"
+    )
+    expect(profileRowSub(driving, true, false)).toBe(
+      "Active · speed above 50 km/h · Every 2 s after 10 m · syncs every 1 min"
+    )
+  })
+
+  it("says while still for a stationary profile, since its distance is forced to 0", () => {
+    expect(profileRowSub(resting, false, false)).toBe("When stationary · Every 1 min while still · syncs every 5 min")
+    expect(recordingClause(resting)).toBe("Every 1 min while still")
+  })
+
+  it("drops the sync clause in offline mode", () => {
+    expect(profileRowSub(commute, false, true)).toBe("When charging · Every 5 s, any movement")
+  })
+
+  it("prints the speed in the user's unit", async () => {
+    await units("imperial")
+    expect(conditionText(driving)).toBe("Speed above 31 mph")
+    expect(profileRowSub(driving, false, false)).toBe("Speed above 31 mph · Every 2 s after 33 ft · syncs every 1 min")
+    await units("metric")
+  })
+})
+
+describe("profileSentence", () => {
+  it("is the rule the editor reads back", () => {
+    expect(profileSentence(commute, false)).toBe("When charging, track every 5 s, any movement and sync each fix.")
+    expect(profileSentence(driving, false)).toBe(
+      "When faster than 50 km/h, track every 2 s after 10 m and sync every 1 min."
+    )
+    expect(profileSentence(resting, false)).toBe("When stationary, track every 1 min while still and sync every 5 min.")
+    expect(profileSentence({ ...driving, condition: { type: "speed_below", speedThreshold: 2.78 } }, false)).toBe(
+      "When slower than 10 km/h, track every 2 s after 10 m and sync every 1 min."
+    )
+  })
+
+  it("stops after the recording clause in offline mode", () => {
+    expect(profileSentence(commute, true)).toBe("When charging, track every 5 s, any movement.")
+  })
+})
+
+describe("describeProfileState", () => {
+  it("names the profile in force with its values", () => {
+    const s = describeProfileState(driving, settings, true)
+    expect(s.tone).toBe("success")
+    expect(s.label).toBe("Driving is active")
+    expect(s.caption).toBe("In force: every 2 s after 10 m · syncs every 1 min")
+  })
+
+  it("gives the default a meaning when tracking runs with no profile", () => {
+    const s = describeProfileState(null, settings, true)
+    expect(s.tone).toBe("secondary")
+    expect(s.label).toBe("No profile active")
+    expect(s.caption).toBe("Tracking & sync applies: every 30 s after 2 m · syncs every 5 min")
+  })
+
+  it("says profiles wait for tracking rather than inventing a state", () => {
+    expect(describeProfileState(driving, settings, false).caption).toBe("Profiles apply while tracking runs")
+  })
+
+  it("prints while still for a stationary profile in force", () => {
+    expect(describeProfileState(resting, settings, true).caption).toBe(
+      "In force: every 1 min while still · syncs every 5 min"
+    )
+  })
+})

--- a/apps/mobile/src/utils/geo.ts
+++ b/apps/mobile/src/utils/geo.ts
@@ -158,6 +158,16 @@ export function shortDistanceUnit(): string {
   return usesMiles() ? "ft" : "m"
 }
 
+/** A stored speed in m/s as the whole number the speed field shows, in the user's unit. */
+export function speedToInput(metersPerSecond: number): number {
+  return Math.round(metersPerSecond * getSpeedUnit().factor)
+}
+
+/** A typed speed in the user's unit back to the m/s the profile stores. */
+export function inputToSpeed(value: number): number {
+  return value / getSpeedUnit().factor
+}
+
 /** Convert a user-entered short distance to meters. */
 export function inputToMeters(value: number): number {
   return usesMiles() ? value / FEET_PER_METER : value

--- a/apps/mobile/src/utils/profileRow.ts
+++ b/apps/mobile/src/utils/profileRow.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import { UserRoundPen, type LucideIcon } from "lucide-react-native"
+import { PROFILE_CONDITIONS } from "../constants"
+import type { SavedTrackingProfile, Settings, TrackingProfile } from "../types/global"
+import { formatInterval, recordingSummary, syncSummary, trackingSummary } from "./dashboardState"
+import { getSpeedUnit, speedToInput } from "./geo"
+
+type ProfileLike = Pick<TrackingProfile, "condition" | "interval" | "distance" | "syncInterval">
+
+const lowerFirst = (text: string) => text.charAt(0).toLowerCase() + text.slice(1)
+
+export function conditionOf(profile: Pick<TrackingProfile, "condition">) {
+  return PROFILE_CONDITIONS.find((c) => c.type === profile.condition.type) ?? PROFILE_CONDITIONS[0]
+}
+
+/** "When charging", "Speed above 50 km/h": the clause a row and the editor's sentence open with. */
+export function conditionText(profile: Pick<TrackingProfile, "condition">): string {
+  const { type, speedThreshold } = profile.condition
+  if (type === "speed_above" || type === "speed_below") {
+    return `${conditionOf(profile).listLabel} ${speedToInput(speedThreshold ?? 0)} ${getSpeedUnit().unit}`
+  }
+  return conditionOf(profile).listLabel
+}
+
+/** The recording half; a stationary profile forces the distance to 0, so "any movement" would mislead. */
+export function recordingClause(profile: ProfileLike): string {
+  if (profile.condition.type === "stationary") return `${formatInterval(profile.interval)} while still`
+  return recordingSummary(profile.interval, profile.distance)
+}
+
+/** The one line under a profile's name: [Active · ]condition · recording · sync. */
+export function profileRowSub(profile: ProfileLike, inForce: boolean, isOfflineMode: boolean): string {
+  const condition = conditionText(profile)
+  const parts = [inForce ? `Active · ${lowerFirst(condition)}` : condition, recordingClause(profile)]
+  if (!isOfflineMode) parts.push(syncSummary(profile.syncInterval))
+  return parts.join(" · ")
+}
+
+/** The rule as one sentence, the editor's caption: "When charging, track every 5 s, any movement and sync each fix." */
+export function profileSentence(profile: ProfileLike, isOfflineMode: boolean): string {
+  const { type, speedThreshold } = profile.condition
+  const unit = getSpeedUnit().unit
+  const when =
+    type === "speed_above"
+      ? `When faster than ${speedToInput(speedThreshold ?? 0)} ${unit}`
+      : type === "speed_below"
+        ? `When slower than ${speedToInput(speedThreshold ?? 0)} ${unit}`
+        : conditionText(profile)
+  const track = `track ${lowerFirst(recordingClause(profile))}`
+  if (isOfflineMode) return `${when}, ${track}.`
+  return `${when}, ${track} and ${syncSummary(profile.syncInterval).replace(/^syncs/, "sync")}.`
+}
+
+export interface ProfileState {
+  icon: LucideIcon
+  tone: "success" | "secondary"
+  label: string
+  caption: string
+}
+
+/** The list's first row: which profile is in force, or what applies instead. */
+export function describeProfileState(
+  activeProfile: SavedTrackingProfile | null,
+  settings: Pick<Settings, "interval" | "distance" | "syncInterval" | "isOfflineMode">,
+  tracking: boolean
+): ProfileState {
+  if (!tracking) {
+    return {
+      icon: UserRoundPen,
+      tone: "secondary",
+      label: "No profile active",
+      caption: "Profiles apply while tracking runs"
+    }
+  }
+  if (activeProfile) {
+    const sync = settings.isOfflineMode ? "" : ` · ${syncSummary(activeProfile.syncInterval)}`
+    return {
+      icon: conditionOf(activeProfile).icon,
+      tone: "success",
+      label: `${activeProfile.name} is active`,
+      caption: `In force: ${lowerFirst(recordingClause(activeProfile))}${sync}`
+    }
+  }
+  return {
+    icon: UserRoundPen,
+    tone: "secondary",
+    label: "No profile active",
+    caption: `Tracking & sync applies: ${lowerFirst(trackingSummary(settings.interval, settings.distance, settings.syncInterval, settings.isOfflineMode))}`
+  }
+}


### PR DESCRIPTION
Tracking profiles list and editor rebuilt on the settings grammar: a state line for the profile in force, rows that read as rules with their switch in a ListItem trailing slot, a condition-first editor with a live sentence and inline validation, one profileRow derivation shared with Tracking & sync. Native profiles order by priority then id.
