### PR TITLE
refactor(appearance): every row carries the value it produces

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -302,7 +302,7 @@ For backups, two `internal` methods support the export/import flow without expos
 | `SettingsScreen` | The hub, a tab of five grouped lists: Tracking (Connection, Tracking & sync, Tracking profiles), Display, Data, Help and About. Two rows carry live state through the derivation their target screen opens with (`serverState.describeServer`, `profileRow.profileStateLabel`); every other sub is a stored value, an on-disk fact or the nouns inside the screen, computed by `utils/settingsRow` |
 | `ConnectionScreen` | The server hub: a sync state line from `utils/serverState`, offline mode, the endpoint (saved on blur), Test connection, and rows to Request format, Authentication and Client certificate |
 | `TrackingSyncScreen` | GPS interval, distance filter, accuracy threshold and sync strategy preset |
-| `AppearanceScreen` | Light/dark theme, unit system, time format and custom map tile URLs (light and dark) |
+| `AppearanceScreen` | Theme, wallpaper colors on Android 12 and up, unit system, time format and custom map tile URLs (light and dark, refused unless they parse as an http or https URL) |
 | `ApiSettingsScreen` | Route **Request Format**. Backend template as a row opening the picker, HTTP method and Dawarich mode as radio rows, and the field mapping |
 | `BackendTemplateScreen` | The eight backend templates as radio rows, each stating what it sends, returning the choice with `popTo` and `merge`. Eight options that each need a sentence do not fit inline on a form screen |
 | `AuthSettingsScreen` | Authentication method as a radio group (None, Basic auth, Bearer token) with never-echoed secrets, and custom HTTP headers |

--- a/apps/docs/docs/guides/tile-server.md
+++ b/apps/docs/docs/guides/tile-server.md
@@ -32,7 +32,7 @@ If you find Colota useful and want to help keep the default server running, cont
 
 :::note[Offline maps]
 
-Offline map packs are downloaded from whichever tile server is configured at the time. Switching to a custom server won't affect packs you've already downloaded, but new downloads will come from the new server.
+Offline map packs are downloaded from the **light** style URL, whichever tile server that points at. Filling only the dark field leaves downloads coming from the default server. Switching servers won't affect packs you've already downloaded, but new downloads will come from the new one.
 
 :::
 
@@ -40,6 +40,8 @@ Offline map packs are downloaded from whichever tile server is configured at the
 2. Open **Appearance** and tap **Map Tile Server**
 3. Enter your style JSON URLs for light and dark mode
 4. Leave a field empty to fall back to the default
+
+A URL is checked when you leave the field. If it doesn't start with `http://` or `https://` and name a host, it is refused and the previous value stays in place, so a typo can't leave you with a blank map.
 
 Any [MapLibre GL style](https://maplibre.org/maplibre-style-spec/) endpoint works. If you only have one style, use the same URL in both fields.
 

--- a/apps/mobile/src/components/features/inspector/LocationTable.tsx
+++ b/apps/mobile/src/components/features/inspector/LocationTable.tsx
@@ -182,7 +182,7 @@ const keyExtractor = (item: TableRow, index: number) => String(item.id ?? index)
 const getItemLayout = (_: unknown, index: number) => ({ length: ROW_LENGTH, offset: ROW_LENGTH * index, index })
 
 export function LocationTable({ locations, colors, hasEndpoint, selectedPointId, onSelectPoint }: Props) {
-  const speedUnit = useMemo(() => getSpeedUnit(), [])
+  const speedUnit = getSpeedUnit()
   const timeListRef = useRef<FlatList<TableRow>>(null)
 
   const data = useMemo<TableRow[]>(() => {

--- a/apps/mobile/src/components/features/map/ColotaMapView.tsx
+++ b/apps/mobile/src/components/features/map/ColotaMapView.tsx
@@ -31,6 +31,7 @@ import { DialogShell } from "../../ui/DialogShell"
 import { Divider } from "../../ui/Divider"
 import { ListItem } from "../../ui/ListItem"
 import { Button } from "../../ui/Button"
+import { logger } from "../../../utils/logger"
 
 interface AttributionLink {
   url: string
@@ -241,6 +242,7 @@ export const ColotaMapView = forwardRef<ColotaMapRef, Props>(function ColotaMapV
         logo={false}
         compass={false}
         onDidFinishLoadingMap={onMapReady}
+        onDidFailLoadingMap={() => logger.error("[ColotaMapView] Map style failed to load")}
         onPress={onPress ? handlePress : undefined}
         onRegionDidChange={handleRegionDidChange}
       >

--- a/apps/mobile/src/hooks/__tests__/useTheme.test.tsx
+++ b/apps/mobile/src/hooks/__tests__/useTheme.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { renderHook, act, waitFor } from "@testing-library/react-native"
-import { Appearance, AppState } from "react-native"
+import { Appearance, AppState, Platform } from "react-native"
 import { lightColors, darkColors } from "@colota/shared"
 
 import NativeLocationService from "../../services/NativeLocationService"
@@ -207,13 +207,30 @@ describe("useTheme", () => {
 })
 
 describe("wallpaper colors", () => {
-  it("offers nothing to turn on where the platform has no palette", async () => {
+  it("separates what the platform offers from whether a palette arrived", async () => {
     const { result } = renderHook(() => useTheme(), { wrapper })
 
     await waitFor(() => {
       expect(NativeLocationService.getSystemPalette).toHaveBeenCalled()
     })
-    expect(result.current.wallpaperColorsAvailable).toBe(false)
+    expect(result.current.wallpaperPaletteReady).toBe(false)
+    expect(result.current.wallpaperColorsAvailable).toBe(Platform.OS === "android" && Number(Platform.Version) >= 31)
+  })
+
+  it("still offers the setting when the platform supports it but the read failed", async () => {
+    ;(NativeLocationService.getSystemPalette as jest.Mock).mockResolvedValue(null)
+    // Version is a getter with no setter under the preset, so it is redefined rather than assigned.
+    const version = Object.getOwnPropertyDescriptor(Platform, "Version")
+    Object.defineProperty(Platform, "Version", { configurable: true, get: () => 34 })
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    await waitFor(() => {
+      expect(NativeLocationService.getSystemPalette).toHaveBeenCalled()
+    })
+    expect(result.current.wallpaperColorsAvailable).toBe(Platform.OS === "android")
+    expect(result.current.wallpaperPaletteReady).toBe(false)
+    if (version) Object.defineProperty(Platform, "Version", version)
   })
 
   it("keeps the brand palette while the toggle is off, so having one is not using one", async () => {
@@ -222,7 +239,7 @@ describe("wallpaper colors", () => {
     const { result } = renderHook(() => useTheme(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.wallpaperColorsAvailable).toBe(true)
+      expect(result.current.wallpaperPaletteReady).toBe(true)
     })
     expect(result.current.colors.primary).toBe(lightColors.primary)
   })
@@ -233,7 +250,7 @@ describe("wallpaper colors", () => {
     const { result } = renderHook(() => useTheme(), { wrapper })
 
     await waitFor(() => {
-      expect(result.current.wallpaperColorsAvailable).toBe(true)
+      expect(result.current.wallpaperPaletteReady).toBe(true)
     })
     act(() => {
       result.current.setWallpaperColors(true)

--- a/apps/mobile/src/hooks/useTheme.tsx
+++ b/apps/mobile/src/hooks/useTheme.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect, useContext, createContext, ReactNode, useMemo, useCallback } from "react"
-import { Appearance, AppState, ColorSchemeName } from "react-native"
+import { Appearance, AppState, ColorSchemeName, Platform } from "react-native"
 import { ThemeColors, ThemeMode } from "../types/global"
 import { darkColors, lightColors } from "../styles/colors"
 import { buildDynamicColors, type SystemPalette } from "../styles/dynamicColors"
@@ -26,8 +26,10 @@ interface ThemeContextType {
   isDark: boolean
   wallpaperColors: boolean
   setWallpaperColors: (enabled: boolean) => void
-  /** False below API 31, where there is no wallpaper palette to offer. */
+  /** False below API 31, where the platform has no wallpaper palette to offer. */
   wallpaperColorsAvailable: boolean
+  /** Whether a palette has been read. Separate from availability, so a failed read still offers the switch. */
+  wallpaperPaletteReady: boolean
 }
 
 /**
@@ -123,7 +125,8 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
       isDark: mode === "dark",
       wallpaperColors,
       setWallpaperColors,
-      wallpaperColorsAvailable: palette !== null
+      wallpaperColorsAvailable: Platform.OS === "android" && Number(Platform.Version) >= 31,
+      wallpaperPaletteReady: palette !== null
     }),
     [colors, mode, preference, setPreference, wallpaperColors, setWallpaperColors, palette]
   )
@@ -135,7 +138,7 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
  * Hook to access theme context.
  *
  * Provides colors, mode, preference, setPreference, isDark, wallpaperColors, setWallpaperColors
- * and wallpaperColorsAvailable.
+ * wallpaperColorsAvailable and wallpaperPaletteReady.
  *
  * @throws If used outside ThemeProvider
  *

--- a/apps/mobile/src/i18n/index.ts
+++ b/apps/mobile/src/i18n/index.ts
@@ -54,7 +54,7 @@ export function initI18n(): SupportedLanguage {
 // starts mattering the day the screen-config and preset constants become keys.
 initI18n()
 
-/** The non-React entry point. Nothing calls it yet; modalService and setupConfig are the ones that will. */
+/** The non-React entry point, for a caller with no hook available. `utils/appearance` uses it. */
 export function t(key: string, options?: Record<string, unknown>): string {
   return i18next.t(key, options) as string
 }

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -4,16 +4,18 @@
   "appearance.theme.light": "Light",
   "appearance.theme.dark": "Dark",
   "appearance.wallpaperColors": "Wallpaper colors",
-  "appearance.wallpaperColors.hint": "Take the palette from the Android wallpaper",
+  "appearance.wallpaperColors.hint": "Accents and surfaces follow the Android wallpaper. Warnings and errors keep their color.",
   "appearance.units": "Units",
   "appearance.units.metric": "Metric",
   "appearance.units.imperial": "Imperial",
   "appearance.timeFormat": "Time format",
+  "appearance.timeFormat.24h": "24h",
+  "appearance.timeFormat.12h": "12h",
   "appearance.mapTileServer": "Map tile server",
   "appearance.mapStyle.placeholder": "Default",
-  "appearance.mapStyle.emptyHint": "Leave empty to use the default",
+  "appearance.mapStyle.emptyHint": "Leave empty for the default. Offline areas download from the light style.",
   "appearance.mapStyle.reset": "Reset to default",
-  "appearance.mapStyle.subtitle": "Override the default map tile source",
   "appearance.mapStyle.light": "Light style URL",
-  "appearance.mapStyle.dark": "Dark style URL"
+  "appearance.mapStyle.dark": "Dark style URL",
+  "appearance.mapStyle.error": "Starts with http:// or https:// and names a host."
 }

--- a/apps/mobile/src/screens/AppearanceScreen.tsx
+++ b/apps/mobile/src/screens/AppearanceScreen.tsx
@@ -3,30 +3,55 @@
  * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
  */
 
-import React, { useState, useCallback, useEffect } from "react"
-import { Text, StyleSheet, View, ScrollView, Pressable } from "react-native"
+import React, { useState, useCallback, useEffect, useRef } from "react"
+import { StyleSheet, View, ScrollView } from "react-native"
 import { ScreenProps } from "../types/global"
 import { useTheme, type ThemePreference } from "../hooks/useTheme"
 import { useTranslation } from "../i18n/useTranslation"
 import NativeLocationService from "../services/NativeLocationService"
-import { fontSizes, fonts } from "../styles/typography"
-import { Card, ChipGroup, Container, Divider, SettingRow, TextField, ListItem, Toggle } from "../components"
+import {
+  Button,
+  Card,
+  ChipGroup,
+  Container,
+  Divider,
+  FieldMessage,
+  SettingRow,
+  TextField,
+  ListItem,
+  Toggle
+} from "../components"
 import { ChevronDown, ChevronUp } from "lucide-react-native"
 import { logger } from "../utils/logger"
 import { loadDisplayPreferences, getUnitSystem, getTimeFormat } from "../utils/geo"
 import type { UnitSystem, TimeFormat } from "../utils/geo"
-import { space, STATE_LAYER_ALPHA } from "../constants"
+import { clockSample, isStyleUrlValid, tileRowSub, unitNotation } from "../utils/appearance"
+import { space } from "../constants"
+
+type StyleKey = "mapStyleUrlLight" | "mapStyleUrlDark"
 
 export function AppearanceScreen({}: ScreenProps) {
-  const { preference, setPreference, colors, wallpaperColors, setWallpaperColors, wallpaperColorsAvailable } =
-    useTheme()
+  const {
+    preference,
+    setPreference,
+    colors,
+    wallpaperColors,
+    setWallpaperColors,
+    wallpaperColorsAvailable,
+    wallpaperPaletteReady
+  } = useTheme()
   const { t } = useTranslation()
 
   const [unitSystem, setUnitSystem] = useState<UnitSystem>(getUnitSystem)
   const [timeFormat, setTimeFormat] = useState<TimeFormat>(getTimeFormat)
 
-  const [mapStyleUrlLight, setMapStyleUrlLight] = useState("")
-  const [mapStyleUrlDark, setMapStyleUrlDark] = useState("")
+  // The row sub reads the saved pair, not the drafts, so the host moves on a save and not per keystroke.
+  const [draftLight, setDraftLight] = useState("")
+  const [draftDark, setDraftDark] = useState("")
+  const [savedLight, setSavedLight] = useState("")
+  const [savedDark, setSavedDark] = useState("")
+  const [lightError, setLightError] = useState<string | undefined>()
+  const [darkError, setDarkError] = useState<string | undefined>()
   const [showMapTileServer, setShowMapTileServer] = useState(false)
 
   const selectUnitSystem = useCallback(
@@ -57,34 +82,61 @@ export function AppearanceScreen({}: ScreenProps) {
     [timeFormat]
   )
 
+  // The initial read must not undo a save that beat it.
+  const edited = useRef(false)
+
   useEffect(() => {
     Promise.all([
       NativeLocationService.getSetting("mapStyleUrlLight"),
       NativeLocationService.getSetting("mapStyleUrlDark")
     ])
       .then(([light, dark]) => {
-        setMapStyleUrlLight(light ?? "")
-        setMapStyleUrlDark(dark ?? "")
+        if (edited.current) return
+        setDraftLight(light ?? "")
+        setDraftDark(dark ?? "")
+        setSavedLight(light ?? "")
+        setSavedDark(dark ?? "")
       })
       .catch(() => {})
   }, [])
 
-  const saveMapStyleUrl = useCallback(async (key: "mapStyleUrlLight" | "mapStyleUrlDark", value: string) => {
-    try {
-      await NativeLocationService.saveSetting(key, value.trim())
-    } catch (err) {
-      logger.error("[AppearanceScreen] Failed to save map style URL:", err)
-    }
-  }, [])
+  /** Refused rather than stored: a URL the map cannot load blanks every map, and only the reset undoes it. */
+  const commitStyleUrl = useCallback(
+    async (key: StyleKey, text: string) => {
+      const setError = key === "mapStyleUrlLight" ? setLightError : setDarkError
+      const setSaved = key === "mapStyleUrlLight" ? setSavedLight : setSavedDark
+      const trimmed = text.trim()
+      if (!isStyleUrlValid(trimmed)) {
+        setError(t("appearance.mapStyle.error"))
+        return
+      }
+      setError(undefined)
+      edited.current = true
+      try {
+        await NativeLocationService.saveSetting(key, trimmed)
+        setSaved(trimmed)
+      } catch (err) {
+        logger.error("[AppearanceScreen] Failed to save map style URL:", err)
+      }
+    },
+    [t]
+  )
 
   const resetMapStyle = useCallback(() => {
-    setMapStyleUrlLight("")
-    setMapStyleUrlDark("")
+    edited.current = true
+    setDraftLight("")
+    setDraftDark("")
+    setSavedLight("")
+    setSavedDark("")
+    setLightError(undefined)
+    setDarkError(undefined)
     Promise.all([
       NativeLocationService.saveSetting("mapStyleUrlLight", ""),
       NativeLocationService.saveSetting("mapStyleUrlDark", "")
     ]).catch((err) => logger.error("[AppearanceScreen] Failed to reset map style URLs:", err))
   }, [])
+
+  const hasCustom = savedLight.trim() !== "" || savedDark.trim() !== ""
 
   return (
     <Container>
@@ -93,7 +145,7 @@ export function AppearanceScreen({}: ScreenProps) {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Card rows style={showMapTileServer && styles.cardTail}>
+        <Card rows style={showMapTileServer ? (hasCustom ? styles.cardTailButton : styles.cardTail) : undefined}>
           <SettingRow label={t("appearance.theme")}>
             <ChipGroup
               options={[
@@ -109,12 +161,17 @@ export function AppearanceScreen({}: ScreenProps) {
           {wallpaperColorsAvailable && (
             <>
               <Divider tight />
-
-              <SettingRow label={t("appearance.wallpaperColors")} hint={t("appearance.wallpaperColors.hint")}>
+              {/* Present whenever the platform offers it, so a failed read cannot hide the way to turn it off. */}
+              <SettingRow
+                label={t("appearance.wallpaperColors")}
+                hint={t("appearance.wallpaperColors.hint")}
+                disabled={!wallpaperPaletteReady}
+              >
                 <Toggle
                   testID="wallpaper-colors-toggle"
                   value={wallpaperColors}
                   onValueChange={setWallpaperColors}
+                  disabled={!wallpaperPaletteReady}
                   accessibilityLabel={t("appearance.wallpaperColors")}
                 />
               </SettingRow>
@@ -123,7 +180,7 @@ export function AppearanceScreen({}: ScreenProps) {
 
           <Divider tight />
 
-          <SettingRow label={t("appearance.units")}>
+          <SettingRow label={t("appearance.units")} hint={unitNotation(unitSystem)}>
             <ChipGroup
               options={[
                 { value: "metric", label: t("appearance.units.metric"), testID: "unit-metric" },
@@ -136,11 +193,11 @@ export function AppearanceScreen({}: ScreenProps) {
 
           <Divider tight />
 
-          <SettingRow label={t("appearance.timeFormat")}>
+          <SettingRow label={t("appearance.timeFormat")} hint={clockSample(timeFormat)}>
             <ChipGroup
               options={[
-                { value: "24h", label: "24h", testID: "time-format-24h" },
-                { value: "12h", label: "12h", testID: "time-format-12h" }
+                { value: "24h", label: t("appearance.timeFormat.24h"), testID: "time-format-24h" },
+                { value: "12h", label: t("appearance.timeFormat.12h"), testID: "time-format-12h" }
               ]}
               selected={timeFormat}
               onSelect={selectTimeFormat}
@@ -152,56 +209,55 @@ export function AppearanceScreen({}: ScreenProps) {
           <ListItem
             testID="map-tile-server-toggle"
             label={t("appearance.mapTileServer")}
-            sub={t("appearance.mapStyle.subtitle")}
+            sub={tileRowSub(savedLight, savedDark)}
+            subLines={2}
             trailingIcon={showMapTileServer ? ChevronUp : ChevronDown}
             expanded={showMapTileServer}
             onPress={() => setShowMapTileServer(!showMapTileServer)}
           />
 
           {showMapTileServer && (
-            <View style={styles.mapTilePanel}>
-              <TextField
-                testID="map-style-url-light"
-                label={t("appearance.mapStyle.light")}
-                mono
-                value={mapStyleUrlLight}
-                onChangeText={setMapStyleUrlLight}
-                onBlur={() => saveMapStyleUrl("mapStyleUrlLight", mapStyleUrlLight)}
-                placeholder={t("appearance.mapStyle.placeholder")}
-                placeholderTextColor={colors.placeholder}
-                autoCapitalize="none"
-                autoCorrect={false}
-                keyboardType="url"
-              />
-              <TextField
-                testID="map-style-url-dark"
-                label={t("appearance.mapStyle.dark")}
-                mono
-                value={mapStyleUrlDark}
-                onChangeText={setMapStyleUrlDark}
-                onBlur={() => saveMapStyleUrl("mapStyleUrlDark", mapStyleUrlDark)}
-                placeholder={t("appearance.mapStyle.placeholder")}
-                placeholderTextColor={colors.placeholder}
-                autoCapitalize="none"
-                autoCorrect={false}
-                keyboardType="url"
-              />
-              <View style={styles.mapStyleFooter}>
-                <Text style={[styles.mapStyleHint, { color: colors.textLight }]}>
-                  {t("appearance.mapStyle.emptyHint")}
-                </Text>
-                {mapStyleUrlLight.trim() || mapStyleUrlDark.trim() ? (
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={resetMapStyle}
-                    android_ripple={{ color: colors.primaryDark + STATE_LAYER_ALPHA, borderless: true }}
-                  >
-                    <Text style={[styles.mapStyleHint, { color: colors.primary }]}>
-                      {t("appearance.mapStyle.reset")}
-                    </Text>
-                  </Pressable>
-                ) : null}
+            <View style={styles.panel}>
+              <View style={styles.fields}>
+                <TextField
+                  testID="map-style-url-light"
+                  label={t("appearance.mapStyle.light")}
+                  mono
+                  value={draftLight}
+                  onChangeText={setDraftLight}
+                  onBlur={() => commitStyleUrl("mapStyleUrlLight", draftLight)}
+                  error={lightError}
+                  placeholder={t("appearance.mapStyle.placeholder")}
+                  placeholderTextColor={colors.placeholder}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="url"
+                />
+                <TextField
+                  testID="map-style-url-dark"
+                  label={t("appearance.mapStyle.dark")}
+                  mono
+                  value={draftDark}
+                  onChangeText={setDraftDark}
+                  onBlur={() => commitStyleUrl("mapStyleUrlDark", draftDark)}
+                  error={darkError}
+                  placeholder={t("appearance.mapStyle.placeholder")}
+                  placeholderTextColor={colors.placeholder}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="url"
+                />
               </View>
+              <FieldMessage>{t("appearance.mapStyle.emptyHint")}</FieldMessage>
+              {hasCustom && (
+                <Button
+                  variant="ghost"
+                  shape="rounded"
+                  testID="map-style-reset-btn"
+                  title={t("appearance.mapStyle.reset")}
+                  onPress={resetMapStyle}
+                />
+              )}
             </View>
           )}
         </Card>
@@ -211,26 +267,17 @@ export function AppearanceScreen({}: ScreenProps) {
 }
 
 const styles = StyleSheet.create({
-  // rows drops the card\'s vertical padding for the first row; the last child
-  // here is not a row, so it takes the bottom inset back.
+  // `rows` drops the card's vertical padding, and the panel's last child is not a row, so it comes back.
   cardTail: { paddingBottom: space.lg },
+  cardTailButton: { paddingBottom: space.sm },
   scrollContent: {
     paddingHorizontal: space.lg,
     paddingTop: space.lg,
-    paddingBottom: space.lg
+    paddingBottom: space.xxl
   },
-  mapTilePanel: {
-    marginTop: space.xs,
-    paddingBottom: space.xs,
+  // Pulled up against the owning row's bottom padding, so it groups with that row and not the next.
+  panel: { marginTop: -space.xs },
+  fields: {
     gap: space.lg
-  },
-  mapStyleFooter: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center"
-  },
-  mapStyleHint: {
-    fontSize: fontSizes.small,
-    ...fonts.regular
   }
 })

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -32,13 +32,13 @@ import {
   UserRoundPen
 } from "lucide-react-native"
 import { getTimeFormat, getUnitSystem } from "../utils/geo"
-import { t } from "../i18n"
 import { trackingSummary } from "../utils/dashboardState"
 import { describeServer } from "../utils/serverState"
 import { profileStateLabel } from "../utils/profileRow"
 import { dataRowSub, getVariantLabel, loggingRowSub, offlineMapsRowSub } from "../utils/settingsRow"
 import { ProfileService } from "../services/ProfileService"
 import { loadOfflineAreas, type OfflineAreaInfo } from "../components/features/map/OfflinePackManager"
+import { appearanceRowSub } from "../utils/appearance"
 import { transferRowSub } from "../utils/locationTransfer"
 import { logger } from "../utils/logger"
 import { space, RELEASES_URL, ISSUES_URL, SUPPORT_URL, PLAY_STORE_MARKET_URL, PLAY_STORE_WEB_URL } from "../constants"
@@ -153,7 +153,7 @@ export function SettingsScreen({ navigation }: Props) {
   // Both getters read a module cache the Appearance screen refreshes on save, so this costs no
   // bridge call and is not worth a memo: memoising on `preference` alone would keep the units and
   // the time format from the render before the change for the rest of the session.
-  const appearanceSummary = `${t(`appearance.theme.${preference}`)} · ${t(`appearance.units.${getUnitSystem()}`)} · ${getTimeFormat()}`
+  const appearanceSummary = appearanceRowSub(preference, getUnitSystem(), getTimeFormat())
 
   const profileSummary = profileCount === 0 ? "No profiles yet" : profileStateLabel(activeProfileName, tracking)
   const inForce = profileCount > 0 && tracking && !!activeProfileName

--- a/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AppearanceScreen.test.tsx
@@ -5,7 +5,7 @@ import { render, fireEvent, waitFor } from "@testing-library/react-native"
 
 const mockSetPreference = jest.fn()
 const mockSetWallpaperColors = jest.fn()
-const theme = { wallpaperColors: false, wallpaperColorsAvailable: true }
+const theme = { wallpaperColors: false, wallpaperColorsAvailable: true, wallpaperPaletteReady: true }
 
 jest.mock("../../hooks/useTheme", () => ({
   useTheme: () => ({
@@ -15,17 +15,20 @@ jest.mock("../../hooks/useTheme", () => ({
     wallpaperColors: theme.wallpaperColors,
     setWallpaperColors: mockSetWallpaperColors,
     wallpaperColorsAvailable: theme.wallpaperColorsAvailable,
+    wallpaperPaletteReady: theme.wallpaperPaletteReady,
     colors: require("@colota/shared").lightColors
   })
 }))
 
 const mockSaveSetting = jest.fn().mockResolvedValue(undefined)
+const mockGetSetting = jest.fn().mockResolvedValue(null)
 
 jest.mock("../../services/NativeLocationService", () => ({
   __esModule: true,
   default: {
     saveSetting: (key: string, value: string) => mockSaveSetting(key, value),
-    getSetting: jest.fn().mockResolvedValue(null)
+    getSetting: (key: string) => mockGetSetting(key),
+    getBuildConfig: () => ({ APP_LANGUAGE: "en-GB" })
   }
 }))
 
@@ -68,9 +71,12 @@ jest.mock("../../components", () => {
         testID: props.testID,
         accessibilityLabel: props.accessibilityLabel,
         disabled: props.disabled,
+        accessibilityState: { disabled: !!props.disabled },
         onPress: () => props.onValueChange(!props.value)
       })
     },
+    FieldMessage: ({ children, variant }: any) =>
+      R.createElement(Text, { accessibilityValue: { text: variant ?? "info" } }, children),
     Container: ({ children }: any) => R.createElement(View, null, children),
     Card: ({ children }: any) => R.createElement(View, null, children),
     Divider: () => R.createElement(View, null),
@@ -94,6 +100,8 @@ describe("AppearanceScreen", () => {
     jest.clearAllMocks()
     theme.wallpaperColors = false
     theme.wallpaperColorsAvailable = true
+    theme.wallpaperPaletteReady = true
+    mockGetSetting.mockResolvedValue(null)
   })
 
   it("renders theme, units and time format rows", () => {
@@ -170,12 +178,59 @@ describe("AppearanceScreen", () => {
     expect(queryByTestId("wallpaper-colors-toggle")).toBeNull()
   })
 
+  // A failed read must not hide the only control that turns the setting off.
+  it("keeps the wallpaper row when the palette read has not landed, and disables it", () => {
+    theme.wallpaperPaletteReady = false
+
+    const { getByTestId } = render(<AppearanceScreen navigation={mockNavigation} />)
+
+    expect(getByTestId("wallpaper-colors-toggle").props.accessibilityState.disabled).toBe(true)
+  })
+
   it("hands the wallpaper choice to the theme, which owns the palette", () => {
     const { getByTestId } = render(<AppearanceScreen navigation={mockNavigation} />)
 
     fireEvent.press(getByTestId("wallpaper-colors-toggle"))
 
     expect(mockSetWallpaperColors).toHaveBeenCalledWith(true)
+  })
+
+  it("puts the units the choice produces under the label", async () => {
+    const { getByText, queryByText } = render(<AppearanceScreen navigation={mockNavigation} />)
+
+    expect(getByText("km · km/h · m")).toBeTruthy()
+
+    fireEvent.press(getByText("Imperial"))
+
+    await waitFor(() => expect(getByText("mi · mph · ft")).toBeTruthy())
+    expect(queryByText("km · km/h · m")).toBeNull()
+  })
+
+  it("puts a clock in the chosen format under the time format label", async () => {
+    const { getByText } = render(<AppearanceScreen navigation={mockNavigation} />)
+    const { clockSample } = require("../../utils/appearance")
+
+    expect(getByText(clockSample("24h"))).toBeTruthy()
+
+    fireEvent.press(getByText("12h"))
+
+    await waitFor(() => expect(getByText(clockSample("12h"))).toBeTruthy())
+  })
+
+  it("names the host serving tiles rather than describing the setting", async () => {
+    const { findByText } = render(<AppearanceScreen navigation={mockNavigation} />)
+
+    expect(await findByText("maps.mxd.codes")).toBeTruthy()
+  })
+
+  it("names both hosts when the two styles come from different servers", async () => {
+    mockGetSetting.mockImplementation((key: string) =>
+      Promise.resolve(key === "mapStyleUrlLight" ? "https://a.example.org/l.json" : "https://b.example.org/d.json")
+    )
+
+    const { findByText } = render(<AppearanceScreen navigation={mockNavigation} />)
+
+    expect(await findByText("a.example.org · b.example.org")).toBeTruthy()
   })
 
   it("toggles the map tile server panel when pressed", () => {
@@ -187,5 +242,54 @@ describe("AppearanceScreen", () => {
 
     expect(queryByTestId("map-style-url-light")).toBeTruthy()
     expect(queryByTestId("map-style-url-dark")).toBeTruthy()
+  })
+
+  // A stored typo blanks every map, and only the reset undoes it.
+  it("refuses a URL that is not one, and saves nothing", async () => {
+    const { getByTestId, findByText } = render(<AppearanceScreen navigation={mockNavigation} />)
+    fireEvent.press(getByTestId("map-tile-server-toggle"))
+
+    fireEvent.changeText(getByTestId("map-style-url-light"), "htps://tiles.example.org")
+    fireEvent(getByTestId("map-style-url-light"), "blur")
+
+    expect(await findByText("Starts with http:// or https:// and names a host.")).toBeTruthy()
+    expect(mockSaveSetting).not.toHaveBeenCalledWith("mapStyleUrlLight", expect.anything())
+  })
+
+  it("saves a good URL and moves the host on the row", async () => {
+    const { getByTestId, findByText } = render(<AppearanceScreen navigation={mockNavigation} />)
+    fireEvent.press(getByTestId("map-tile-server-toggle"))
+
+    fireEvent.changeText(getByTestId("map-style-url-light"), "https://tiles.example.org/light.json")
+    fireEvent(getByTestId("map-style-url-light"), "blur")
+
+    await waitFor(() =>
+      expect(mockSaveSetting).toHaveBeenCalledWith("mapStyleUrlLight", "https://tiles.example.org/light.json")
+    )
+    expect(await findByText(/tiles\.example\.org/)).toBeTruthy()
+  })
+
+  it("accepts an emptied field as a return to the default", async () => {
+    mockGetSetting.mockResolvedValue("https://tiles.example.org/light.json")
+    const { getByTestId } = render(<AppearanceScreen navigation={mockNavigation} />)
+    fireEvent.press(getByTestId("map-tile-server-toggle"))
+
+    fireEvent.changeText(getByTestId("map-style-url-light"), "")
+    fireEvent(getByTestId("map-style-url-light"), "blur")
+
+    await waitFor(() => expect(mockSaveSetting).toHaveBeenCalledWith("mapStyleUrlLight", ""))
+  })
+
+  it("offers the reset only once something custom is stored", async () => {
+    const { getByTestId, queryByTestId } = render(<AppearanceScreen navigation={mockNavigation} />)
+    fireEvent.press(getByTestId("map-tile-server-toggle"))
+
+    expect(queryByTestId("map-style-reset-btn")).toBeNull()
+
+    mockGetSetting.mockResolvedValue("https://tiles.example.org/light.json")
+    const custom = render(<AppearanceScreen navigation={mockNavigation} />)
+    fireEvent.press(custom.getByTestId("map-tile-server-toggle"))
+
+    await waitFor(() => expect(custom.getByTestId("map-style-reset-btn")).toBeTruthy())
   })
 })

--- a/apps/mobile/src/utils/__tests__/appearance.test.ts
+++ b/apps/mobile/src/utils/__tests__/appearance.test.ts
@@ -1,0 +1,86 @@
+jest.mock("../../services/NativeLocationService", () => ({
+  __esModule: true,
+  default: { getBuildConfig: () => ({ APP_LANGUAGE: "en-GB" }) }
+}))
+
+import { MAP_STYLE_URL_LIGHT } from "../../constants"
+import { formatTimeIn } from "../geo"
+import { appearanceRowSub, clockSample, isStyleUrlValid, tileRowSub, unitNotation } from "../appearance"
+
+describe("unitNotation", () => {
+  it("names distance, speed and elevation, in the order the app prints them", () => {
+    expect(unitNotation("metric")).toBe("km · km/h · m")
+    expect(unitNotation("imperial")).toBe("mi · mph · ft")
+  })
+})
+
+describe("clockSample", () => {
+  const noon = new Date("2026-09-09T14:05:00Z")
+
+  it("shows the current time in the format being offered", () => {
+    expect(clockSample("24h", noon)).toBe(formatTimeIn(Math.floor(noon.getTime() / 1000), "24h"))
+    expect(clockSample("12h", noon)).toBe(formatTimeIn(Math.floor(noon.getTime() / 1000), "12h"))
+  })
+
+  it("differs between the two formats", () => {
+    expect(clockSample("24h", noon)).not.toBe(clockSample("12h", noon))
+  })
+})
+
+describe("tileRowSub", () => {
+  it("names the default host when nothing is stored", () => {
+    expect(tileRowSub("", "")).toBe("maps.mxd.codes")
+    expect(MAP_STYLE_URL_LIGHT).toContain("maps.mxd.codes")
+  })
+
+  it("names one host when both styles come from it", () => {
+    expect(tileRowSub("https://tiles.example.org/l.json", "https://tiles.example.org/d.json")).toBe("tiles.example.org")
+  })
+
+  it("names both when they differ, since one name would hide half the answer", () => {
+    expect(tileRowSub("https://a.example.org/l.json", "https://b.example.org/d.json")).toBe(
+      "a.example.org · b.example.org"
+    )
+  })
+
+  it("falls back per field, so filling one leaves the other on the default", () => {
+    expect(tileRowSub("https://a.example.org/l.json", "")).toBe("a.example.org · maps.mxd.codes")
+  })
+})
+
+describe("isStyleUrlValid", () => {
+  it("accepts an empty value as a return to the default", () => {
+    expect(isStyleUrlValid("")).toBe(true)
+    expect(isStyleUrlValid("   ")).toBe(true)
+  })
+
+  it("accepts either scheme, because a tile server on a LAN is a real case", () => {
+    expect(isStyleUrlValid("https://tiles.example.org/style.json")).toBe(true)
+    expect(isStyleUrlValid("http://192.168.1.20:8080/style.json")).toBe(true)
+  })
+
+  it("refuses what MapLibre could never load", () => {
+    expect(isStyleUrlValid("htps://tiles.example.org")).toBe(false)
+    expect(isStyleUrlValid("tiles.example.org")).toBe(false)
+    expect(isStyleUrlValid("asset://style.json")).toBe(false)
+  })
+})
+
+describe("appearanceRowSub", () => {
+  it("reads back how the app looks and reads", () => {
+    expect(appearanceRowSub("dark", "metric", "24h")).toBe("Dark · Metric · 24h")
+    expect(appearanceRowSub("system", "imperial", "12h")).toBe("System · Imperial · 12h")
+  })
+
+  it("takes every word from the catalog, including the clock", () => {
+    expect(appearanceRowSub("light", "metric", "12h")).not.toContain("timeFormat")
+    expect(appearanceRowSub("light", "metric", "12h")).toContain("12h")
+  })
+
+  it("adds the tile host only once a custom style is stored", () => {
+    expect(appearanceRowSub("dark", "metric", "24h", "", "")).toBe("Dark · Metric · 24h")
+    expect(appearanceRowSub("dark", "metric", "24h", "https://a.example.org/l.json", "")).toBe(
+      "Dark · Metric · 24h · a.example.org · maps.mxd.codes"
+    )
+  })
+})

--- a/apps/mobile/src/utils/appearance.ts
+++ b/apps/mobile/src/utils/appearance.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2026 Max Dietrich
+ * Licensed under the GNU AGPLv3. See LICENSE in the project root for details.
+ */
+
+import { MAP_STYLE_URL_LIGHT, MAP_STYLE_URL_DARK } from "../constants"
+import { t } from "../i18n"
+import type { ThemePreference } from "../hooks/useTheme"
+import { formatTimeIn, type TimeFormat, type UnitSystem } from "./geo"
+import { endpointHost } from "./serverState"
+import { isEndpointAllowed } from "./settingsValidation"
+
+/**
+ * What each Appearance choice produces, as the words the rows print. Computed rather than
+ * translated: this is the app's only translated screen, so a value costs a translator nothing.
+ */
+
+/** The units the choice puts on screen, in the order distance, speed then elevation. */
+export function unitNotation(unit: UnitSystem): string {
+  return unit === "imperial" ? "mi · mph · ft" : "km · km/h · m"
+}
+
+/** The current time in the chosen format, through the app's own formatter so it cannot drift. */
+export function clockSample(format: TimeFormat, now: Date = new Date()): string {
+  return formatTimeIn(Math.floor(now.getTime() / 1000), format)
+}
+
+/** The host actually serving tiles. One name when both styles agree, both when they do not. */
+export function tileRowSub(light: string, dark: string): string {
+  const lightHost = endpointHost(light.trim() || MAP_STYLE_URL_LIGHT)
+  const darkHost = endpointHost(dark.trim() || MAP_STYLE_URL_DARK)
+  return lightHost === darkHost ? lightHost : `${lightHost} · ${darkHost}`
+}
+
+/** Empty means the default, so only a non-empty value has to be a URL this app can load. */
+export function isStyleUrlValid(text: string): boolean {
+  const trimmed = text.trim()
+  return trimmed === "" || isEndpointAllowed(trimmed)
+}
+
+/** The Settings hub row: what the app looks and reads like, and the tile host once one is stored. */
+export function appearanceRowSub(
+  preference: ThemePreference,
+  unit: UnitSystem,
+  format: TimeFormat,
+  light = "",
+  dark = ""
+): string {
+  const parts = [
+    t(`appearance.theme.${preference}`),
+    t(`appearance.units.${unit}`),
+    t(`appearance.timeFormat.${format}`)
+  ]
+  if (light.trim() || dark.trim()) parts.push(tileRowSub(light, dark))
+  return parts.join(" · ")
+}

--- a/apps/mobile/src/utils/geo.ts
+++ b/apps/mobile/src/utils/geo.ts
@@ -103,8 +103,12 @@ export function formatSpeed(metersPerSecond: number): string {
 }
 
 /** Return the speed unit info (used by TrackMap). */
+// Module-level so the identity tracks the unit, and a caller can read it during render.
+const MPH = Object.freeze({ factor: MPH_PER_MPS, unit: "mph" })
+const KMH = Object.freeze({ factor: 3.6, unit: "km/h" })
+
 export function getSpeedUnit(): { factor: number; unit: string } {
-  return usesMiles() ? { factor: MPH_PER_MPS, unit: "mph" } : { factor: 3.6, unit: "km/h" }
+  return usesMiles() ? MPH : KMH
 }
 
 /** Format seconds duration as "Xh Ymin" or "Ymin" */
@@ -122,14 +126,19 @@ export function spokenDistance(meters: number): string {
   return formatDistance(meters).replace(/ km$/, " kilometres").replace(/ mi$/, " miles")
 }
 
-export function formatTime(unixSeconds: number, showSeconds = false): string {
+/** The app's clock, with the format passed in, so a sample of a format cannot drift from it. */
+export function formatTimeIn(unixSeconds: number, format: TimeFormat | null, showSeconds = false): string {
   const d = new Date(unixSeconds * 1000)
   return d.toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
     ...(showSeconds && { second: "2-digit" }),
-    ...(cachedTimeFormat && { hour12: cachedTimeFormat === "12h" })
+    ...(format && { hour12: format === "12h" })
   })
+}
+
+export function formatTime(unixSeconds: number, showSeconds = false): string {
+  return formatTimeIn(unixSeconds, cachedTimeFormat, showSeconds)
 }
 
 /** Format a Unix-seconds timestamp as a localized date string (e.g. "Wed, Feb 27"). */

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -8,3 +8,5 @@
 - Appearance can take the app colors from your Android wallpaper
 - GeoJSON exports write one point per recording, so mapping tools can read and filter them
 - Export and import share one screen, and an import says what it will add before you confirm
+- Switching units updates every screen at once, instead of leaving the location table on the old one
+- Appearance shows the units and clock each setting produces, and names the server your map tiles come from


### PR DESCRIPTION
Each row shows what its choice makes rather than describing itself: the units, the clock, and the host serving map tiles. On the app's only translated screen a computed value costs a translator nothing, so the catalog grows by two net keys and loses the one sentence that was never true.

Four correctness fixes came with it. The location table froze the speed unit for the life of a mount. A failed wallpaper palette read hid the only control that turns the setting off. A map style URL was stored unvalidated, and the map never reported a style it could not load.