### PR TITLE
fix(backup): stop claiming a backup carries the client certificate

### DIFF
--- a/apps/docs/docs/guides/backup-restore.md
+++ b/apps/docs/docs/guides/backup-restore.md
@@ -12,12 +12,14 @@ Use this when you want a full archive of your data, when you're moving to a new 
 
 | Included | Excluded |
 | --- | --- |
-| Location history (the full SQLite database) | mTLS client certificate (private key in OS keystore - re-import the `.p12` after restore) |
+| Location history (the full SQLite database) | mTLS client certificate (the private key is generated inside the OS keystore and cannot be exported) |
 | Settings (sync, GPS, server, appearance) | Offline map tiles (re-download after restore) |
 | Geofences and tracking profiles | Cached map tiles |
 | Manual trip merges and splits (see [Editing Trips](editing-trips.md)) |  |
 | Auth credentials (Basic, Bearer, custom headers) |  |
 | mTLS Trusted Server CA (public cert bytes) |  |
+
+The client certificate belongs to the device, not to the archive. A backup cannot carry it and a restore does not remove it, so the certificate on the device you restore onto is the one that stays in use. A device that has none will need one imported before an mTLS endpoint from the archive will connect.
 
 The auth credentials Colota uses to reach your tracking endpoint (Basic Auth, Bearer token, custom headers) are stored as plaintext inside the encrypted container - they are protected by the backup password, not by the device's hardware-backed key. The leaked credentials let an attacker do whatever your server lets those credentials do. If you configured Colota with a credential limited to writing location data, that's all an attacker gets. If you used a credential tied to a user with broader privileges, or any token with more scope than posting locations requires, the attacker inherits that scope. Configure Colota with the minimum permission its endpoint actually needs. On restore the credentials are rewrapped under the destination device's key.
 

--- a/apps/mobile/src/screens/BackupRestoreScreen.tsx
+++ b/apps/mobile/src/screens/BackupRestoreScreen.tsx
@@ -26,6 +26,7 @@ import { logger } from "../utils/logger"
 import {
   archiveLine,
   backupErrorMessage,
+  backupExcludesLine,
   backupScopeLine,
   backupState,
   BACKUP_WRITTEN_LINE,
@@ -213,7 +214,8 @@ export function BackupRestoreScreen({}: ScreenProps) {
   }, [picked, manifest, restorePassword])
 
   const opening = backupState(lastBackupAt, stats)
-  const caveat = manifest ? restoreCaveat(hasClientCert, manifest) : null
+  const caveat = manifest ? restoreCaveat(hasClientCert) : null
+  const excludes = backupExcludesLine(hasClientCert)
   const pwLine = passwordLine(strength, strengthFailed)
 
   return (
@@ -282,8 +284,9 @@ export function BackupRestoreScreen({}: ScreenProps) {
             onPress={onCreateBackup}
           />
           <FieldMessage variant={backupMessage?.tone === "error" ? "error" : "info"}>
-            {backupMessage?.text ?? blocked ?? backupScopeLine(stats.total, hasClientCert)}
+            {backupMessage?.text ?? blocked ?? backupScopeLine(stats.total)}
           </FieldMessage>
+          {!backupMessage && !blocked && excludes ? <FieldMessage>{excludes}</FieldMessage> : null}
         </View>
 
         <View style={styles.section}>

--- a/apps/mobile/src/screens/__tests__/BackupRestoreScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/BackupRestoreScreen.test.tsx
@@ -276,14 +276,15 @@ describe("BackupRestoreScreen", () => {
       expect(api.getByTestId("restore-btn").props.accessibilityValue.text).toBe("danger")
     })
 
-    it("warns once about a certificate the archive cannot carry", async () => {
+    // The restore never touches the keystore, so the caveat says the certificate stays, not that it goes.
+    it("says once that the certificate is untouched by a restore", async () => {
       mockGetClientCertInfo.mockResolvedValue({ subject: "phone" })
       const api = renderScreen()
       await api.findByText(/^You last backed up /)
 
       await openArchive(api)
 
-      expect(api.getByText(/client certificate is not in this backup/)).toBeTruthy()
+      expect(api.getByText(/client certificate stays as it is/)).toBeTruthy()
     })
   })
 

--- a/apps/mobile/src/utils/__tests__/backupState.test.ts
+++ b/apps/mobile/src/utils/__tests__/backupState.test.ts
@@ -3,6 +3,7 @@ import { formatDateWithYear } from "../geo"
 import {
   archiveLine,
   backupErrorMessage,
+  backupExcludesLine,
   backupRowSub,
   backupScopeLine,
   backupState,
@@ -101,10 +102,20 @@ describe("passwordLine", () => {
   })
 })
 
-describe("backupScopeLine", () => {
-  it("names the certificate only when there is one to lose", () => {
-    expect(backupScopeLine(12481, true)).toContain("client certificate")
-    expect(backupScopeLine(12481, false)).not.toContain("certificate")
+describe("backupScopeLine and backupExcludesLine", () => {
+  /**
+   * BACKED_UP_KEYS carries the auth config and the mTLS server CA. The client certificate's private
+   * key is generated in the Android keystore and cannot be read back, so no archive holds it and the
+   * scope line must never claim one does.
+   */
+  it("never claims the client certificate is written", () => {
+    expect(backupScopeLine(12481)).not.toContain("certificate")
+    expect(backupScopeLine(12481)).toContain("stored server credentials")
+  })
+
+  it("says the certificate is excluded, and only to someone who has one", () => {
+    expect(backupExcludesLine(true)).toContain("not included")
+    expect(backupExcludesLine(false)).toBeNull()
   })
 })
 
@@ -136,8 +147,17 @@ describe("archiveLine and restoreConfirm", () => {
 describe("restoreCaveat", () => {
   // One string or none, so restraint is a signature rather than a discipline.
   it("returns at most one caveat", () => {
-    expect(restoreCaveat(true, manifest())).toContain("client certificate")
-    expect(restoreCaveat(false, manifest())).toBeNull()
+    expect(restoreCaveat(true)).toContain("client certificate")
+    expect(restoreCaveat(false)).toBeNull()
+  })
+
+  /**
+   * deleteAndroidKeyStoreClientCert has one caller, the Remove button in MtlsSection. Nothing in the
+   * restore path touches the keystore, so a caveat promising removal would be false.
+   */
+  it("does not claim a restore removes the certificate", () => {
+    expect(restoreCaveat(true)).not.toMatch(/remov|delet/i)
+    expect(restoreCaveat(true)).toContain("stays as it is")
   })
 })
 

--- a/apps/mobile/src/utils/backupState.ts
+++ b/apps/mobile/src/utils/backupState.ts
@@ -74,9 +74,17 @@ export function submitBlockedReason(
 }
 
 /** What a new archive would contain. Stated once, where the button that writes it lives. */
-export function backupScopeLine(total: number, hasClientCert: boolean): string {
-  const cert = hasClientCert ? ", your stored credentials and your client certificate" : " and your stored credentials"
-  return `Writes ${plural(total, "location")}, your geofences, profiles, settings${cert} to a file you pick.`
+export function backupScopeLine(total: number): string {
+  return `Writes ${plural(total, "location")}, your geofences, profiles, settings and your stored server credentials to a file you pick.`
+}
+
+/**
+ * The client certificate's private key is generated in the Android keystore and cannot be read back
+ * out, so no backup can carry it. Only said to someone who has one, since it is otherwise noise.
+ */
+export function backupExcludesLine(hasClientCert: boolean): string | null {
+  if (!hasClientCert) return null
+  return "Your client certificate is not included. Its private key cannot leave this device's keystore."
 }
 
 /** The archive is encrypted and there is no reset, which is the one thing worth saying twice. */
@@ -103,11 +111,9 @@ export function archiveLine(manifest: BackupManifest): { label: string; caption:
 }
 
 /** At most one caveat, so restraint is a signature rather than a discipline. */
-export function restoreCaveat(certConfigured: boolean, manifest: BackupManifest): string | null {
-  if (certConfigured && manifest.appBuild > 0) {
-    return "Your client certificate is not in this backup and will be removed. Add it again afterwards."
-  }
-  return null
+export function restoreCaveat(certConfigured: boolean): string | null {
+  if (!certConfigured) return null
+  return "Your client certificate stays as it is. A backup carries none, and a restore does not replace it."
 }
 
 export interface ConfirmCopy {


### PR DESCRIPTION
Three strings said the mTLS client certificate is written into a backup and removed by a restore. Neither is true: the private key is generated inside the Android keystore and cannot be exported, and nothing in the restore path touches the keystore.

The screen now says the certificate belongs to the device, and the guide drops its instruction to re-import the p12 after a restore.

Two tests pin it: the scope line never mentions a certificate, and the caveat never matches /remov|delet/i.