### PR TITLE
fix(ui): a card takes the height of its rows, not of its container

### DIFF
--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -110,7 +110,6 @@ export function Card({
 
 const styles = StyleSheet.create({
   card: {
-    flex: 1,
     padding: space.lg,
     borderRadius: radius.md,
     width: "100%",


### PR DESCRIPTION
Card no longer carries flex: 1. It stretched the Tracking profiles card, and the Geofences card below a short list, to the bottom of the viewport, because both screens give their scroll content flexGrow: 1 to centre the empty state. No layout depended on it: no cards sit side by side, and MapDock caps its own ScrollView.