### PR TITLE
refactor(data): each delete names its scope and count before it runs

### DIFF
--- a/apps/docs/docs/configuration/server-settings.md
+++ b/apps/docs/docs/configuration/server-settings.md
@@ -72,7 +72,7 @@ The UI simplifies to remove sync-related elements that don't apply:
 - Server endpoint, Test connection and the Server details rows (Request format, Authentication, Client certificate); the sync state line and the Offline mode switch stay
 - Sync interval, Sync only on (Any network / Wi-Fi or Ethernet / Specific Wi-Fi network / VPN)
 - Queue statistics (Queued / Sent counts)
-- Queue actions (Sync Now, Clear Sent History, Clear Queue)
+- Queue actions (Sync now, Delete queued locations, Delete synced locations)
 - Queue info in the tracking notification
 
 **Still available in offline mode:**
@@ -80,8 +80,8 @@ The UI simplifies to remove sync-related elements that don't apply:
 - All tracking parameters (interval, movement threshold, accuracy)
 - Tracking profiles and geofences
 - Data export (CSV, GeoJSON, GPX, KML) - both manual and auto-export
-- Database statistics (Total locations, Today count, Storage)
-- Data cleanup (Delete All Locations, Delete Old, Optimize Database)
+- Database statistics (Total locations, Storage)
+- Data cleanup (Delete older than, Delete all locations, Compact database)
 
 ### Disabling Offline Mode
 

--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -61,7 +61,7 @@ Three React Native bridge modules are registered by `LocationServicePackage`: `L
 The primary React Native bridge module (exposed as `"LocationServiceModule"`). Handles all JS-to-native communication for:
 
 - Service control (`startService`, `stopService`)
-- Database queries (`getStats`, `getTableData`, `getLocationsByDateRange`, `getDaysWithData`, `getDailyStats`)
+- Database queries (`getStats`, `getTableData`, `getLocationsByDateRange`, `getDaysWithData`, `getDailyStats`, `countOlderThan`, `countUnsentOlderThan`)
 - Geofence CRUD operations
 - Settings persistence
 - Device info, file operations, authentication
@@ -71,7 +71,8 @@ Emits events back to JavaScript:
 - `onLocationUpdate` - new GPS fix received
 - `onTrackingStopped` - service stopped (user action or OOM kill)
 - `onSyncError` - 3+ consecutive sync failures
-- `onSyncProgress` - batch sync progress updates with `{sent, failed, total}`
+- `onSyncProgress` - batch sync progress updates with `{sent, failed, total}`, plus `remaining` on the one event that ends a pass. A pass caps at `MAX_BATCHES_PER_SYNC`, so `sent + failed` reaching `total` does not mean the queue is empty
+- `onDatabaseCompacted` - the detached `VACUUM` after a bulk delete has finished, with `{success}`, so a size read before it is known to be stale
 - `onPauseZoneChange` - entered or exited a geofence pause zone
 - `onProfileSwitch` - a tracking profile was activated or deactivated
 - `onAutoExportComplete` - auto-export finished with `{success, fileName, rowCount, error}`
@@ -318,7 +319,7 @@ For backups, two `internal` methods support the export/import flow without expos
 | `ImportLocationsScreen` | Import external location files (GeoJSON, Google Timeline legacy + new, GPX, KML, CSV) with auto format detection, dedup preview, and recovery vs migration (queue-for-sync) commit choice |
 | `AutoExportScreen` | Configure scheduled auto-export: directory, format, frequency, time of day, weekday or day-of-month, export range and file retention |
 | `OfflineMapsScreen` | Download and manage offline map areas - interactive bounding box picker, size estimate, progress tracking, and area deletion |
-| `DataManagementScreen` | Clear sent history, delete old data, vacuum database, sync controls |
+| `DataManagementScreen` | Database ledger, manual flush, compaction, deletes by sync state or age |
 | `BackupRestoreScreen` | Create or restore a password-encrypted `.colota` archive of all data, with strength meter and no-recovery confirmation |
 | `SetupImportScreen` | Confirmation screen for `colota://setup` deep link imports |
 | `ShareSetupScreen` | Bundles selected config categories into a `colota://setup` link to share; credentials opt-in |

--- a/apps/docs/docs/guides/data-import.md
+++ b/apps/docs/docs/guides/data-import.md
@@ -76,7 +76,7 @@ If you've configured an optional sync backend in **Settings → Connection**, th
 
 - Rows are written into Colota with `sent=1` - flagged as already replicated.
 - **The sync engine will not push them to your backend.**
-- Use this when the backend already holds these points - for example, you're re-importing your own Colota export, or repopulating local history after a "Clear Sent History".
+- Use this when the backend already holds these points - for example, you're re-importing your own Colota export, or repopulating local history after a "Delete synced locations".
 
 ### Import + Queue for Sync
 

--- a/apps/docs/docs/guides/data-management.md
+++ b/apps/docs/docs/guides/data-management.md
@@ -10,21 +10,26 @@ import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
 <ScreenshotGallery screenshots={[ { src: "/img/screenshots/DataManagement.png", label: "Data management" }, ]} />
 
-## Actions
+## What the screen holds
 
-| Action                       | Description                                                                |
-| ---------------------------- | -------------------------------------------------------------------------- |
-| **Sync Now**                 | Manually flush the queue and upload pending locations                      |
-| **Clear Sent History**       | Remove locations that have already been synced                             |
-| **Clear Queue**              | Remove unsent locations from the upload queue                              |
-| **Delete Older Than X Days** | Clean up old data past a specified age                                     |
-| **Vacuum Database**          | Reclaim disk space after deletions                                         |
-| **Export locations**         | Export location history - see [Data Export](data-export.md)                |
-| **Import locations**         | Merge external files into your history - see [Data Import](data-import.md) |
+**Stored on this device** is the ledger: how many locations this device holds and what they take on disk.
 
-In [offline mode](/docs/configuration/server-settings#offline-mode), sync-related actions (Sync Now, Clear Sent History, Clear Queue) are hidden since no queue is used. A **Delete All Locations** action is available instead. Data export remains fully available - see [Data Export](data-export.md).
+| Control | What it does |
+| --- | --- |
+| **Sync now** | Uploads the queued locations immediately, whatever [Sync only on](/docs/configuration/sync-presets) says. The tracking notification appears for a moment if tracking was off, and nothing is recorded |
+| **Compact database** | Rewrites the database to give unused space back. It deletes nothing. Deleting trips and points from Location History leaves gaps that only this reclaims, so press it after a round of track editing |
+| **Delete queued locations** | Deletes the locations waiting to upload, not their pending uploads. Nothing else holds a copy, so they leave Location History too |
+| **Delete synced locations** | Deletes locations already on your server. Those days leave Location History, notes included, and imported locations count as synced. Copies on your server stay |
+| **Delete older than** | Deletes every location recorded before the age you pick: 30 days, 90 days, 1 year or a custom number of days. Sync state is ignored, so queued locations go with the rest |
+| **Delete all locations** | Deletes every location and every manual trip split you made. Geofences, profiles and settings stay |
 
-For a full archive of locations, settings and credentials in a single password-encrypted file, use **Settings → Backup & restore** - see [Backup & restore](backup-restore.md).
+Each delete names its own count before you press it. No age is chosen when the screen opens, so nothing is counted until you pick one. Every delete asks you to confirm, and none can be undone.
+
+In [offline mode](/docs/configuration/server-settings#offline-mode) nothing new is queued, so Sync now and both sync-scoped deletes leave the screen. Locations queued before you turned it on are still there, and the age delete and Delete all still reach them.
+
+Location History deletes single points and whole trips, see below. Export lives on its own screen, see [Data Export](data-export.md), and so does import, see [Data Import](data-import.md).
+
+For a full archive of locations, settings and credentials in a single password-encrypted file, use **Settings > Backup & restore** - see [Backup & restore](backup-restore.md).
 
 ## Deleting from Location History
 

--- a/apps/docs/docs/guides/troubleshooting.md
+++ b/apps/docs/docs/guides/troubleshooting.md
@@ -148,9 +148,9 @@ To change: **Settings > Tracking & sync > Sync only on**.
 
 ## Database growing too large
 
-- Use **Clear Sent History** to remove synced locations
-- Use **Delete Older Than X Days** for cleanup
-- Export data first if you want to keep it
-- Use **Vacuum Database** to reclaim space after deletions
+- Use **Delete synced locations** to remove what your server already holds
+- Use **Delete older than** for an age cutoff, which ignores sync state
+- Back up or export first if you want to keep it
+- Use **Compact database** to reclaim space after deleting trips or points, which leave gaps nothing else reclaims
 
 **Size reference**: ~200 bytes per location, ~2 MB per 10,000 locations.

--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -54,7 +54,7 @@ Colota has twenty-eight screens, each focused on a specific task:
 | **Export locations** | Export tracked locations as CSV, GeoJSON, GPX, or KML |
 | **Import locations** | Import tracks from GeoJSON, Google Timeline, GPX, KML or CSV with a preview before committing |
 | **Auto-export** | Configure scheduled exports: directory, format, frequency, time of day (with weekday or day-of-month for weekly/monthly), export range and file retention |
-| **Data management** | Clear sent history, delete old data, vacuum the database |
+| **Data management** | Delete by sync state or age, compact the database |
 | **Backup & restore** | Create or restore a single password-encrypted `.colota` archive of all data (locations, settings, geofences, credentials) |
 | **Setup Import** | Confirmation screen for deep link configuration imports (`colota://setup`) |
 | **Share setup** | Build a `colota://setup` link or QR code from selected settings to configure another device |

--- a/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/bridge/LocationServiceModule.kt
@@ -195,12 +195,19 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
             }
         }
 
+        /** The detached rewrite after a bulk delete has finished, so any size read before it is stale. */
         @JvmStatic
-        fun sendSyncProgressEvent(sent: Int, failed: Int, total: Int): Boolean =
+        fun sendDatabaseCompactedEvent(success: Boolean): Boolean =
+            emit("onDatabaseCompacted") { putBoolean("success", success) }
+
+        /** `remaining` is present only on the event that ends a pass, and is what says the pass ended. */
+        @JvmStatic
+        fun sendSyncProgressEvent(sent: Int, failed: Int, total: Int, remaining: Int? = null): Boolean =
             emit("onSyncProgress") {
                 putInt("sent", sent)
                 putInt("failed", failed)
                 putInt("total", total)
+                if (remaining != null) putInt("remaining", remaining)
             }
 
         @JvmStatic
@@ -441,8 +448,22 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun countOlderThan(days: Int, promise: Promise) = executeAsync(promise) {
+        val counted = dbHelper.countOlderThan(days)
+        Arguments.createMap().apply {
+            putInt("total", counted.total)
+            putDouble("cutoffSeconds", counted.cutoffSeconds.toDouble())
+        }
+    }
+
+    @ReactMethod
+    fun countUnsentOlderThan(days: Int, promise: Promise) = executeAsync(promise) {
+        dbHelper.countUnsentOlderThan(days)
+    }
+
+    @ReactMethod
     fun deleteLocationsInRange(startTs: Double, endTs: Double, promise: Promise) = executeAsync(promise) {
-        deleteThenVacuum(refresh = true) { dbHelper.deleteInRange(startTs.toLong(), endTs.toLong()) }
+        deleteWithoutVacuum { dbHelper.deleteInRange(startTs.toLong(), endTs.toLong()) }
     }
 
     @ReactMethod
@@ -454,17 +475,25 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
             val end = r.getDouble("end").toLong()
             pairs.add(start to end)
         }
-        deleteThenVacuum(refresh = true) { dbHelper.deleteInRanges(pairs) }
+        deleteWithoutVacuum { dbHelper.deleteInRanges(pairs) }
     }
 
     @ReactMethod
     fun deleteLocationsByIds(ids: ReadableArray, promise: Promise) = executeAsync(promise) {
         val locationIds = (0 until ids.size()).map { ids.getDouble(it).toLong() }
-        val deleted = dbHelper.deleteLocations(locationIds)
+        deleteWithoutVacuum { dbHelper.deleteLocations(locationIds) }
+    }
+
+    /**
+     * Editing a track, not maintaining a database: a point or a trip is a few rows out of millions,
+     * and the delete gets repeated. Rewriting the whole file each time holds the one write
+     * connection for minutes and stalls the recording service. Compact database is the deliberate
+     * rewrite, and its figure is what the user watches move.
+     */
+    private fun deleteWithoutVacuum(delete: () -> Int): Int {
+        val deleted = delete()
         if (deleted > 0) refreshNotificationIfTracking()
-        // No vacuum here: a few rows are not worth rewriting the database, and this delete gets
-        // repeated. Data Management has an explicit Vacuum action.
-        deleted
+        return deleted
     }
 
     @ReactMethod
@@ -493,9 +522,11 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun vacuumDatabase(promise: Promise) = executeAsync(promise) { 
-        dbHelper.vacuum()
-        true 
+    fun vacuumDatabase(promise: Promise) = executeAsync(promise) {
+        // Rejecting is what lets the caller say the database was busy. Resolving regardless made a
+        // failure look like a rewrite that found nothing to release.
+        if (!dbHelper.vacuum()) throw IllegalStateException("The database was busy")
+        true
     }
 
     private fun triggerZoneRecheck() {
@@ -529,11 +560,20 @@ class LocationServiceModule(reactContext: ReactApplicationContext) :
         triggerProfileRecheck()
     }
 
-    /** delete() runs inline; vacuum is fire-and-forget so callers return immediately. */
+    /**
+     * For the bulk deletes on Data management only: rare, deliberate, and asked for by someone who
+     * just said to remove a large share of the table. delete() runs inline; vacuum is
+     * fire-and-forget so callers return immediately.
+     */
     private fun deleteThenVacuum(refresh: Boolean = false, delete: () -> Int): Int {
         val deleted = delete()
         if (refresh) refreshNotificationIfTracking()
-        moduleScope.launch(Dispatchers.IO) { dbHelper.vacuum() }
+        // The rewrite runs detached so the delete returns at once, which leaves the file its old
+        // size for as long as it takes. The event is how a caller learns the size it read is stale.
+        moduleScope.launch(Dispatchers.IO) {
+            val ok = dbHelper.vacuum()
+            sendDatabaseCompactedEvent(ok)
+        }
         return deleted
     }
 

--- a/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/data/DatabaseHelper.kt
@@ -874,11 +874,44 @@ class DatabaseHelper private constructor(context: Context) :
         return out
     }
 
+    /** The boundary a retention age names, in seconds. The preview and the delete must share it or they drift. */
+    /**
+     * The boundary a retention age names, snapped to the start of that local day. A rolling instant
+     * would move between the count and the delete the user then confirms, so the delete would take
+     * slightly more than the confirmation named. Snapped, the boundary holds still, and the date the
+     * confirmation prints is the whole of what goes.
+     */
+    private fun cutoffFor(days: Int): Long =
+        LocalDate.now().minusDays(days.toLong()).atStartOfDay(ZoneId.systemDefault()).toEpochSecond()
+
     fun deleteOlderThan(days: Int): Int {
         requireNotRestoring()
-        val cutoff = (System.currentTimeMillis() - days.toLong() * 24 * 60 * 60 * 1000) / 1000
-        return writableDatabase.delete(TABLE_LOCATIONS, "timestamp < ?", arrayOf(cutoff.toString()))
+        return writableDatabase.delete(TABLE_LOCATIONS, "timestamp < ?", arrayOf(cutoffFor(days).toString()))
     }
+
+    /** What `deleteOlderThan(days)` would take, and the boundary it would take it at. */
+    data class OlderThan(val total: Int, val cutoffSeconds: Long)
+
+    /** Cheap: the timestamp index answers this without reading the table. Safe to call as the user types. */
+    fun countOlderThan(days: Int): OlderThan {
+        requireNotRestoring()
+        val cutoff = cutoffFor(days)
+        return OlderThan(countWhereOlder("", arrayOf(cutoff.toString())), cutoff)
+    }
+
+    /**
+     * Expensive: `sent` is not in any index, so this reads every matching row. Call it once, when a
+     * delete is actually pressed, never on the way to one.
+     */
+    fun countUnsentOlderThan(days: Int): Int {
+        requireNotRestoring()
+        return countWhereOlder(" AND sent = 0", arrayOf(cutoffFor(days).toString()))
+    }
+
+    private fun countWhereOlder(extra: String, args: Array<String>): Int =
+        readableDatabase.rawQuery("SELECT COUNT(*) FROM $TABLE_LOCATIONS WHERE timestamp < ?$extra", args).use {
+            if (it.moveToFirst()) it.getInt(0) else 0
+        }
 
     fun deleteInRange(startTs: Long, endTs: Long): Int {
         requireNotRestoring()
@@ -912,15 +945,18 @@ class DatabaseHelper private constructor(context: Context) :
     }
 
     /** Reclaims unused space. Call from background thread only. */
-    fun vacuum() {
+    /** False when the rewrite did not happen, so a caller cannot report a failure as nothing to release. */
+    fun vacuum(): Boolean {
         requireNotRestoring()
         AppLogger.d(TAG, "Starting VACUUM + ANALYZE")
-        try {
+        return try {
             writableDatabase.execSQL("VACUUM")
             writableDatabase.execSQL("ANALYZE")
             AppLogger.d(TAG, "VACUUM + ANALYZE completed")
+            true
         } catch (e: Exception) {
             AppLogger.e(TAG, "Vacuum failed (likely concurrent access)", e)
+            false
         }
     }
 

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
@@ -134,10 +134,21 @@ class SyncManager(
     }
 
     suspend fun manualFlush() {
-        if (endpoint.isNotBlank()) {
-            val total = dbHelper.getQueuedCount()
-            AppLogger.d(TAG, "Manual flush started: $total items in queue")
-            syncQueue { sent, failed -> LocationServiceModule.sendSyncProgressEvent(sent, failed, total) }
+        if (endpoint.isBlank()) return
+        val total = dbHelper.getQueuedCount()
+        AppLogger.d(TAG, "Manual flush started: $total items in queue")
+        var pass = SyncPass(0, 0)
+        try {
+            pass = syncQueue { sent, failed -> LocationServiceModule.sendSyncProgressEvent(sent, failed, total) }
+        } finally {
+            // A pass caps at MAX_BATCHES_PER_SYNC and stops when a batch moves nothing, so the
+            // running count need not reach the queue it started with. Only this event ends the pass,
+            // and a throw or a cancellation must still send it or the caller waits out its own
+            // timeout and reports a failure over an upload that worked. The totals come from the
+            // pass, not from the last progress tick, which only fires when a batch succeeded.
+            invalidateQueueCache()
+            val remaining = runCatching { dbHelper.getQueuedCount() }.getOrDefault(total - pass.sent)
+            LocationServiceModule.sendSyncProgressEvent(pass.sent, pass.failed, pass.sent + pass.failed, remaining)
         }
     }
 
@@ -220,7 +231,10 @@ class SyncManager(
         delay(backoffSeconds * 1000L)
     }
 
-    private suspend fun syncQueue(onProgress: ((sent: Int, failed: Int) -> Unit)? = null) = coroutineScope {
+    /** What one pass moved. It caps at [MAX_BATCHES_PER_SYNC], so it need not empty the queue. */
+    data class SyncPass(val sent: Int, val failed: Int)
+
+    private suspend fun syncQueue(onProgress: ((sent: Int, failed: Int) -> Unit)? = null): SyncPass = coroutineScope {
         // Snapshot volatile config so it stays consistent for the entire sync pass
         val currentEndpoint = endpoint
         val currentAuthHeaders = authHeaders
@@ -321,6 +335,8 @@ class SyncManager(
         if (totalSucceeded > 0) {
             markSuccess()
         }
+
+        SyncPass(totalSucceeded, totalFailed)
     }
 
     private data class BatchSendResult(val processed: Int, val failed: Int, val stop: Boolean)

--- a/apps/mobile/android/app/src/test/java/com/Colota/bridge/LocationServiceModuleTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/bridge/LocationServiceModuleTest.kt
@@ -5,7 +5,9 @@
 
 package com.Colota.bridge
 
+import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.location.Location
 import com.Colota.data.DatabaseHelper
 import com.Colota.data.GeofenceHelper
@@ -13,9 +15,13 @@ import com.Colota.data.ProfileHelper
 import com.Colota.service.LocationForegroundService
 import com.Colota.service.TrackingWatchdogScheduler
 import com.Colota.util.AppLogger
+import com.Colota.util.SecureStorageHelper
 import com.Colota.util.DeviceInfoHelper
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import io.mockk.*
@@ -24,6 +30,8 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import java.lang.ref.WeakReference
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Tests for LocationServiceModule:
@@ -53,9 +61,18 @@ class LocationServiceModuleTest {
         every { AppLogger.e(any(), any(), any()) } just Runs
 
         mockkStatic(Arguments::class)
-        every { Arguments.createMap() } returns JavaOnlyMap()
+        // A fresh map per call. One shared instance makes every emitted payload look identical, so
+        // an assertion about what one event carries silently reads what a later one wrote.
+        every { Arguments.createMap() } answers { JavaOnlyMap() }
+
+        // NetworkManager casts this in a field initialiser, and a relaxed mock hands back an Object.
+        every { mockContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns mockk<ConnectivityManager>(relaxed = true)
 
         mockkObject(DatabaseHelper.Companion)
+        // The module builds one in a field initialiser, and it opens an encrypted keystore a plain
+        // JVM has no keys for, so constructing the module needs this stubbed.
+        mockkObject(SecureStorageHelper.Companion)
+        every { SecureStorageHelper.getInstance(any()) } returns mockk(relaxed = true)
         mockkObject(LocationForegroundService.Companion)
         every { LocationForegroundService.isRunning } returns true
 
@@ -76,6 +93,7 @@ class LocationServiceModuleTest {
         unmockkObject(AppLogger)
         unmockkStatic(Arguments::class)
         unmockkObject(DatabaseHelper.Companion)
+        unmockkObject(SecureStorageHelper.Companion)
         unmockkObject(LocationForegroundService.Companion)
         unmockkObject(TrackingWatchdogScheduler)
         setCompanionField("reactContextRef", WeakReference<ReactApplicationContext>(null))
@@ -207,6 +225,25 @@ class LocationServiceModuleTest {
     fun `sendSyncProgressEvent emits onSyncProgress`() {
         assertTrue(LocationServiceModule.sendSyncProgressEvent(5, 2, 100))
         verify { mockEmitter.emit("onSyncProgress", any()) }
+    }
+
+    /**
+     * `remaining` is the whole completion contract. A pass caps at MAX_BATCHES_PER_SYNC, so the
+     * running count need not reach the queue it started with, and a tick carrying the key would end
+     * the caller's flush on the first batch.
+     */
+    @Test
+    fun `a progress tick carries no remaining, and only the event that ends a pass does`() {
+        val payloads = mutableListOf<WritableMap>()
+        every { mockEmitter.emit("onSyncProgress", capture(payloads)) } just Runs
+
+        LocationServiceModule.sendSyncProgressEvent(50, 0, 412)
+        LocationServiceModule.sendSyncProgressEvent(500, 3, 503, 120)
+
+        assertFalse(payloads[0].hasKey("remaining"))
+        assertTrue(payloads[1].hasKey("remaining"))
+        assertEquals(120, payloads[1].getInt("remaining"))
+        assertEquals(3, payloads[1].getInt("failed"))
     }
 
     @Test
@@ -688,6 +725,94 @@ class LocationServiceModuleTest {
             }
         }
         throw NoSuchFieldException(name)
+    }
+
+    // ========================================================================
+    // Which deletes rewrite the database
+    // ========================================================================
+
+    /**
+     * A track edit is a few rows out of millions and gets repeated, so it must not trigger a full
+     * rewrite: VACUUM holds the one write connection for minutes and stalls the recording service.
+     * The bulk deletes on Data management are rare and asked for, so they still do.
+     */
+    @Test
+    fun `deleting a trip does not rewrite the database`() {
+        val db = stubDatabase()
+        every { db.deleteInRange(any(), any()) } returns 120
+
+        awaitPromise { promise -> LocationServiceModule(mockContext).deleteLocationsInRange(1000.0, 2000.0, promise) }
+
+        verify(exactly = 1) { db.deleteInRange(1000L, 2000L) }
+        assertNoVacuum(db)
+    }
+
+    @Test
+    fun `deleting selected trips does not rewrite the database`() {
+        val db = stubDatabase()
+        every { db.deleteInRanges(any()) } returns 40
+        val ranges = JavaOnlyArray().apply {
+            pushMap(JavaOnlyMap().apply {
+                putDouble("start", 10.0)
+                putDouble("end", 20.0)
+            })
+        }
+
+        awaitPromise { promise -> LocationServiceModule(mockContext).deleteLocationsInRanges(ranges, promise) }
+
+        verify(exactly = 1) { db.deleteInRanges(listOf(10L to 20L)) }
+        assertNoVacuum(db)
+    }
+
+    @Test
+    fun `deleting single points does not rewrite the database`() {
+        val db = stubDatabase()
+        every { db.deleteLocations(any()) } returns 1
+        val ids = JavaOnlyArray().apply { pushDouble(7.0) }
+
+        awaitPromise { promise -> LocationServiceModule(mockContext).deleteLocationsByIds(ids, promise) }
+
+        verify(exactly = 1) { db.deleteLocations(listOf(7L)) }
+        assertNoVacuum(db)
+    }
+
+    @Test
+    fun `a bulk delete on Data management still rewrites the database`() {
+        val db = stubDatabase()
+        every { db.deleteOlderThan(any()) } returns 9000
+
+        awaitPromise { promise -> LocationServiceModule(mockContext).deleteOlderThan(90, promise) }
+
+        verify(exactly = 1) { db.deleteOlderThan(90) }
+        // Fire-and-forget on its own coroutine, so the promise resolves before it runs.
+        verify(timeout = 5000, exactly = 1) { db.vacuum() }
+    }
+
+    /**
+     * The rewrite runs on a detached coroutine, so the promise can settle before it would have
+     * started. Proving it never runs means giving it the chance and then checking.
+     */
+    private fun assertNoVacuum(db: DatabaseHelper) {
+        Thread.sleep(200)
+        verify(exactly = 0) { db.vacuum() }
+    }
+
+    private fun stubDatabase(): DatabaseHelper {
+        val db = mockk<DatabaseHelper>(relaxed = true)
+        every { DatabaseHelper.getInstance(any()) } returns db
+        return db
+    }
+
+    /** The bridge resolves on its own coroutine, so a test has to wait for the promise, not the call. */
+    private fun awaitPromise(call: (Promise) -> Unit) {
+        val latch = CountDownLatch(1)
+        val promise = mockk<Promise>(relaxed = true)
+        every { promise.resolve(any()) } answers { latch.countDown() }
+        every { promise.reject(any<String>(), any<String>(), any<Throwable>()) } answers { latch.countDown() }
+
+        call(promise)
+
+        assertTrue("the bridge never settled its promise", latch.await(5, TimeUnit.SECONDS))
     }
 
     private fun getField(obj: Any, name: String): Any? {

--- a/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/data/DatabaseHelperSQLiteTest.kt
@@ -145,6 +145,8 @@ class DatabaseHelperSQLiteTest {
         DatabaseHelper.migrateCandidate(candidate)
 
         SQLiteDatabase.openDatabase(candidate.absolutePath, null, SQLiteDatabase.OPEN_READONLY).use { migrated ->
+            // A literal on purpose: migrateCandidate stamps the constant, so comparing against it
+            // passes for any value and stops forcing a migration arm when the version moves.
             assertEquals(7, migrated.version)
             // migrateCandidate stamps the version unconditionally, so the version alone proves
             // nothing about the v7 step. This is the restore-an-older-backup path.
@@ -184,6 +186,8 @@ class DatabaseHelperSQLiteTest {
         DatabaseHelper.migrateCandidate(candidate)
 
         SQLiteDatabase.openDatabase(candidate.absolutePath, null, SQLiteDatabase.OPEN_READONLY).use { migrated ->
+            // A literal on purpose: migrateCandidate stamps the constant, so comparing against it
+            // passes for any value and stops forcing a migration arm when the version moves.
             assertEquals(7, migrated.version)
             assertMigratedTableExists(migrated, DatabaseHelper.TABLE_BOUNDARY_OVERRIDES)
             migrated.rawQuery("PRAGMA table_info(locations)", null).use { locCursor ->
@@ -1166,6 +1170,79 @@ class DatabaseHelperSQLiteTest {
         val remaining = db.getTableData(DatabaseHelper.TABLE_LOCATIONS, 100, 0)
         assertEquals(1, remaining.size)
         assertEquals(53.0, remaining[0]["latitude"] as Double, 0.001)
+    }
+
+    @Test
+    fun `countOlderThan counts exactly what deleteOlderThan then removes, so a preview cannot promise a wrong number`() {
+        val now = System.currentTimeMillis() / 1000
+        // Rows sitting on the boundary and one second either side, so a shift of one day or a flip
+        // between < and <= moves the two figures apart instead of leaving both unchanged.
+        val cutoff = db.countOlderThan(7).cutoffSeconds
+        db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = cutoff - 1)
+        db.saveLocation(latitude = 52.1, longitude = 13.1, timestamp = cutoff)
+        db.saveLocation(latitude = 52.2, longitude = 13.2, timestamp = cutoff + 1)
+        db.saveLocation(latitude = 53.0, longitude = 14.0, timestamp = now)
+
+        val predicted = db.countOlderThan(7).total
+        val deleted = db.deleteOlderThan(7)
+
+        assertEquals(predicted, deleted)
+        // Only the row strictly before the boundary goes; the one on it stays.
+        assertEquals(1, deleted)
+    }
+
+    @Test
+    fun `the boundary holds still across a dwell, so a confirmation cannot name less than the delete takes`() {
+        val first = db.countOlderThan(30).cutoffSeconds
+
+        Thread.sleep(20)
+
+        assertEquals(first, db.countOlderThan(30).cutoffSeconds)
+    }
+
+    @Test
+    fun `countUnsentOlderThan reports how many matches were never uploaded, since no copy of those survives`() {
+        val now = System.currentTimeMillis() / 1000
+        val sentId = db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = now - 86400 * 10)
+        db.saveLocation(latitude = 52.1, longitude = 13.1, timestamp = now - 86400 * 9)
+        db.markLocationsSent(listOf(sentId))
+
+        assertEquals(2, db.countOlderThan(7).total)
+        assertEquals(1, db.countUnsentOlderThan(7))
+    }
+
+    @Test
+    fun `countOlderThan is zero on an empty window rather than reporting a phantom match`() {
+        db.saveLocation(latitude = 53.0, longitude = 14.0, timestamp = System.currentTimeMillis() / 1000)
+
+        assertEquals(0, db.countOlderThan(7).total)
+        assertEquals(0, db.countUnsentOlderThan(7))
+    }
+
+    @Test
+    fun `countOlderThan reports the boundary it counted at, so the confirmation cannot name a different one`() {
+        val now = System.currentTimeMillis() / 1000
+        db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = now - 86400 * 10)
+
+        val counted = db.countOlderThan(7)
+
+        // Every row it counted sits before the boundary it reports.
+        assertEquals(1, counted.total)
+        assertTrue(counted.cutoffSeconds <= now - 86400 * 7)
+        assertTrue(counted.cutoffSeconds > now - 86400 * 8)
+    }
+
+    @Test
+    fun `getStats agrees with the table on how many rows have been uploaded`() {
+        val sentId = db.saveLocation(latitude = 52.0, longitude = 13.0, timestamp = 1000L)
+        db.saveLocation(latitude = 52.1, longitude = 13.1, timestamp = 2000L)
+        db.saveLocation(latitude = 52.2, longitude = 13.2, timestamp = 3000L)
+        db.markLocationsSent(listOf(sentId))
+
+        val stats = db.getStats()
+
+        assertEquals(3, stats.total)
+        assertEquals(1, stats.sent)
     }
 
     // ========================================================================

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -8,8 +8,12 @@ import { Zap, Car, ArrowUp, ArrowDown, Pause } from "lucide-react-native"
 
 // Timing
 export const AUTOSAVE_DEBOUNCE_MS = 1500
-export const STATS_REFRESH_FAST = 3_000
 export const SAVE_SUCCESS_DISPLAY_MS = 2000
+/** manualFlush is fire and forget, so the screen gives up on progress events after this. */
+export const MANUAL_FLUSH_TIMEOUT_MS = 30_000
+/** A retention preview runs a COUNT per keystroke, so it waits for the typing to settle. */
+export const RETENTION_PREVIEW_DEBOUNCE_MS = 300
+export const RETENTION_PRESET_DAYS = [30, 90, 365]
 /** A certificate this close to its notAfter reads as expiring: a CA round trip takes weeks. */
 export const CERT_EXPIRY_WARNING_DAYS = 30
 export const SERVICE_RESTART_DELAY_MS = 500

--- a/apps/mobile/src/hooks/__tests__/useTimeout.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useTimeout.test.ts
@@ -84,6 +84,18 @@ describe("useTimeout", () => {
     expect(callback).not.toHaveBeenCalled()
   })
 
+  // Callers list the returned object in dependency arrays. A fresh one per render re-runs their
+  // effects every render, which is how DataManagementScreen came to poll the database in a loop.
+  it("returns the same object across renders, so a dependency on it is stable", () => {
+    const { result, rerender } = renderHook(() => useTimeout())
+    const first = result.current
+
+    rerender({})
+    rerender({})
+
+    expect(result.current).toBe(first)
+  })
+
   it("clear is safe to call with no pending timeout", () => {
     const { result } = renderHook(() => useTimeout())
 

--- a/apps/mobile/src/hooks/useTimeout.ts
+++ b/apps/mobile/src/hooks/useTimeout.ts
@@ -3,7 +3,7 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import { useRef, useEffect, useCallback } from "react"
+import { useRef, useEffect, useCallback, useMemo } from "react"
 
 /**
  * Hook that manages a single timeout with automatic cleanup on unmount.
@@ -30,5 +30,7 @@ export function useTimeout() {
     }
   }, [])
 
-  return { set, clear }
+  // Stable identity: callers list this object in dependency arrays, and a fresh one per render
+  // re-runs their effects forever.
+  return useMemo(() => ({ set, clear }), [set, clear])
 }

--- a/apps/mobile/src/screens/DataManagementScreen.tsx
+++ b/apps/mobile/src/screens/DataManagementScreen.tsx
@@ -3,21 +3,12 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useCallback, useRef } from "react"
-import {
-  Text,
-  StyleSheet,
-  View,
-  ScrollView,
-  Pressable,
-  KeyboardAvoidingView,
-  Platform,
-  NativeEventEmitter,
-  NativeModules
-} from "react-native"
-import { Lightbulb } from "lucide-react-native"
+import React, { useState, useCallback, useRef, useEffect } from "react"
+import { Text, StyleSheet, View, ScrollView, DeviceEventEmitter } from "react-native"
+import { Archive, Clock, CloudUpload, HardDrive, MapPin, Trash2 } from "lucide-react-native"
 import { useFocusEffect } from "@react-navigation/native"
-import { ScreenProps, DatabaseStats } from "../types/global"
+import { DatabaseStats } from "../types/global"
+import type { RootScreenProps } from "../types/navigation"
 import { useTheme } from "../hooks/useTheme"
 import { fonts, fontSizes, lineHeights } from "../styles/typography"
 import NativeLocationService from "../services/NativeLocationService"
@@ -25,480 +16,548 @@ import { useTracking } from "../contexts/TrackingProvider"
 import {
   Button,
   Card,
+  ChipGroup,
   Container,
   Divider,
-  FloatingSaveIndicator,
+  EmptyState,
+  FieldMessage,
+  ListItem,
+  NumericInput,
   SectionTitle,
-  StatRow,
-  TextField
+  StatRow
 } from "../components"
-import { SAVE_SUCCESS_DISPLAY_MS, STATS_REFRESH_FAST, size, space, STATE_LAYER_ALPHA } from "../constants"
+import {
+  MANUAL_FLUSH_TIMEOUT_MS,
+  RETENTION_PRESET_DAYS,
+  RETENTION_PREVIEW_DEBOUNCE_MS,
+  SAVE_SUCCESS_DISPLAY_MS,
+  space
+} from "../constants"
 import { useTimeout } from "../hooks/useTimeout"
-import { showConfirm } from "../services/modalService"
+import { showAlert, showConfirm } from "../services/modalService"
+import { allSub, deleteCopy, olderSub, scopeSub, type DataScope } from "../utils/dataScope"
+import { parseWholeNumber, wholeNumberError } from "../utils/settingsValidation"
+import { formatWhen } from "../utils/geo"
 import { logger } from "../utils/logger"
 
-const BACKUP_TIP = "Tip: back up your data first (Settings > Backup & restore)."
+/** Only a placeholder in the custom field. Nothing is selected until the user selects it. */
+const PLACEHOLDER_DAYS = 90
 
-export function DataManagementScreen({}: ScreenProps) {
+/** A hundred years. Past this the value stops being an age and starts being a typo. */
+const MAX_RETENTION_DAYS = 36500
+
+type Message = { text: string; failed?: boolean }
+type Preview = { days: number; total: number; cutoffSeconds: number } | null
+
+const EMPTY_STATS: DatabaseStats = {
+  queued: 0,
+  sent: 0,
+  total: 0,
+  today: 0,
+  databaseSizeMB: 0,
+  lastSyncTime: 0,
+  lastSyncError: ""
+}
+
+export function DataManagementScreen({ navigation }: RootScreenProps<"Data Management">) {
   const { colors } = useTheme()
-  const { settings } = useTracking()
+  const { settings, tracking } = useTracking()
   const isOfflineMode = settings.isOfflineMode
 
-  const [stats, setStats] = useState<DatabaseStats>({
-    queued: 0,
-    sent: 0,
-    total: 0,
-    today: 0,
-    databaseSizeMB: 0,
-    lastSyncTime: 0,
-    lastSyncError: ""
-  })
+  const [stats, setStats] = useState<DatabaseStats>(EMPTY_STATS)
+  const [loaded, setLoaded] = useState(false)
+  const [busy, setBusy] = useState<"count" | "flush" | "compact" | "delete" | null>(null)
+  const [syncMessage, setSyncMessage] = useState<Message | null>(null)
+  const [compactMessage, setCompactMessage] = useState<Message | null>(null)
 
-  const [daysInput, setDaysInput] = useState("90")
-  const [isProcessing, setIsProcessing] = useState(false)
-  const [feedback, setFeedback] = useState<string | null>(null)
-  const feedbackTimeout = useTimeout()
+  // Nothing preselected: an age is an argument to a delete, so the screen opens with none chosen,
+  // arms nothing and counts nothing until the user picks one.
+  const [ageChoice, setAgeChoice] = useState("")
+  const [customText, setCustomText] = useState("")
+  const lastValidDays = useRef<number | null>(null)
+  const [clampNote, setClampNote] = useState<string | undefined>()
+  const [preview, setPreview] = useState<Preview>(null)
 
-  // Update stats
+  const compactTimeout = useTimeout()
+  const clampTimeout = useTimeout()
+  const previewTimeout = useTimeout()
+  const flushTimeout = useTimeout()
+
+  // A ref, not the state, because two presses inside one render both read the same state value.
+  const busyRef = useRef(false)
+  const isProcessing = busy !== null
+
+  const statsIssued = useRef(0)
+  const statsApplied = useRef(0)
+  // The flush listener lives outside any effect, so only this removes it when the screen goes.
+  const flushSub = useRef<{ remove: () => void } | null>(null)
+  useEffect(() => () => flushSub.current?.remove(), [])
+
+  /**
+   * Reads are numbered so a slow earlier one cannot land on a newer one. The comparison is against
+   * what has landed, not against what has been issued, or a newer read that then fails would leave
+   * the screen with nothing applied and the ledger stuck on its placeholder.
+   */
+  const applyStats = useCallback((next: DatabaseStats, generation: number) => {
+    if (generation < statsApplied.current) return
+    statsApplied.current = generation
+    setStats(next)
+    setLoaded(true)
+  }, [])
+
   const updateStats = useCallback(async () => {
+    const generation = ++statsIssued.current
     try {
-      const nativeStats = await NativeLocationService.getStats()
-      setStats(nativeStats)
+      applyStats(await NativeLocationService.getStats(), generation)
     } catch (err) {
       logger.error("[DataManagementScreen] Failed to update stats:", err)
     }
-  }, [])
+  }, [applyStats])
 
-  // Load debug mode setting
+  const isCustom = ageChoice === "custom"
+  const customDays = parseWholeNumber(customText)
+  const days = isCustom ? customDays : parseWholeNumber(ageChoice)
+  // The bridge parameter is a Kotlin Int, so an age past its range would arrive coerced and could
+  // put the cutoff in the future, where every row matches.
+  const ageError = isCustom
+    ? (wholeNumberError(customText, 1, "day") ??
+      (customDays !== null && customDays > MAX_RETENTION_DAYS ? `At most ${MAX_RETENTION_DAYS} days` : undefined))
+    : undefined
+
+  /** One count per settled age, from the same cutoff arithmetic the delete uses. */
+  const runPreview = useCallback(
+    (forDays: number | null) => {
+      previewTimeout.clear()
+      if (forDays === null || forDays < 1) {
+        setPreview(null)
+        return
+      }
+      if (forDays > MAX_RETENTION_DAYS) {
+        setPreview(null)
+        return
+      }
+      previewTimeout.set(async () => {
+        // An age the user settled on long enough to have it counted. Recording per keystroke would
+        // catch every prefix, so backspacing 365 to nothing would restore 3 and arm a far wider delete.
+        lastValidDays.current = forDays
+        try {
+          const { total, cutoffSeconds } = await NativeLocationService.countOlderThan(forDays)
+          setPreview({ days: forDays, total, cutoffSeconds })
+        } catch (err) {
+          logger.error("[DataManagementScreen] Failed to count old locations:", err)
+          setPreview(null)
+        }
+      }, RETENTION_PREVIEW_DEBOUNCE_MS)
+    },
+    [previewTimeout]
+  )
+
+  // No preview call here. This callback is stable, so it would capture the age from the first
+  // render, which is always none, and re-focusing would wipe a count the user had already asked for.
+  // The preview runs from the controls that change the age.
   useFocusEffect(
     useCallback(() => {
       updateStats()
-      const interval = setInterval(updateStats, STATS_REFRESH_FAST)
-      return () => clearInterval(interval)
+      const subs = ["onSyncProgress", "onSyncError", "onLocationUpdate", "onDatabaseCompacted"].map((event) =>
+        DeviceEventEmitter.addListener(event, updateStats)
+      )
+      return () => subs.forEach((s) => s.remove())
     }, [updateStats])
   )
 
-  // Show feedback message
-  const showFeedback = useCallback(
-    (message: string, duration = SAVE_SUCCESS_DISPLAY_MS) => {
-      setFeedback(message)
-      feedbackTimeout.set(() => setFeedback(null), duration)
-    },
-    [feedbackTimeout]
-  )
+  const handleAgeChoice = (value: string) => {
+    setAgeChoice(value)
+    setClampNote(undefined)
+    runPreview(value === "custom" ? customDays : parseWholeNumber(value))
+  }
 
-  // Manual flush with progress
-  const progressListenerRef = useRef<any>(null)
-  const syncEmitter = useRef(new NativeEventEmitter(NativeModules.LocationServiceModule)).current
-  const flushTimeout = useTimeout()
+  const handleCustomChange = (text: string) => {
+    setCustomText(text)
+    setClampNote(undefined)
+    const parsed = parseWholeNumber(text)
+    runPreview(parsed !== null && parsed >= 1 ? parsed : null)
+  }
 
-  const cleanupFlush = useCallback(async () => {
-    progressListenerRef.current?.remove()
-    progressListenerRef.current = null
-    flushTimeout.clear()
-    await updateStats()
-    setIsProcessing(false)
-  }, [updateStats, flushTimeout])
-
-  const handleManualFlush = useCallback(async () => {
-    if (isProcessing || stats.queued === 0) return
-    const total = stats.queued
-
-    try {
-      setIsProcessing(true)
-      setFeedback(`Syncing 0/${total}...`)
-      feedbackTimeout.clear()
-
-      const receivedProgress = { current: false }
-
-      progressListenerRef.current = syncEmitter.addListener("onSyncProgress", (rawEvent: any) => {
-        const event = rawEvent as { sent: number; failed: number; total: number }
-        receivedProgress.current = true
-        const processed = event.sent + event.failed
-        if (processed >= event.total) {
-          // Sync finished - show final result, then clean up
-          const msg =
-            event.failed > 0
-              ? `Synced ${event.sent}/${event.total} (${event.failed} failed)`
-              : `Synced ${event.sent}/${event.total}`
-          setFeedback(msg)
-          flushTimeout.set(async () => {
-            await cleanupFlush()
-            showFeedback("Sync complete")
-          }, 1500)
-        } else {
-          setFeedback(`Syncing ${processed}/${event.total}...`)
-        }
-      })
-
-      // manualFlush is fire-and-forget; fall back after 30s if no progress events arrive
-      await NativeLocationService.manualFlush()
-      flushTimeout.set(async () => {
-        await cleanupFlush()
-        showFeedback(receivedProgress.current ? "Sync complete" : "Sync failed! Check connection")
-      }, 30000)
-    } catch (err) {
-      logger.error("[DataManagementScreen] Manual flush error:", err)
-      await cleanupFlush()
-      showFeedback("Sync failed. Check your connection and endpoint.")
-    }
-  }, [stats.queued, isProcessing, showFeedback, feedbackTimeout, flushTimeout, syncEmitter, cleanupFlush])
-
-  // Generic delete handler
-  const handleDeleteAction = useCallback(
-    async (action: () => Promise<number | void>, successMessage: (count: number) => string) => {
-      setIsProcessing(true)
-      try {
-        const deleted = await action()
-        await updateStats()
-        if (typeof deleted === "number") {
-          showFeedback(successMessage(deleted))
-        }
-      } catch (err) {
-        logger.error("[DataManagementScreen] Delete action failed:", err)
-        showFeedback("Action failed")
-      } finally {
-        setIsProcessing(false)
-      }
-    },
-    [updateStats, showFeedback]
-  )
-
-  const handleClearSentHistory = useCallback(async () => {
-    const confirmed = await showConfirm({
-      title: "Clear sent history",
-      message: `Delete ${stats.sent} sent location${stats.sent !== 1 ? "s" : ""}? This cannot be undone.\n\n${BACKUP_TIP}`,
-      confirmText: "Clear",
-      destructive: true
-    })
-    if (!confirmed) return
-
-    handleDeleteAction(
-      () => NativeLocationService.clearSentHistory().then(() => stats.sent),
-      (count) => `Cleared ${count} sent location${count !== 1 ? "s" : ""}`
-    )
-  }, [handleDeleteAction, stats.sent])
-
-  const handleClearQueue = useCallback(async () => {
-    const confirmed = await showConfirm({
-      title: "Clear queue",
-      message: `Delete ${stats.queued} pending location${stats.queued !== 1 ? "s" : ""}? These will not be synced.\n\n${BACKUP_TIP}`,
-      confirmText: "Clear",
-      destructive: true
-    })
-    if (!confirmed) return
-
-    handleDeleteAction(
-      () => NativeLocationService.clearQueue(),
-      (count) => `Cleared ${count} queued location${count !== 1 ? "s" : ""}`
-    )
-  }, [handleDeleteAction, stats.queued])
-
-  const handleDeleteAllLocations = useCallback(async () => {
-    const confirmed = await showConfirm({
-      title: "Delete all locations",
-      message: `Delete all ${stats.total} stored location${stats.total !== 1 ? "s" : ""}? This cannot be undone.\n\n${BACKUP_TIP}`,
-      confirmText: "Delete all",
-      destructive: true
-    })
-    if (!confirmed) return
-
-    handleDeleteAction(
-      () => NativeLocationService.clearAllLocations(),
-      (count) => `Deleted ${count} location${count !== 1 ? "s" : ""}`
-    )
-  }, [handleDeleteAction, stats.total])
-
-  const handleDeleteOlderThan = useCallback(async () => {
-    const days = parseInt(daysInput, 10)
-    if (isNaN(days) || days <= 0) {
-      showFeedback("Please enter a valid number of days")
+  // The siblings clamp an emptied field up to the minimum, which is right for a stored setting.
+  // Here the value is a delete argument: clamping to 1 would arm "delete everything older than a
+  // day" in silence, so an invalid entry falls back to the last age the user actually chose.
+  const handleCustomBlur = () => {
+    if (customDays !== null && customDays >= 1) {
+      lastValidDays.current = customDays
       return
     }
+    const restored = lastValidDays.current
+    // Nothing settled yet, so there is nothing to fall back to. The field stays empty and the
+    // delete stays disarmed, which is the right resting state for a delete argument.
+    if (restored === null) return
+    setCustomText(String(restored))
+    setClampNote(`Set to ${restored} day${restored === 1 ? "" : "s"}`)
+    clampTimeout.set(() => setClampNote(undefined), SAVE_SUCCESS_DISPLAY_MS)
+    runPreview(restored)
+  }
 
-    const confirmed = await showConfirm({
-      title: "Delete old locations",
-      message: `Delete all locations older than ${days} day${days !== 1 ? "s" : ""}? This cannot be undone.\n\n${BACKUP_TIP}`,
-      confirmText: "Delete",
-      destructive: true
-    })
-    if (!confirmed) return
+  /** Every dialog names a count read immediately before it opens, never one held in state. */
+  const confirmAndDelete = useCallback(
+    async (scope: DataScope, run: () => Promise<number>) => {
+      if (busyRef.current) return
+      busyRef.current = true
+      setBusy("count")
+      try {
+        const generation = ++statsIssued.current
+        const fresh = await NativeLocationService.getStats()
+        applyStats(fresh, generation)
+        let count = fresh.total
+        let older
+        if (scope === "queued") count = fresh.queued
+        if (scope === "synced") count = fresh.sent
+        if (scope === "older") {
+          if (days === null) return
+          const { total, cutoffSeconds } = await NativeLocationService.countOlderThan(days)
+          count = total
+          // Reads every match, so it is taken here and nowhere on the way here.
+          const unsent = total === 0 ? 0 : await NativeLocationService.countUnsentOlderThan(days)
+          older = { days, unsent, cutoffSeconds }
+        }
+        if (count === 0) {
+          showAlert("Nothing to delete", "That count came back empty. The figures above are current.", "info")
+          return
+        }
 
-    handleDeleteAction(
-      () => NativeLocationService.deleteOlderThan(days),
-      (count) => `Deleted ${count} location${count !== 1 ? "s" : ""} older than ${days} day${days !== 1 ? "s" : ""}`
-    )
-  }, [daysInput, handleDeleteAction, showFeedback])
+        const copy = deleteCopy(scope, count, older)
+        if (!(await showConfirm({ ...copy, destructive: true }))) return
 
-  const handleVacuum = useCallback(async () => {
-    setIsProcessing(true)
-    try {
-      const sizeBefore = stats.databaseSizeMB
-      await NativeLocationService.vacuumDatabase()
-      const freshStats = await NativeLocationService.getStats()
-      setStats(freshStats)
-      const freed = sizeBefore - freshStats.databaseSizeMB
-      if (freed > 0.01) {
-        showFeedback(`Freed ${freed.toFixed(2)} MB`)
-      } else {
-        showFeedback("Database already optimized")
+        setBusy("delete")
+        await run()
+        await updateStats()
+        runPreview(days)
+      } catch (err) {
+        logger.error(`[DataManagementScreen] Failed to delete ${scope} locations:`, err)
+        showAlert(
+          "Delete failed",
+          "The database reported an error. Check the figures above before trying again.",
+          "error"
+        )
+      } finally {
+        busyRef.current = false
+        setBusy(null)
       }
-    } catch (err) {
-      logger.error("[DataManagementScreen] Vacuum failed:", err)
-      showFeedback("Optimization failed")
-    } finally {
-      setIsProcessing(false)
+    },
+    [days, updateStats, runPreview, applyStats]
+  )
+
+  const handleManualFlush = useCallback(async () => {
+    if (busyRef.current || stats.queued === 0 || !settings.endpoint) return
+    busyRef.current = true
+    const queuedBefore = stats.queued
+    setBusy("flush")
+    setSyncMessage({ text: `Sent 0 of ${queuedBefore.toLocaleString()}.` })
+
+    const finish = async (message: Message) => {
+      flushTimeout.clear()
+      sub.remove()
+      flushSub.current = null
+      await updateStats()
+      setSyncMessage(message)
+      busyRef.current = false
+      setBusy(null)
     }
-  }, [stats.databaseSizeMB, showFeedback])
+
+    // The fallback means no event for this long, not no ending within this long of the press. A pass
+    // over a large queue outlives the window while still reporting, and declaring it dead would
+    // remove the listener and re-enable the button over a run that is still uploading.
+    const armFallback = () =>
+      flushTimeout.set(
+        () => finish({ text: "No answer from the tracking service. Check the queued count above.", failed: true }),
+        MANUAL_FLUSH_TIMEOUT_MS
+      )
+
+    const sub = DeviceEventEmitter.addListener(
+      "onSyncProgress",
+      (event: { sent: number; failed: number; total: number; remaining?: number }) => {
+        // Only the event that ends a pass carries `remaining`. A pass caps at a fixed number of
+        // batches, so the running count reaching the queue it started with is not the signal.
+        if (event.remaining === undefined) {
+          armFallback()
+          setSyncMessage({ text: `Sent ${event.sent.toLocaleString()} of ${queuedBefore.toLocaleString()}.` })
+          return
+        }
+        // `remaining` is a fresh count of the queue. `failed` counts attempts inside the pass and can
+        // exceed it, since a row that failed twice is one row, so it never stands in for the queue.
+        const sent = `Sent ${event.sent.toLocaleString()} of ${queuedBefore.toLocaleString()}.`
+        const left = event.remaining > 0 ? ` ${event.remaining.toLocaleString()} still queued; press again.` : ""
+        if (event.failed > 0) {
+          finish({ text: `${sent} Some uploads failed.${left}`, failed: true })
+        } else {
+          finish({ text: `${sent}${left}` })
+        }
+      }
+    )
+
+    flushSub.current = sub
+
+    try {
+      await NativeLocationService.manualFlush()
+      armFallback()
+    } catch (err) {
+      logger.error("[DataManagementScreen] Manual flush failed:", err)
+      flushTimeout.clear()
+      sub.remove()
+      flushSub.current = null
+      busyRef.current = false
+      setBusy(null)
+      setSyncMessage(null)
+      showAlert("Sync failed", "Check your connection settings and try again.", "error")
+    }
+  }, [stats.queued, settings.endpoint, updateStats, flushTimeout])
+
+  const handleCompact = useCallback(async () => {
+    if (busyRef.current) return
+    busyRef.current = true
+    setBusy("compact")
+    try {
+      // Both figures come from the same moment, and both go through the generation guard so a read
+      // issued before the rewrite cannot land after it and put the old size back.
+      const beforeGeneration = ++statsIssued.current
+      const beforeStats = await NativeLocationService.getStats()
+      applyStats(beforeStats, beforeGeneration)
+      const before = beforeStats.databaseSizeMB
+      await NativeLocationService.vacuumDatabase()
+      const afterGeneration = ++statsIssued.current
+      const after = await NativeLocationService.getStats()
+      applyStats(after, afterGeneration)
+      const freed = before - after.databaseSizeMB
+      setCompactMessage({ text: freed > 0.01 ? `Released ${freed.toFixed(2)} MB` : "Nothing to release" })
+      compactTimeout.set(() => setCompactMessage(null), SAVE_SUCCESS_DISPLAY_MS)
+    } catch (err) {
+      logger.error("[DataManagementScreen] Compact failed:", err)
+      showAlert("Could not compact", "The database is busy. Try again in a moment.", "error")
+    } finally {
+      busyRef.current = false
+      setBusy(null)
+    }
+  }, [compactTimeout, applyStats])
+
+  const syncBlocker = !settings.endpoint
+    ? "No server configured. Set one on Connection."
+    : stats.queued === 0
+      ? stats.lastSyncTime > 0
+        ? `Nothing queued. Last upload ${formatWhen(Math.floor(stats.lastSyncTime / 1000))}.`
+        : "Nothing queued. New locations upload on their own."
+      : null
+  const syncIdle = `Uploads the ${stats.queued.toLocaleString()} queued location${stats.queued === 1 ? "" : "s"} now, whatever Sync only on says.${
+    tracking ? "" : " The tracking notification appears for a moment. Nothing is recorded."
+  }`
+  const syncLine = busy === "flush" || syncMessage ? syncMessage : { text: syncBlocker ?? syncIdle }
+
+  const ageCount = preview && preview.days === days ? preview.total : null
+  // The field owns its own error; repeating it here would print the same sentence twice.
+  const ageLine = ageError
+    ? "Fix the age above."
+    : days === null
+      ? "Choose how old a location must be."
+      : ageCount === null
+        ? "Counting…"
+        : olderSub(ageCount, days, preview?.cutoffSeconds ?? 0)
 
   return (
     <Container>
-      <KeyboardAvoidingView style={styles.keyboardAvoid} behavior={Platform.OS === "ios" ? "padding" : undefined}>
-        <ScrollView contentContainerStyle={styles.scrollContent}>
-          <Text style={[styles.intro, { color: colors.textSecondary }]}>
-            What this device is storing, and how to clear it
-          </Text>
-          {/* Stats */}
-          <View style={styles.section}>
-            <SectionTitle>Database statistics</SectionTitle>
-            <Card>
-              {[
-                ["Total locations", stats.total.toLocaleString()],
-                ...(!isOfflineMode
-                  ? [
-                      ["Sent", stats.sent.toLocaleString()],
-                      ["Queued", stats.queued.toLocaleString()]
-                    ]
-                  : []),
-                ["Today", stats.today.toLocaleString()],
-                ["Storage", `${stats.databaseSizeMB.toFixed(2)} MB`]
-              ].map(([label, value], i, arr) => (
-                <React.Fragment key={i}>
-                  <StatRow label={label} value={value} />
-                  {i < arr.length - 1 && <Divider />}
-                </React.Fragment>
-              ))}
-            </Card>
-          </View>
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        <Text style={[styles.intro, { color: colors.textSecondary }]}>
+          What this device is storing, and what deleting it takes away.
+        </Text>
 
-          {/* Queue Actions */}
+        <View style={styles.section}>
+          <SectionTitle>Stored on this device</SectionTitle>
+          <Card rows>
+            <StatRow
+              icon={MapPin}
+              label="Locations"
+              value={loaded ? stats.total.toLocaleString() : "…"}
+              testID="stat-locations"
+            />
+            <Divider tight inset />
+            <StatRow
+              icon={HardDrive}
+              label="Database size"
+              value={loaded ? `${stats.databaseSizeMB.toFixed(2)} MB` : "…"}
+              testID="stat-size"
+            />
+          </Card>
+
           {!isOfflineMode && (
-            <View style={styles.section}>
-              <SectionTitle>Queue actions</SectionTitle>
-              <Card>
-                <Button onPress={handleManualFlush} disabled={isProcessing || stats.queued === 0} title="Sync now" />
-                <Text style={[styles.hint, { color: colors.textLight }]}>
-                  {stats.queued === 0
-                    ? "Queue is empty"
-                    : `Trigger immediate sync of ${stats.queued} queued location${stats.queued !== 1 ? "s" : ""}`}
-                </Text>
-              </Card>
+            <View>
+              <Button
+                variant="secondary"
+                title="Sync now"
+                testID="sync-now-btn"
+                loading={busy === "flush"}
+                disabled={isProcessing || syncBlocker !== null}
+                onPress={handleManualFlush}
+              />
+              <FieldMessage variant={syncLine?.failed ? "error" : "info"}>{syncLine?.text ?? ""}</FieldMessage>
             </View>
           )}
 
-          {/* Cleanup Actions */}
-          <View style={styles.section}>
-            <SectionTitle>Cleanup actions</SectionTitle>
-            <Card>
-              {!isOfflineMode ? (
-                <>
-                  {/* Clear Sent History */}
-                  <ActionRow
-                    label="Clear sent history"
-                    hint="Delete all successfully sent locations"
-                    value={stats.sent.toLocaleString()}
-                    onPress={handleClearSentHistory}
-                    disabled={isProcessing || stats.sent === 0}
-                  />
-                  <Divider />
-
-                  {/* Clear Queue */}
-                  <ActionRow
-                    label="Clear queue"
-                    hint="Delete all pending locations"
-                    value={stats.queued.toLocaleString()}
-                    onPress={handleClearQueue}
-                    disabled={isProcessing || stats.queued === 0}
-                  />
-                  <Divider />
-                </>
-              ) : (
-                <>
-                  {/* Delete All Locations (offline mode) */}
-                  <ActionRow
-                    label="Delete all locations"
-                    hint="Remove all stored locations from the database"
-                    value={stats.total.toLocaleString()}
-                    onPress={handleDeleteAllLocations}
-                    disabled={isProcessing || stats.total === 0}
-                  />
-                  <Divider />
-                </>
-              )}
-
-              {/* Delete Older Than */}
-              <View style={styles.actionColumn}>
-                <Text style={[styles.actionLabel, { color: colors.text }]}>Delete old locations</Text>
-                <Text style={[styles.actionHint, { color: colors.textLight }]}>
-                  Remove locations older than specified days
-                </Text>
-                <View style={styles.daysInputRow}>
-                  <TextField
-                    testID="retention-days-input"
-                    accessibilityLabel="Days to keep"
-                    figure
-                    style={styles.daysInput}
-                    keyboardType="numeric"
-                    value={daysInput}
-                    onChangeText={setDaysInput}
-                    placeholder="90"
-                  />
-                  <Text style={[styles.daysLabel, { color: colors.textSecondary }]}>days</Text>
-                  <Button
-                    testID="delete-older-btn"
-                    onPress={handleDeleteOlderThan}
-                    disabled={isProcessing}
-                    title="Delete"
-                    variant="danger"
-                  />
-                </View>
-              </View>
-              <Divider />
-
-              {/* Vacuum */}
-              <View style={styles.actionColumn}>
-                <Text style={[styles.actionLabel, { color: colors.text }]}>Optimize database</Text>
-                <Text style={[styles.actionHint, { color: colors.textLight }]}>
-                  Reclaim unused space and improve performance
-                </Text>
-                <View style={styles.hintRow}>
-                  <Lightbulb size={size.icon.sm} color={colors.textLight} />
-                  <Text style={[styles.actionHint, { color: colors.textLight }]}>
-                    Run after large deletions to reclaim space
-                  </Text>
-                </View>
-                <Button onPress={handleVacuum} disabled={isProcessing} title="Optimize" variant="secondary" />
-              </View>
-            </Card>
+          <View>
+            <Button
+              variant="ghost"
+              title="Compact database"
+              testID="compact-btn"
+              loading={busy === "compact"}
+              disabled={isProcessing}
+              onPress={handleCompact}
+            />
+            <FieldMessage>
+              {compactMessage?.text ??
+                "Rewrites the database to give unused space back. Deleting trips and points leaves gaps that only this reclaims. Nothing is deleted."}
+            </FieldMessage>
           </View>
-        </ScrollView>
+        </View>
 
-        {/* Floating Feedback */}
-        <FloatingSaveIndicator
-          saving={isProcessing}
-          message={feedback}
-          isError={feedback?.toLowerCase().includes("failed") ?? false}
-        />
-      </KeyboardAvoidingView>
+        <View style={styles.section}>
+          <SectionTitle>Delete locations</SectionTitle>
+          {/* Until the first count lands the screen knows nothing, and "Nothing stored" over a full
+              database is both a lie and a whole subtree that mounts only to be torn down again. */}
+          {!loaded ? null : stats.total === 0 ? (
+            <Card rows style={styles.emptyCard}>
+              <EmptyState title="Nothing stored" hint="This device has no locations yet." style={styles.empty} />
+            </Card>
+          ) : (
+            <>
+              <Card rows>
+                <ListItem
+                  testID="nav-backup-restore"
+                  icon={Archive}
+                  label="Back up first"
+                  sub="A backup is the only way to bring any of this back."
+                  subLines={2}
+                  onPress={() => navigation.navigate("Backup & Restore")}
+                />
+                {!isOfflineMode && (
+                  <>
+                    <Divider tight inset />
+                    <ListItem
+                      testID="delete-queued-row"
+                      icon={Clock}
+                      trailingIcon={Trash2}
+                      label="Delete queued locations"
+                      sub={scopeSub("queued", stats.queued)}
+                      subLines={2}
+                      disabled={isProcessing || stats.queued === 0}
+                      accessibilityHint="Asks you to confirm, then deletes"
+                      onPress={() => confirmAndDelete("queued", () => NativeLocationService.clearQueue())}
+                    />
+                    <Divider tight inset />
+                    <ListItem
+                      testID="delete-synced-row"
+                      icon={CloudUpload}
+                      trailingIcon={Trash2}
+                      label="Delete synced locations"
+                      sub={scopeSub("synced", stats.sent)}
+                      subLines={2}
+                      disabled={isProcessing || stats.sent === 0}
+                      accessibilityHint="Asks you to confirm, then deletes"
+                      onPress={() => confirmAndDelete("synced", () => NativeLocationService.clearSentHistory())}
+                    />
+                  </>
+                )}
+              </Card>
+
+              <Card style={styles.ageCard}>
+                <ChipGroup
+                  accessibilityLabel="Age"
+                  options={[
+                    ...RETENTION_PRESET_DAYS.map((preset) => ({
+                      value: String(preset),
+                      label: preset === 365 ? "1 year" : `${preset} days`,
+                      testID: `age-${preset}`
+                    })),
+                    { value: "custom", label: "Custom", testID: "age-custom" }
+                  ]}
+                  selected={ageChoice}
+                  onSelect={handleAgeChoice}
+                />
+                {isCustom && (
+                  <View style={styles.customField}>
+                    <NumericInput
+                      label="Delete locations older than"
+                      testID="retention-days-input"
+                      value={customText}
+                      onChange={handleCustomChange}
+                      onBlur={handleCustomBlur}
+                      unit="days"
+                      placeholder={String(PLACEHOLDER_DAYS)}
+                      hint="At least 1 day."
+                      error={ageError}
+                      message={clampNote}
+                    />
+                  </View>
+                )}
+              </Card>
+
+              <View>
+                <Button
+                  variant="ghost"
+                  color={colors.error}
+                  icon={Trash2}
+                  testID="delete-older-btn"
+                  title={
+                    ageCount && ageCount > 0
+                      ? `Delete ${ageCount.toLocaleString()} location${ageCount === 1 ? "" : "s"}`
+                      : "Delete older locations"
+                  }
+                  loading={busy === "count" || busy === "delete"}
+                  disabled={isProcessing || !!ageError || days === null || !ageCount}
+                  onPress={() => confirmAndDelete("older", () => NativeLocationService.deleteOlderThan(days as number))}
+                />
+                <FieldMessage variant={ageError ? "error" : "info"}>{ageLine}</FieldMessage>
+              </View>
+
+              <View>
+                <Button
+                  variant="danger"
+                  icon={Trash2}
+                  title="Delete all locations"
+                  testID="delete-all-btn"
+                  loading={busy === "count" || busy === "delete"}
+                  disabled={isProcessing}
+                  onPress={() => confirmAndDelete("all", () => NativeLocationService.clearAllLocations())}
+                />
+                <FieldMessage>{allSub(stats.total)}</FieldMessage>
+              </View>
+            </>
+          )}
+        </View>
+      </ScrollView>
     </Container>
   )
 }
 
-const ActionRow = ({
-  label,
-  hint,
-  value,
-  onPress,
-  disabled
-}: {
-  label: string
-  hint: string
-  value: string
-  onPress: () => void
-  disabled: boolean
-}) => {
-  const { colors } = useTheme()
-
-  return (
-    <Pressable
-      android_ripple={{ color: colors.text + STATE_LAYER_ALPHA }}
-      style={styles.actionRow}
-      onPress={onPress}
-      disabled={disabled}
-      accessibilityRole="button"
-      accessibilityState={{ disabled }}
-      accessibilityLabel={`${label}, ${value}. ${hint}`}
-    >
-      <View style={styles.actionInfo}>
-        <Text style={[styles.actionLabel, { color: disabled ? colors.textDisabled : colors.error }]}>{label}</Text>
-        <Text style={[styles.actionHint, { color: disabled ? colors.textDisabled : colors.textLight }]}>{hint}</Text>
-      </View>
-      <Text style={[styles.actionCount, { color: disabled ? colors.textDisabled : colors.textSecondary }]}>
-        {value}
-      </Text>
-    </Pressable>
-  )
-}
-
 const styles = StyleSheet.create({
+  scrollContent: {
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.xxl
+  },
   intro: {
     fontSize: fontSizes.body,
     ...fonts.regular,
     lineHeight: lineHeights.body,
     marginBottom: space.lg
   },
-  keyboardAvoid: {
-    flex: 1
-  },
-  scrollContent: {
-    paddingHorizontal: space.lg,
-    paddingBottom: space.xxl
-  },
   section: {
     marginBottom: space.xl
   },
-  hint: {
-    fontSize: fontSizes.caption,
-    ...fonts.regular,
-    textAlign: "center",
-    lineHeight: lineHeights.caption,
-    marginTop: space.sm
+  ageCard: {
+    marginTop: space.md
   },
-  actionRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: space.md
+  customField: {
+    marginTop: space.lg
   },
-  actionColumn: {
-    paddingVertical: space.md
+  emptyCard: {
+    paddingVertical: space.lg
   },
-  actionInfo: {
-    flex: 1
-  },
-  actionLabel: {
-    fontSize: fontSizes.label,
-    ...fonts.semiBold,
-    marginBottom: space.xs
-  },
-  actionHint: {
-    fontSize: fontSizes.caption,
-    ...fonts.regular,
-    lineHeight: lineHeights.caption,
-    marginTop: space.xxs
-  },
-  actionCount: {
-    fontSize: fontSizes.description,
-    ...fonts.medium,
-    fontVariant: ["tabular-nums"]
-  },
-  daysInputRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginTop: space.md,
-    gap: space.sm
-  },
-  daysInput: {
-    flex: 1
-  },
-  hintRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: space.sm,
-    marginTop: space.xxs
-  },
-  daysLabel: {
-    fontSize: fontSizes.input,
-    ...fonts.medium
+  empty: {
+    paddingHorizontal: 0
   }
 })

--- a/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/DataManagementScreen.test.tsx
@@ -1,379 +1,800 @@
 import React from "react"
-import { render, fireEvent, waitFor } from "@testing-library/react-native"
-import { StyleSheet } from "react-native"
-import { lightColors } from "@colota/shared"
+import { render, fireEvent, waitFor, act, within } from "@testing-library/react-native"
+import { DeviceEventEmitter } from "react-native"
+import { DEFAULT_SETTINGS, Settings } from "../../types/global"
 
-// --- Mocks ---
-
+// The device re-invokes the same captured callback on every focus, and a callback whose
+// dependencies are all stable is captured once and never rebuilt. A test has to be able to fire it
+// again or every closure-capture bug in a focus effect is invisible.
+let mockRefocus: (() => void) | null = null
 jest.mock("@react-navigation/native", () => ({
-  useFocusEffect: jest.fn((cb) => cb()())
+  useFocusEffect: (cb: () => (() => void) | void) => {
+    const R = require("react")
+    R.useEffect(() => {
+      let cleanup = cb()
+      mockRefocus = () => {
+        if (typeof cleanup === "function") cleanup()
+        cleanup = cb()
+      }
+      return () => {
+        if (typeof cleanup === "function") cleanup()
+        mockRefocus = null
+      }
+    }, [cb])
+  }
 }))
 
 jest.mock("../../hooks/useTheme", () => ({
-  useTheme: () => ({ colors: jest.requireActual("@colota/shared").lightColors })
+  useTheme: () => ({ colors: require("@colota/shared").lightColors })
 }))
 
-jest.mock("../../hooks/useTimeout", () => ({
-  useTimeout: () => ({ set: jest.fn(), clear: jest.fn() })
-}))
-
-const mockGetStats = jest.fn().mockResolvedValue({ queued: 5, sent: 100, total: 105, today: 3, databaseSizeMB: 1.5 })
-const mockManualFlush = jest.fn().mockResolvedValue(undefined)
-const mockClearSentHistory = jest.fn().mockResolvedValue(undefined)
-const mockClearQueue = jest.fn().mockResolvedValue(5)
-const mockDeleteOlderThan = jest.fn().mockResolvedValue(10)
-const mockVacuumDatabase = jest.fn().mockResolvedValue(undefined)
-
-jest.mock("../../services/NativeLocationService", () => ({
-  __esModule: true,
-  default: {
-    getStats: function () {
-      return mockGetStats.apply(null, arguments)
-    },
-    manualFlush: function () {
-      return mockManualFlush.apply(null, arguments)
-    },
-    clearSentHistory: function () {
-      return mockClearSentHistory.apply(null, arguments)
-    },
-    clearQueue: function () {
-      return mockClearQueue.apply(null, arguments)
-    },
-    deleteOlderThan: function () {
-      return mockDeleteOlderThan.apply(null, arguments)
-    },
-    vacuumDatabase: function () {
-      return mockVacuumDatabase.apply(null, arguments)
+// The preview debounce coalesces the way it does on a device: a callback scheduled while an earlier
+// one is pending replaces it, so keystrokes inside one tick produce a single count. Longer timers
+// are held rather than dropped, so a test can decide when the flush fallback fires and can count how
+// often it was re-armed. The object is stable per hook instance, as the real hook's is, or a caller
+// listing it as a dependency loops.
+const mockLongTimers: Array<{ later: (() => void) | null }> = []
+let mockLongArms = 0
+jest.mock("../../hooks/useTimeout", () => {
+  const R = require("react")
+  const { RETENTION_PREVIEW_DEBOUNCE_MS } = jest.requireActual("../../constants")
+  return {
+    useTimeout: () => {
+      const ref = R.useRef(null)
+      if (!ref.current) {
+        ref.current = { pending: null, later: null }
+        mockLongTimers.push(ref.current)
+      }
+      const state = ref.current
+      return R.useMemo(
+        () => ({
+          set: (fn: () => void, delay: number) => {
+            if (delay !== RETENTION_PREVIEW_DEBOUNCE_MS) {
+              mockLongArms += 1
+              state.later = fn
+              return
+            }
+            state.pending = fn
+            Promise.resolve().then(() => {
+              if (state.pending !== fn) return
+              state.pending = null
+              fn()
+            })
+          },
+          clear: () => {
+            state.pending = null
+            state.later = null
+          }
+        }),
+        [state]
+      )
     }
   }
-}))
+})
 
-const mockShowConfirm = jest.fn().mockResolvedValue(true)
+/** Runs whatever long timer is currently armed, the way the device would after its delay elapsed. */
+const fireLongTimers = () => mockLongTimers.forEach((t) => t.later?.())
 
-jest.mock("../../services/modalService", () => ({
-  showConfirm: function () {
-    return mockShowConfirm.apply(null, arguments)
-  }
-}))
-
-jest.mock("../../utils/logger", () => ({
-  logger: { error: jest.fn(), warn: jest.fn() }
-}))
-
-let mockIsOfflineMode = false
+let mockSettings: Settings = { ...DEFAULT_SETTINGS }
+let mockTracking = true
 jest.mock("../../contexts/TrackingProvider", () => ({
-  useTracking: () => ({
-    settings: { isOfflineMode: mockIsOfflineMode }
-  })
+  useTracking: () => ({ settings: mockSettings, tracking: mockTracking })
 }))
+
+const mockGetStats = jest.fn()
+const mockCountOlderThan = jest.fn()
+const mockCountUnsentOlderThan = jest.fn()
+/** The boundary native reports back, so the dialog's date is pinned rather than read off the clock. */
+const CUTOFF = 1735689600
+const mockManualFlush = jest.fn()
+const mockClearSentHistory = jest.fn()
+const mockClearQueue = jest.fn()
+const mockClearAllLocations = jest.fn()
+const mockDeleteOlderThan = jest.fn()
+const mockVacuumDatabase = jest.fn()
+
+// Every real method is a static opening with `this.ensureModule()`, so a callback handed over
+// unbound throws before it reaches native. Arrows on a plain object would swallow that and a dead
+// button would pass, so the mock loses its receiver the same way the real service does.
+jest.mock("../../services/NativeLocationService", () => {
+  const service: Record<string, unknown> = {}
+  const onReceiver = (impl: (...a: unknown[]) => unknown) =>
+    function (this: unknown, ...a: unknown[]) {
+      if (this !== service) throw new TypeError("undefined is not a function")
+      return impl(...a)
+    }
+  Object.assign(service, {
+    getStats: onReceiver((...a) => mockGetStats(...a)),
+    countOlderThan: onReceiver((...a) => mockCountOlderThan(...a)),
+    countUnsentOlderThan: onReceiver((...a) => mockCountUnsentOlderThan(...a)),
+    manualFlush: onReceiver((...a) => mockManualFlush(...a)),
+    clearSentHistory: onReceiver((...a) => mockClearSentHistory(...a)),
+    clearQueue: onReceiver((...a) => mockClearQueue(...a)),
+    clearAllLocations: onReceiver((...a) => mockClearAllLocations(...a)),
+    deleteOlderThan: onReceiver((...a) => mockDeleteOlderThan(...a)),
+    vacuumDatabase: onReceiver((...a) => mockVacuumDatabase(...a))
+  })
+  return { __esModule: true, default: service }
+})
+
+const mockShowConfirm = jest.fn()
+const mockShowAlert = jest.fn()
+jest.mock("../../services/modalService", () => ({
+  showConfirm: (...a: unknown[]) => mockShowConfirm(...a),
+  showAlert: (...a: unknown[]) => mockShowAlert(...a)
+}))
+
+jest.mock("../../utils/logger", () => ({ logger: { error: jest.fn(), warn: jest.fn(), debug: jest.fn() } }))
 
 jest.mock("../../components", () => {
   const R = require("react")
-  const RN = require("react-native")
+  const { View, Text, Pressable, TextInput } = require("react-native")
   return {
-    StatRow: ({ label, value }: any) =>
-      R.createElement(RN.View, null, R.createElement(RN.Text, null, label), R.createElement(RN.Text, null, value)),
-    TextField: require("../../testing/componentStubs").TextFieldStub,
-    Toggle: function (props: any) {
-      return require("react").createElement(require("react-native").Switch, {
-        testID: props.testID,
-        value: props.value,
-        onValueChange: props.onValueChange,
-        disabled: props.disabled,
-        accessibilityLabel: props.accessibilityLabel
-      })
-    },
-    Button: function (props: any) {
-      // variant and testID ride through, so a screen test can assert which button it asked for.
-      return R.createElement(
-        RN.Pressable,
+    Container: ({ children }: any) => R.createElement(View, null, children),
+    SectionTitle: ({ children }: any) => R.createElement(Text, null, children),
+    Card: ({ children }: any) => R.createElement(View, null, children),
+    Divider: () => R.createElement(View, null),
+    StatRow: ({ label, value, testID }: any) =>
+      R.createElement(View, { testID }, R.createElement(Text, null, label), R.createElement(Text, null, value)),
+    EmptyState: ({ title, hint }: any) =>
+      R.createElement(View, null, R.createElement(Text, null, title), R.createElement(Text, null, hint)),
+    FieldMessage: ({ children, variant }: any) =>
+      R.createElement(Text, { accessibilityValue: { text: variant ?? "info" } }, children),
+    Button: ({ title, onPress, disabled, testID, variant, color }: any) =>
+      R.createElement(
+        Pressable,
         {
-          testID: props.testID,
-          variant: props.variant ?? "primary",
-          onPress: props.onPress,
-          disabled: props.disabled,
-          accessibilityRole: "button"
+          testID,
+          onPress,
+          disabled,
+          accessibilityRole: "button",
+          accessibilityState: { disabled: !!disabled },
+          accessibilityValue: { text: `${variant ?? "primary"}${color ? "/error" : ""}` }
         },
-        R.createElement(RN.Text, null, props.title)
+        R.createElement(Text, null, title)
+      ),
+    ListItem: ({ testID, label, sub, onPress, disabled, trailingIcon }: any) =>
+      R.createElement(
+        Pressable,
+        {
+          testID,
+          onPress,
+          disabled,
+          accessibilityRole: "button",
+          accessibilityState: { disabled: !!disabled },
+          accessibilityValue: { text: trailingIcon ? "trash" : "chevron" }
+        },
+        R.createElement(Text, null, label),
+        R.createElement(Text, null, sub)
+      ),
+    ChipGroup: ({ options, selected, onSelect }: any) =>
+      R.createElement(
+        View,
+        null,
+        options.map((o: any) =>
+          R.createElement(
+            Pressable,
+            {
+              key: o.value,
+              testID: o.testID,
+              onPress: () => onSelect(o.value),
+              accessibilityState: { selected: selected === o.value }
+            },
+            R.createElement(Text, null, o.label)
+          )
+        )
+      ),
+    NumericInput: ({ label, value, onChange, onBlur, unit, hint, error, message, testID }: any) =>
+      R.createElement(
+        View,
+        null,
+        R.createElement(Text, null, label),
+        hint ? R.createElement(Text, null, hint) : null,
+        R.createElement(TextInput, { testID, value, onChangeText: onChange, onBlur }),
+        R.createElement(Text, null, unit),
+        error ? R.createElement(Text, null, error) : null,
+        message ? R.createElement(Text, null, message) : null
       )
-    },
-    SectionTitle: function (props: any) {
-      return R.createElement(RN.Text, null, props.children)
-    },
-    Card: function (props: any) {
-      return R.createElement(RN.View, null, props.children)
-    },
-    Container: function (props: any) {
-      return R.createElement(RN.View, null, props.children)
-    },
-    Divider: function () {
-      return R.createElement(RN.View, null)
-    },
-    FloatingSaveIndicator: function () {
-      return null
-    }
-  }
-})
-
-jest.mock("lucide-react-native", () => {
-  const R = require("react")
-  const RN = require("react-native")
-  function stub(name: any) {
-    return function () {
-      return R.createElement(RN.Text, null, name)
-    }
-  }
-  return {
-    Lightbulb: stub("Lightbulb")
-  }
-})
-
-// Mock NativeEventEmitter from react-native
-const mockAddListener = jest.fn().mockReturnValue({ remove: jest.fn() })
-jest.mock("react-native/Libraries/EventEmitter/NativeEventEmitter", () => {
-  return {
-    __esModule: true,
-    default: function () {
-      return {
-        addListener: function () {
-          return mockAddListener.apply(null, arguments)
-        }
-      }
-    }
   }
 })
 
 import { DataManagementScreen } from "../DataManagementScreen"
 
+const props = { navigation: { navigate: jest.fn() }, route: { key: "d", name: "Data Management" } } as any
+const renderScreen = () => render(<DataManagementScreen {...props} />)
+const stats = (over: Partial<Record<string, number | string>> = {}) => ({
+  queued: 412,
+  sent: 12068,
+  total: 12480,
+  today: 142,
+  databaseSizeMB: 3.4213,
+  lastSyncTime: 0,
+  lastSyncError: "",
+  ...over
+})
+
 describe("DataManagementScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockIsOfflineMode = false
-    mockGetStats.mockResolvedValue({ queued: 5, sent: 100, total: 105, today: 3, databaseSizeMB: 1.5 })
+    mockSettings = { ...DEFAULT_SETTINGS, endpoint: "https://api.example.com/track" }
+    mockTracking = true
+    mockGetStats.mockResolvedValue(stats())
+    mockCountOlderThan.mockResolvedValue({ total: 3120, cutoffSeconds: CUTOFF })
+    mockCountUnsentOlderThan.mockResolvedValue(96)
+    mockClearQueue.mockResolvedValue(412)
+    mockClearSentHistory.mockResolvedValue(12068)
+    mockClearAllLocations.mockResolvedValue(12480)
+    mockDeleteOlderThan.mockResolvedValue(3120)
+    mockVacuumDatabase.mockResolvedValue(undefined)
+    mockManualFlush.mockResolvedValue(undefined)
     mockShowConfirm.mockResolvedValue(true)
   })
 
-  function renderScreen() {
-    return render(<DataManagementScreen navigation={{} as any} />)
-  }
+  describe("the ledger", () => {
+    it("shows two figures in the shape the Settings row that opens this screen prints", async () => {
+      const api = renderScreen()
 
-  it("says a cleanup row is a button, because nothing but the label marks it as one", async () => {
-    const { getByLabelText } = renderScreen()
+      expect(await api.findByText("12,480")).toBeTruthy()
+      expect(api.getByText("3.42 MB")).toBeTruthy()
+    })
 
-    await waitFor(() => expect(getByLabelText(/^Clear sent history,/)).toBeTruthy())
-    expect(getByLabelText(/^Clear sent history,/).props.accessibilityRole).toBe("button")
-  })
+    it("carries no Sent, Queued or Today figure, because those parts never sum to the total", async () => {
+      // Offline-recorded rows are neither sent nor queued, and a mid-sync read can make the parts exceed the whole.
+      const api = renderScreen()
+      await api.findByText("12,480")
 
-  it("paints every cleanup label in error, since all three delete locations for good", async () => {
-    const { getByText } = renderScreen()
+      expect(api.queryByText("12,068")).toBeNull()
+      expect(api.queryByText("142")).toBeNull()
+      expect(api.queryByTestId("stat-queued")).toBeNull()
+    })
 
-    await waitFor(() => expect(getByText("Clear sent history")).toBeTruthy())
-    for (const label of ["Clear sent history", "Clear queue"]) {
-      expect(StyleSheet.flatten(getByText(label).props.style).color).toBe(lightColors.error)
-    }
-  })
+    it("refreshes on a sync event rather than polling every three seconds", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
 
-  it("recedes a cleanup row with nothing to clear, so error does not advertise a dead action", async () => {
-    mockGetStats.mockResolvedValue({ queued: 0, sent: 100, total: 100, today: 3, databaseSizeMB: 1.5 })
-    const { getByText } = renderScreen()
+      mockGetStats.mockResolvedValue(stats({ total: 12500 }))
+      act(() => {
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 1, failed: 0, total: 1, remaining: 0 })
+      })
 
-    await waitFor(() => expect(getByText("Clear queue")).toBeTruthy())
-    expect(StyleSheet.flatten(getByText("Clear queue").props.style).color).toBe(lightColors.textDisabled)
-    expect(StyleSheet.flatten(getByText("Clear sent history").props.style).color).toBe(lightColors.error)
-  })
-
-  it("gives the retention Delete the danger fill, since it drops locations like the rows above it", async () => {
-    const { getByTestId } = renderScreen()
-
-    await waitFor(() => expect(getByTestId("delete-older-btn")).toBeTruthy())
-    expect(getByTestId("delete-older-btn").props.variant).toBe("danger")
-  })
-
-  it("renders Data Management title", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Database statistics")).toBeTruthy()
+      expect(await api.findByText("12,500")).toBeTruthy()
     })
   })
 
-  it("shows database statistics with correct values", async () => {
-    const { getByText, getAllByText } = renderScreen()
+  describe("what each delete says it takes", () => {
+    it("tells the queued row the recordings go and no copy survives", async () => {
+      const api = renderScreen()
 
-    await waitFor(() => {
-      expect(getByText("Total locations")).toBeTruthy()
-      expect(getByText("105")).toBeTruthy()
-      expect(getByText("Sent")).toBeTruthy()
-      // "100" appears as stat value and as badge count for Clear Sent History
-      expect(getAllByText("100").length).toBeGreaterThanOrEqual(1)
-      expect(getByText("Queued")).toBeTruthy()
-      expect(getAllByText("5").length).toBeGreaterThanOrEqual(1)
-      expect(getByText("Today")).toBeTruthy()
-      expect(getByText("3")).toBeTruthy()
-      expect(getByText("Storage")).toBeTruthy()
-      expect(getByText("1.50 MB")).toBeTruthy()
+      expect(
+        await api.findByText("412 locations waiting to upload. Nothing else holds a copy, and they leave History too.")
+      ).toBeTruthy()
+    })
+
+    it("tells the synced row that an import counts as synced, which no label said before", async () => {
+      const api = renderScreen()
+
+      expect(
+        await api.findByText("12,068 locations already on your server. Imported locations count as synced.")
+      ).toBeTruthy()
+    })
+
+    it("names the trip splits and merges under Delete all, which no label, hint or dialog named", async () => {
+      const api = renderScreen()
+
+      expect(
+        await api.findByText(
+          "All 12,480 locations and every trip split and merge you made. Geofences, profiles and settings stay."
+        )
+      ).toBeTruthy()
+    })
+
+    it("explains a disabled row in the same slot rather than leaving it blank", async () => {
+      mockGetStats.mockResolvedValue(stats({ queued: 0 }))
+      const api = renderScreen()
+
+      expect(await api.findByText("Nothing queued.")).toBeTruthy()
+      expect(api.getByTestId("delete-queued-row").props.accessibilityState.disabled).toBe(true)
     })
   })
 
-  it("shows Sync Now button", async () => {
-    const { getByText } = renderScreen()
+  describe("confirming a delete", () => {
+    it("quotes a count read at the moment of the press, never the one on screen", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      mockGetStats.mockResolvedValue(stats({ sent: 12100 }))
 
-    await waitFor(() => {
-      expect(getByText("Sync now")).toBeTruthy()
-    })
-  })
+      fireEvent.press(api.getByTestId("delete-synced-row"))
 
-  it("disables Sync Now when queue is empty", async () => {
-    mockGetStats.mockResolvedValue({ queued: 0, sent: 100, total: 100, today: 3, databaseSizeMB: 1.5 })
-
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Queue is empty")).toBeTruthy()
-    })
-  })
-
-  it("shows Clear Sent History with badge count", async () => {
-    const { getByText, getAllByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Clear sent history")).toBeTruthy()
-      // "100" appears both as the Sent stat and as the Clear Sent History badge
-      expect(getAllByText("100").length).toBeGreaterThanOrEqual(2)
-    })
-  })
-
-  it("shows Clear Queue action", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Clear queue")).toBeTruthy()
-    })
-  })
-
-  it("shows Delete Old Locations section with days input", async () => {
-    const { getByText, getByDisplayValue } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Delete old locations")).toBeTruthy()
-      expect(getByDisplayValue("90")).toBeTruthy()
-      expect(getByText("days")).toBeTruthy()
-      expect(getByText("Delete")).toBeTruthy()
-    })
-  })
-
-  it("shows Optimize Database action", async () => {
-    const { getByText } = renderScreen()
-
-    await waitFor(() => {
-      expect(getByText("Optimize database")).toBeTruthy()
-      expect(getByText("Optimize")).toBeTruthy()
-    })
-  })
-
-  it("Clear Sent History shows confirmation dialog", async () => {
-    const { getByText, getAllByText } = renderScreen()
-
-    // Wait for stats to load so the ActionRow is enabled (stats.sent > 0)
-    await waitFor(() => {
-      expect(getAllByText("100").length).toBeGreaterThanOrEqual(1)
+      await waitFor(() =>
+        expect(mockShowConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ title: "Delete 12,100 synced locations?", destructive: true })
+        )
+      )
+      expect(mockClearSentHistory).toHaveBeenCalled()
     })
 
-    fireEvent.press(getByText("Clear sent history"))
+    it("deletes nothing when the dialog is dismissed", async () => {
+      mockShowConfirm.mockResolvedValue(false)
+      const api = renderScreen()
+      await api.findByText("12,480")
 
-    await waitFor(() => {
-      expect(mockShowConfirm).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: "Clear sent history",
-          destructive: true
-        })
+      fireEvent.press(api.getByTestId("delete-all-btn"))
+
+      await waitFor(() => expect(mockShowConfirm).toHaveBeenCalled())
+      expect(mockClearAllLocations).not.toHaveBeenCalled()
+    })
+
+    it("asks for a distinct verb on the one that empties everything", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("delete-all-btn"))
+
+      await waitFor(() =>
+        expect(mockShowConfirm).toHaveBeenCalledWith(expect.objectContaining({ confirmText: "Delete all" }))
       )
     })
+
+    // A confirmed delete has to reach native. Asserting only the dialog let three dead buttons ship.
+    it.each([
+      ["delete-queued-row", () => mockClearQueue],
+      ["delete-synced-row", () => mockClearSentHistory],
+      ["delete-all-btn", () => mockClearAllLocations]
+    ])("runs the native delete behind %s once confirmed", async (testID, fn) => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId(testID as string))
+
+      await waitFor(() => expect((fn as () => jest.Mock)()).toHaveBeenCalled())
+      expect(mockShowAlert).not.toHaveBeenCalled()
+    })
+
+    it("runs the native delete behind the age button once an age is chosen and confirmed", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("age-90"))
+      await api.findByText("Delete 3,120 locations")
+
+      fireEvent.press(api.getByTestId("delete-older-btn"))
+
+      await waitFor(() => expect(mockDeleteOlderThan).toHaveBeenCalledWith(90))
+      expect(mockShowAlert).not.toHaveBeenCalled()
+    })
+
+    it("reports a failure instead of leaving the screen looking successful", async () => {
+      // The rejection has to come from native. A handler that threw before reaching it would raise
+      // the same alert, which is how a dead button once passed this test.
+      mockClearQueue.mockRejectedValue(new Error("db"))
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("delete-queued-row"))
+
+      await waitFor(() =>
+        expect(mockShowAlert).toHaveBeenCalledWith(
+          "Delete failed",
+          "The database reported an error. Check the figures above before trying again.",
+          "error"
+        )
+      )
+      expect(mockClearQueue).toHaveBeenCalled()
+    })
+
+    it("spends the one filled danger button on Delete all and keeps the age delete a text button", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      expect(api.getByTestId("delete-all-btn").props.accessibilityValue.text).toBe("danger")
+      expect(api.getByTestId("delete-older-btn").props.accessibilityValue.text).toBe("ghost/error")
+    })
   })
 
-  describe("offline mode", () => {
+  describe("the age argument", () => {
+    // An age is an argument to a delete, so opening the screen must not choose one, must not count
+    // for one, and must not arm one.
+    it("chooses nothing on open, so it counts nothing and arms nothing", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      expect(mockCountOlderThan).not.toHaveBeenCalled()
+      expect(api.getByText("Choose how old a location must be.")).toBeTruthy()
+      expect(api.getByTestId("delete-older-btn").props.accessibilityState.disabled).toBe(true)
+    })
+
+    it("counts once an age is chosen, and names the boundary it counted at", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("age-90"))
+
+      expect(await api.findByText("Delete 3,120 locations")).toBeTruthy()
+      expect(mockCountOlderThan).toHaveBeenCalledWith(90)
+    })
+
+    // The unsent count reads every matching row, so it is worth taking once, on the press.
+    it("keeps the never-uploaded count off the typing path and puts it in the confirmation", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("age-90"))
+      await api.findByText("Delete 3,120 locations")
+
+      expect(mockCountUnsentOlderThan).not.toHaveBeenCalled()
+
+      fireEvent.press(api.getByTestId("delete-older-btn"))
+
+      await waitFor(() => expect(mockCountUnsentOlderThan).toHaveBeenCalledWith(90))
+      expect(mockShowConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("96 of them have never been uploaded") })
+      )
+    })
+
+    it("re-counts when the age changes", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("age-90"))
+      await api.findByText("Delete 3,120 locations")
+
+      mockCountOlderThan.mockResolvedValue({ total: 40, cutoffSeconds: CUTOFF })
+      fireEvent.press(api.getByTestId("age-365"))
+
+      expect(await api.findByText("Delete 40 locations")).toBeTruthy()
+      expect(mockCountOlderThan).toHaveBeenLastCalledWith(365)
+    })
+
+    it("offers no delete when nothing matches", async () => {
+      mockCountOlderThan.mockResolvedValue({ total: 0, cutoffSeconds: CUTOFF })
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("age-90"))
+
+      expect(await api.findByText("Nothing on this device is older than 90 days.")).toBeTruthy()
+      expect(api.getByTestId("delete-older-btn").props.accessibilityState.disabled).toBe(true)
+    })
+
+    it("rejects a decimal instead of silently deleting by its integer part", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("age-custom"))
+
+      fireEvent.changeText(api.getByTestId("retention-days-input"), "1.5")
+
+      expect(await api.findByText("A whole number")).toBeTruthy()
+      // The field owns the error; the button points at it rather than printing it twice.
+      expect(api.getByText("Fix the age above.")).toBeTruthy()
+      expect(api.getByTestId("delete-older-btn").props.accessibilityState.disabled).toBe(true)
+    })
+
+    it("restores the last settled age on blur, never the minimum, so an emptied box cannot arm a one-day delete", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("age-custom"))
+      fireEvent.changeText(api.getByTestId("retention-days-input"), "365")
+      await waitFor(() => expect(mockCountOlderThan).toHaveBeenLastCalledWith(365))
+      fireEvent.changeText(api.getByTestId("retention-days-input"), "")
+
+      fireEvent(api.getByTestId("retention-days-input"), "blur")
+
+      expect(api.getByTestId("retention-days-input").props.value).toBe("365")
+      expect(await api.findByText("Set to 365 days")).toBeTruthy()
+      expect(mockCountOlderThan).not.toHaveBeenCalledWith(1)
+    })
+
+    // Recording per keystroke caught every prefix, so clearing 365 armed a delete for 3 days.
+    it("never restores a keystroke the count skipped", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("age-custom"))
+      fireEvent.changeText(api.getByTestId("retention-days-input"), "365")
+      fireEvent.changeText(api.getByTestId("retention-days-input"), "36")
+      fireEvent.changeText(api.getByTestId("retention-days-input"), "3")
+      fireEvent.changeText(api.getByTestId("retention-days-input"), "")
+
+      fireEvent(api.getByTestId("retention-days-input"), "blur")
+
+      expect(api.getByTestId("retention-days-input").props.value).toBe("")
+      expect(mockCountOlderThan).not.toHaveBeenCalledWith(3)
+      expect(mockCountOlderThan).not.toHaveBeenCalledWith(36)
+    })
+
+    // The focus callback is built once from stable dependencies, so anything it reads off state is
+    // frozen at the first render. Counting from inside it wiped a count the user had asked for.
+    it("keeps the count when the screen is left and come back to", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("age-90"))
+      await api.findByText("Delete 3,120 locations")
+
+      await act(async () => {
+        mockRefocus?.()
+      })
+
+      expect(api.getByText("Delete 3,120 locations")).toBeTruthy()
+      expect(api.getByTestId("delete-older-btn").props.accessibilityState.disabled).toBe(false)
+    })
+
+    // Nothing has settled, so there is nothing to fall back to and nothing may be armed.
+    it("leaves an emptied field empty when no age has ever settled", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("age-custom"))
+
+      fireEvent(api.getByTestId("retention-days-input"), "blur")
+
+      expect(api.getByTestId("retention-days-input").props.value).toBe("")
+      expect(api.getByTestId("delete-older-btn").props.accessibilityState.disabled).toBe(true)
+      expect(mockCountOlderThan).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("sync now", () => {
     beforeEach(() => {
-      mockIsOfflineMode = true
+      mockLongTimers.length = 0
+      mockLongArms = 0
     })
 
-    it("hides Sent and Queued stats", async () => {
-      const { queryByText, getByText } = renderScreen()
+    it("says what it overrides, and that a flush records nothing", async () => {
+      mockTracking = false
+      const api = renderScreen()
 
-      await waitFor(() => {
-        expect(getByText("Total locations")).toBeTruthy()
-      })
-
-      expect(queryByText("Sent")).toBeNull()
-      expect(queryByText("Queued")).toBeNull()
-    })
-
-    it("hides Queue Actions section", async () => {
-      const { queryByText, getByText } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByText("Database statistics")).toBeTruthy()
-      })
-
-      expect(queryByText("Queue actions")).toBeNull()
-      expect(queryByText("Sync now")).toBeNull()
-    })
-
-    it("hides Clear Sent History and Clear Queue actions", async () => {
-      const { queryByText, getByText } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByText("Database statistics")).toBeTruthy()
-      })
-
-      expect(queryByText("Clear sent history")).toBeNull()
-      expect(queryByText("Clear queue")).toBeNull()
-    })
-
-    it("still shows Delete Old Locations and Optimize Database", async () => {
-      const { getByText } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByText("Delete old locations")).toBeTruthy()
-        expect(getByText("Optimize database")).toBeTruthy()
-      })
-    })
-
-    it("still shows Today and Storage stats", async () => {
-      const { getByText } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByText("Today")).toBeTruthy()
-        expect(getByText("Storage")).toBeTruthy()
-      })
-    })
-
-    it("shows Delete All Locations action with total count", async () => {
-      const { getByText, getAllByText } = renderScreen()
-
-      await waitFor(() => {
-        expect(getByText("Delete all locations")).toBeTruthy()
-        // "105" appears as Total Locations stat and as Delete All badge
-        expect(getAllByText("105").length).toBeGreaterThanOrEqual(2)
-      })
-    })
-
-    it("Delete All Locations shows confirmation dialog", async () => {
-      const { getByText, getAllByText } = renderScreen()
-
-      await waitFor(() => {
-        expect(getAllByText("105").length).toBeGreaterThanOrEqual(1)
-      })
-
-      fireEvent.press(getByText("Delete all locations"))
-
-      await waitFor(() => {
-        expect(mockShowConfirm).toHaveBeenCalledWith(
-          expect.objectContaining({
-            title: "Delete all locations",
-            destructive: true
-          })
+      expect(
+        await api.findByText(
+          "Uploads the 412 queued locations now, whatever Sync only on says. The tracking notification appears for a moment. Nothing is recorded."
         )
-      })
+      ).toBeTruthy()
     })
+
+    it("is disabled with the reason when no server is configured, since native does nothing", async () => {
+      mockSettings = { ...DEFAULT_SETTINGS, endpoint: "" }
+      const api = renderScreen()
+
+      expect(await api.findByText("No server configured. Set one on Connection.")).toBeTruthy()
+      expect(api.getByTestId("sync-now-btn").props.accessibilityState.disabled).toBe(true)
+    })
+
+    it("reports the run from the progress event and never claims success after failures", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockManualFlush).toHaveBeenCalled())
+
+      // Native's real shape: ticks while it works, then one event carrying `remaining` to end the pass.
+      act(() => {
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 400, failed: 0, total: 412 })
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 400, failed: 12, total: 412, remaining: 12 })
+      })
+
+      const line = await api.findByText("Sent 400 of 412. Some uploads failed. 12 still queued; press again.")
+      expect(line.props.accessibilityValue.text).toBe("error")
+    })
+
+    it("says how many are left when a pass hits the batch cap", async () => {
+      mockGetStats.mockResolvedValue(stats({ queued: 620 }))
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockManualFlush).toHaveBeenCalled())
+      act(() => {
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 500, failed: 0, total: 500, remaining: 120 })
+      })
+
+      expect(await api.findByText("Sent 500 of 620. 120 still queued; press again.")).toBeTruthy()
+    })
+
+    // A pass caps at a fixed number of batches, so its running count never reaches the queue it
+    // started with. Waiting for that is what made a good upload report a failure 30 seconds later.
+    it("finishes on the pass-end event rather than waiting for the running count to reach the queue", async () => {
+      mockGetStats.mockResolvedValue(stats({ queued: 5000 }))
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockManualFlush).toHaveBeenCalled())
+      act(() => {
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 500, failed: 0, total: 5000, remaining: 4500 })
+      })
+
+      expect(await api.findByText("Sent 500 of 5,000. 4,500 still queued; press again.")).toBeTruthy()
+      expect(api.queryByText("No answer from the tracking service. The queue is unchanged.")).toBeNull()
+      await waitFor(() => expect(api.getByTestId("sync-now-btn").props.accessibilityState.disabled).toBe(false))
+    })
+
+    it("says the queue emptied when it did, and nothing about pressing again", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockManualFlush).toHaveBeenCalled())
+      mockGetStats.mockResolvedValue(stats({ queued: 0 }))
+      act(() => {
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 412, failed: 0, total: 412, remaining: 0 })
+      })
+
+      const line = await api.findByText("Sent 412 of 412.")
+      expect(line.props.accessibilityValue.text).toBe("info")
+      expect(api.queryByText(/press again/)).toBeNull()
+    })
+
+    // A pass where every upload failed never fires a progress tick, because the tick sites are gated
+    // on a batch succeeding, so a terminal event of zero and zero is what a total failure looks like.
+    it("does not report a pass that moved nothing as ordinary progress", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockManualFlush).toHaveBeenCalled())
+      act(() => {
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 0, failed: 412, total: 412, remaining: 412 })
+      })
+
+      const line = await api.findByText("Sent 0 of 412. Some uploads failed. 412 still queued; press again.")
+      expect(line.props.accessibilityValue.text).toBe("error")
+    })
+
+    // The fallback means no event for the window, not no ending within the window of the press. Armed
+    // once, a pass that keeps reporting past 30 s is declared dead while it is still uploading.
+    it("re-arms its silence timer on every progress event", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockLongArms).toBe(1))
+
+      act(() => {
+        DeviceEventEmitter.emit("onSyncProgress", { sent: 100, failed: 0, total: 412 })
+      })
+
+      expect(mockLongArms).toBe(2)
+      expect(await api.findByText("Sent 100 of 412.")).toBeTruthy()
+    })
+
+    it("blames the silence rather than the queue when nothing answers", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockManualFlush).toHaveBeenCalled())
+      await act(async () => {
+        fireLongTimers()
+      })
+
+      const line = await api.findByText("No answer from the tracking service. Check the queued count above.")
+      expect(line.props.accessibilityValue.text).toBe("error")
+      await waitFor(() => expect(api.getByTestId("sync-now-btn").props.accessibilityState.disabled).toBe(false))
+    })
+
+    it("stops listening for progress once the screen is gone", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+      fireEvent.press(api.getByTestId("sync-now-btn"))
+      await waitFor(() => expect(mockManualFlush).toHaveBeenCalled())
+      const during = DeviceEventEmitter.listenerCount("onSyncProgress")
+
+      api.unmount()
+
+      expect(DeviceEventEmitter.listenerCount("onSyncProgress")).toBeLessThan(during)
+    })
+
+    it("leaves the screen entirely in offline mode, where the queue is frozen", async () => {
+      mockSettings = { ...DEFAULT_SETTINGS, isOfflineMode: true }
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      expect(api.queryByTestId("sync-now-btn")).toBeNull()
+      expect(api.queryByTestId("delete-queued-row")).toBeNull()
+      expect(api.getByTestId("delete-all-btn")).toBeTruthy()
+    })
+  })
+
+  describe("what the screen claims before it knows", () => {
+    it("does not report an empty device while the first count is still running", async () => {
+      mockGetStats.mockReturnValue(new Promise(() => {}))
+      const api = renderScreen()
+
+      expect(api.queryByText("Nothing stored")).toBeNull()
+      expect(api.queryByTestId("delete-all-btn")).toBeNull()
+      expect(within(api.getByTestId("stat-locations")).getByText("…")).toBeTruthy()
+    })
+
+    // Every read is numbered, so an earlier one landing late cannot revive a deleted database.
+    it("keeps the newer count when a slower earlier read lands after it", async () => {
+      let releaseSlow: (v: unknown) => void = () => {}
+      mockGetStats
+        .mockReturnValueOnce(new Promise((resolve) => (releaseSlow = resolve)))
+        .mockResolvedValue(stats({ total: 7 }))
+      const api = renderScreen()
+
+      act(() => {
+        DeviceEventEmitter.emit("onLocationUpdate", {})
+      })
+      await waitFor(() => expect(within(api.getByTestId("stat-locations")).getByText("7")).toBeTruthy())
+
+      await act(async () => {
+        releaseSlow(stats({ total: 12480 }))
+      })
+
+      expect(within(api.getByTestId("stat-locations")).getByText("7")).toBeTruthy()
+    })
+
+    // Both presses land before React commits the busy state, so the disabled prop cannot stop the
+    // second one. Only the ref can, which is why the guard is a ref.
+    it("cannot arm two confirmations from two presses inside one render", async () => {
+      mockShowConfirm.mockReturnValue(new Promise(() => {}))
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      act(() => {
+        fireEvent.press(api.getByTestId("delete-all-btn"))
+        fireEvent.press(api.getByTestId("delete-synced-row"))
+      })
+
+      await waitFor(() => expect(mockGetStats).toHaveBeenCalled())
+      expect(mockShowConfirm).toHaveBeenCalledTimes(1)
+    })
+
+    it("says so when the fresh count comes back empty instead of doing nothing", async () => {
+      mockGetStats.mockResolvedValue(stats())
+      const api = renderScreen()
+      await api.findByText("12,480")
+      mockGetStats.mockResolvedValue(stats({ sent: 0 }))
+
+      fireEvent.press(api.getByTestId("delete-synced-row"))
+
+      await waitFor(() =>
+        expect(mockShowAlert).toHaveBeenCalledWith(
+          "Nothing to delete",
+          "That count came back empty. The figures above are current.",
+          "info"
+        )
+      )
+      expect(mockShowConfirm).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("compact", () => {
+    it("says it deletes nothing and that the deletes already do this", async () => {
+      const api = renderScreen()
+
+      expect(
+        await api.findByText(
+          "Rewrites the database to give unused space back. Deleting trips and points leaves gaps that only this reclaims. Nothing is deleted."
+        )
+      ).toBeTruthy()
+    })
+
+    it("measures both sizes at the same moment, and says nothing rather than claiming a non-event", async () => {
+      mockGetStats.mockResolvedValue(stats({ databaseSizeMB: 3.42 }))
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      fireEvent.press(api.getByTestId("compact-btn"))
+
+      expect(await api.findByText("Nothing to release")).toBeTruthy()
+    })
+
+    it("reports what a real compaction released", async () => {
+      const api = renderScreen()
+      await api.findByText("12,480")
+
+      // Queued only once the mount read has landed, so the sizes pair with the two reads compact takes.
+      mockGetStats.mockResolvedValueOnce(stats()).mockResolvedValue(stats({ databaseSizeMB: 3.0 }))
+      fireEvent.press(api.getByTestId("compact-btn"))
+
+      expect(await api.findByText(/^Released 0\.4\d MB$/)).toBeTruthy()
+    })
+  })
+
+  it("offers no delete on an empty database and keeps the ledger and Compact", async () => {
+    mockGetStats.mockResolvedValue(stats({ total: 0, sent: 0, queued: 0, databaseSizeMB: 0.02 }))
+    const api = renderScreen()
+
+    expect(await api.findByText("Nothing stored")).toBeTruthy()
+    expect(api.queryByTestId("delete-all-btn")).toBeNull()
+    expect(api.getByText("0.02 MB")).toBeTruthy()
+    expect(api.getByTestId("compact-btn")).toBeTruthy()
   })
 })

--- a/apps/mobile/src/services/NativeLocationService.ts
+++ b/apps/mobile/src/services/NativeLocationService.ts
@@ -260,13 +260,11 @@ class NativeLocationService {
   // CLEANUP OPERATIONS
   // ============================================================================
 
-  /**
-   * Deletes all successfully sent locations
-   */
-  static async clearSentHistory(): Promise<void> {
+  /** Deletes the locations themselves where `sent = 1`, imported rows included. Resolves how many went. */
+  static async clearSentHistory(): Promise<number> {
     this.ensureModule()
-    logger.debug("[NativeLocationService] Clearing sent history")
-    await LocationServiceModule.clearSentHistory()
+    logger.debug("[NativeLocationService] Deleting synced locations")
+    return LocationServiceModule.clearSentHistory()
   }
 
   /**
@@ -298,6 +296,21 @@ class NativeLocationService {
     this.ensureModule()
     logger.debug(`[NativeLocationService] Deleting locations older than ${days} days`)
     return LocationServiceModule.deleteOlderThan(days)
+  }
+
+  /**
+   * What `deleteOlderThan(days)` would take, plus the boundary it used, so a preview cannot name a
+   * different one. The timestamp index answers this, so it is safe to call as the user types.
+   */
+  static async countOlderThan(days: number): Promise<{ total: number; cutoffSeconds: number }> {
+    this.ensureModule()
+    return LocationServiceModule.countOlderThan(days)
+  }
+
+  /** How many of those have never been uploaded. Reads every match, so call it only on a press. */
+  static async countUnsentOlderThan(days: number): Promise<number> {
+    this.ensureModule()
+    return LocationServiceModule.countUnsentOlderThan(days)
   }
 
   /**

--- a/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
+++ b/apps/mobile/src/services/__tests__/NativeLocationService.test.ts
@@ -17,10 +17,12 @@ jest.mock("react-native", () => ({
       getLocationsByDateRange: jest.fn().mockResolvedValue([]),
       getMostRecentLocation: jest.fn().mockResolvedValue(null),
       manualFlush: jest.fn().mockResolvedValue(true),
-      clearSentHistory: jest.fn().mockResolvedValue(undefined),
+      clearSentHistory: jest.fn().mockResolvedValue(42),
       clearQueue: jest.fn().mockResolvedValue(10),
       clearAllLocations: jest.fn().mockResolvedValue(50),
       deleteOlderThan: jest.fn().mockResolvedValue(25),
+      countOlderThan: jest.fn().mockResolvedValue({ total: 3120, cutoffSeconds: 1735689600 }),
+      countUnsentOlderThan: jest.fn().mockResolvedValue(96),
       deleteLocationsInRange: jest.fn().mockResolvedValue(7),
       deleteLocationsByIds: jest.fn().mockResolvedValue(1),
       vacuumDatabase: jest.fn().mockResolvedValue(undefined),
@@ -449,6 +451,44 @@ describe("NativeLocationService", () => {
       const deleted = await NativeLocationService.deleteLocationsByIds([])
       expect(deleted).toBe(0)
       expect(nativeMock.deleteLocationsByIds).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("the age counts", () => {
+    it("hands the age to the cheap count and returns the boundary native used", async () => {
+      const counted = await NativeLocationService.countOlderThan(90)
+
+      expect(nativeMock.countOlderThan).toHaveBeenCalledWith(90)
+      expect(counted).toEqual({ total: 3120, cutoffSeconds: 1735689600 })
+    })
+
+    // Separate on purpose: this one reads every matching row, so it runs on a press and never while
+    // the user types. A single method would put that cost on the typing path.
+    it("keeps the expensive unsent count a separate call", async () => {
+      const unsent = await NativeLocationService.countUnsentOlderThan(90)
+
+      expect(nativeMock.countUnsentOlderThan).toHaveBeenCalledWith(90)
+      expect(unsent).toBe(96)
+      expect(nativeMock.countOlderThan).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("the bulk deletes", () => {
+    it("resolves how many rows each one took", async () => {
+      expect(await NativeLocationService.clearSentHistory()).toBe(42)
+      expect(await NativeLocationService.clearQueue()).toBe(10)
+      expect(await NativeLocationService.clearAllLocations()).toBe(50)
+      expect(await NativeLocationService.deleteOlderThan(90)).toBe(25)
+      expect(nativeMock.deleteOlderThan).toHaveBeenCalledWith(90)
+    })
+
+    // Each is a static opening with this.ensureModule(), so a bare reference loses its receiver and
+    // throws before it reaches native. Three of these shipped dead exactly that way.
+    it("survives being passed as a bare callback", async () => {
+      const run = async (fn: () => Promise<number>) => fn()
+
+      await expect(run(() => NativeLocationService.clearSentHistory())).resolves.toBe(42)
+      await expect(run(() => NativeLocationService.clearAllLocations())).resolves.toBe(50)
     })
   })
 

--- a/apps/mobile/src/utils/__tests__/dataScope.test.ts
+++ b/apps/mobile/src/utils/__tests__/dataScope.test.ts
@@ -1,0 +1,116 @@
+import { allSub, deleteCopy, olderSub, scopeSub } from "../dataScope"
+import { formatDate, loadDisplayPreferences } from "../geo"
+
+const mockGetSetting = jest.fn()
+jest.mock("../../services/NativeLocationService", () => ({
+  __esModule: true,
+  default: { getSetting: (...args: string[]) => mockGetSetting(...args) }
+}))
+
+beforeAll(async () => {
+  mockGetSetting.mockResolvedValue("")
+  await loadDisplayPreferences()
+})
+
+const CUTOFF = Math.floor(new Date(2026, 5, 10, 12, 0, 0).getTime() / 1000)
+
+describe("scopeSub", () => {
+  it("says of the queue that no copy survives, because these were never uploaded", () => {
+    expect(scopeSub("queued", 412)).toBe(
+      "412 locations waiting to upload. Nothing else holds a copy, and they leave History too."
+    )
+  })
+
+  it("says of the synced set that an import counts as synced, which no label has said", () => {
+    // bulkInsertImportedLocations writes sent = 1, so an archive that never touched a network is inside this delete.
+    expect(scopeSub("synced", 12068)).toBe(
+      "12,068 locations already on your server. Imported locations count as synced."
+    )
+  })
+
+  it("explains a disabled row in its own slot instead of leaving it blank", () => {
+    expect(scopeSub("queued", 0)).toBe("Nothing queued.")
+    expect(scopeSub("synced", 0)).toBe("Nothing has been uploaded yet.")
+  })
+
+  it("agrees with itself at one, so no row says 1 locations", () => {
+    expect(scopeSub("queued", 1)).toMatch(/^1 location waiting/)
+    expect(scopeSub("synced", 1)).toMatch(/^1 location already/)
+  })
+})
+
+describe("olderSub", () => {
+  it("names the boundary the count used", () => {
+    expect(olderSub(3120, 90, CUTOFF)).toBe(`Recorded before ${formatDate(CUTOFF)}.`)
+  })
+
+  // Counting those reads every matching row, so the confirmation is the only place worth taking it.
+  it("leaves how many were never uploaded to the confirmation", () => {
+    expect(olderSub(3120, 90, CUTOFF)).not.toContain("uploaded")
+  })
+
+  it("says nothing matches rather than offering a delete of zero", () => {
+    expect(olderSub(0, 90, CUTOFF)).toBe("Nothing on this device is older than 90 days.")
+    expect(olderSub(0, 1, CUTOFF)).toBe("Nothing on this device is older than 1 day.")
+  })
+})
+
+describe("allSub", () => {
+  it("names the trip splits and merges, which no label, hint or dialog has ever named", () => {
+    // clearAllLocations empties boundary_overrides as well as locations and the queue.
+    expect(allSub(12480)).toBe(
+      "All 12,480 locations and every trip split and merge you made. Geofences, profiles and settings stay."
+    )
+  })
+})
+
+describe("deleteCopy", () => {
+  it("tells the queued case that the recordings go, not the pending uploads", () => {
+    const copy = deleteCopy("queued", 412)
+    expect(copy.title).toBe("Delete 412 queued locations?")
+    expect(copy.message).toMatch(/^These are the locations themselves, not their pending uploads\./)
+    expect(copy.message).toMatch(/no copy survives anywhere and they leave History too/)
+    // The one confirmation that used to omit it, while destroying recordings.
+    expect(copy.message).toMatch(/This cannot be undone\.$/)
+    expect(copy.confirmText).toBe("Delete")
+  })
+
+  it("tells the synced case that History empties and an import is included", () => {
+    const copy = deleteCopy("synced", 12068)
+    expect(copy.title).toBe("Delete 12,068 synced locations?")
+    expect(copy.message).toMatch(/not an upload record/)
+    expect(copy.message).toMatch(/locations you imported count as synced/)
+    expect(copy.message).toMatch(/Copies already on your server stay there/)
+  })
+
+  it("tells the age case that it ignores sync state, naming the boundary and the unsent matches", () => {
+    const copy = deleteCopy("older", 3120, { days: 90, cutoffSeconds: CUTOFF, unsent: 96 })
+    expect(copy.title).toBe("Delete 3,120 locations older than 90 days?")
+    expect(copy.message).toMatch(new RegExp(`before ${formatDate(CUTOFF)}`))
+    expect(copy.message).toMatch(/96 of them have never been uploaded, so no copy of those survives/)
+  })
+
+  it("drops the unsent clause from the age case when there is none, leaving one space between sentences", () => {
+    const copy = deleteCopy("older", 3120, { days: 90, cutoffSeconds: CUTOFF, unsent: 0 })
+    expect(copy.message).not.toMatch(/never been uploaded/)
+    expect(copy.message).not.toMatch(/ {2}/)
+  })
+
+  it("tells the everything case about the trip splits and what survives, and asks for a distinct verb", () => {
+    const copy = deleteCopy("all", 12480)
+    expect(copy.title).toBe("Delete all 12,480 locations?")
+    expect(copy.message).toMatch(/every manual trip split and merge you made/)
+    expect(copy.message).toMatch(/settings, geofences and profiles stay/)
+    expect(copy.confirmText).toBe("Delete all")
+  })
+
+  it("ends every confirmation with the permanence, since none of the four can be undone", () => {
+    const cases = [
+      deleteCopy("queued", 1),
+      deleteCopy("synced", 1),
+      deleteCopy("older", 1, { days: 1, cutoffSeconds: CUTOFF, unsent: 0 }),
+      deleteCopy("all", 1)
+    ]
+    for (const copy of cases) expect(copy.message).toMatch(/This cannot be undone\.$/)
+  })
+})

--- a/apps/mobile/src/utils/dataScope.ts
+++ b/apps/mobile/src/utils/dataScope.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import { formatDate } from "./geo"
+
+/**
+ * What each delete on Data management takes, in the words the control and its confirmation use.
+ *
+ * The wording is pinned to the SQL, not to the old labels: `clearSentHistory` is
+ * `DELETE FROM locations WHERE sent = 1`, so synced days leave History and imported archives go
+ * with them; `clearQueue` deletes the recordings, not their pending uploads; `deleteOlderThan`
+ * ignores sync state; `clearAllLocations` also empties `boundary_overrides`, every manual trip
+ * split. A test pins every sentence without rendering the screen.
+ */
+
+export type DataScope = "queued" | "synced" | "older" | "all"
+
+export interface DeleteCopy {
+  title: string
+  message: string
+  confirmText: string
+}
+
+const plural = (n: number, noun: string) => `${n.toLocaleString()} ${noun}${n === 1 ? "" : "s"}`
+
+/** The sub under a delete row, or the message under a delete button: what this press would take. */
+export function scopeSub(scope: "queued" | "synced", count: number): string {
+  if (scope === "queued") {
+    return count === 0
+      ? "Nothing queued."
+      : `${plural(count, "location")} waiting to upload. Nothing else holds a copy, and they leave History too.`
+  }
+  return count === 0
+    ? "Nothing has been uploaded yet."
+    : `${plural(count, "location")} already on your server. Imported locations count as synced.`
+}
+
+/**
+ * The line under the age button: the boundary the count used. How many of them have no copy on the
+ * server is not here, because that count reads every matching row and is only worth taking once, on
+ * the press, where `deleteCopy` says it.
+ */
+export function olderSub(count: number, days: number, cutoffSeconds: number): string {
+  if (count === 0) return `Nothing on this device is older than ${plural(days, "day")}.`
+  return `Recorded before ${formatDate(cutoffSeconds)}.`
+}
+
+/** The line under Delete all: the two things it takes that no label has ever named. */
+export function allSub(total: number): string {
+  return `All ${plural(total, "location")} and every trip split and merge you made. Geofences, profiles and settings stay.`
+}
+
+export interface OlderArgs {
+  days: number
+  /** The boundary in Unix seconds, from the same native read that produced the count. */
+  cutoffSeconds: number
+  unsent: number
+}
+
+/** The confirmation for one delete. Every count comes from a read taken immediately before the dialog. */
+export function deleteCopy(scope: DataScope, count: number, older?: OlderArgs): DeleteCopy {
+  switch (scope) {
+    case "queued":
+      return {
+        title: `Delete ${plural(count, "queued location")}?`,
+        message:
+          "These are the locations themselves, not their pending uploads. Once deleted, no copy survives anywhere and they leave History too. Points already handed to your server during a running sync may still arrive. This cannot be undone.",
+        confirmText: "Delete"
+      }
+    case "synced":
+      return {
+        title: `Delete ${plural(count, "synced location")}?`,
+        message: `Removes ${plural(count, "location")} from this device, not an upload record. Those days leave History, notes included, and locations you imported count as synced. Copies already on your server stay there. This cannot be undone.`,
+        confirmText: "Delete"
+      }
+    case "older": {
+      const { days = 0, cutoffSeconds = 0, unsent = 0 } = older ?? ({} as OlderArgs)
+      const never =
+        unsent === 0
+          ? ""
+          : ` ${unsent.toLocaleString()} of them have never been uploaded, so no copy of those survives.`
+      return {
+        title: `Delete ${plural(count, "location")} older than ${plural(days, "day")}?`,
+        message: `Removes every location recorded before ${formatDate(cutoffSeconds)} from this device.${never} Those days leave History. Copies already on your server stay there. This cannot be undone.`,
+        confirmText: "Delete"
+      }
+    }
+    case "all":
+      return {
+        title: `Delete all ${plural(count, "location")}?`,
+        message:
+          "Removes every location on this device, its upload queue and every manual trip split and merge you made. History becomes empty. Your settings, geofences and profiles stay, and copies already on your server are not touched. This cannot be undone.",
+        confirmText: "Delete all"
+      }
+  }
+}


### PR DESCRIPTION
Reworks the Data management screen and fixes what surfaced while building it.

Three of the four deletes described SQL they did not run, and three of them never reached native at all. The screen polled the database in an unbounded loop, and the retention field could arm a delete far wider than the age chosen.

Wording lives in utils/dataScope.ts and is tested without the screen. Native shares one cutoff between the count and the delete. Trip and point deletes stop rewriting the whole database.