### PR TITLE
fix(sync): run one sync pass at a time

### DIFF
--- a/apps/docs/docs/development/architecture.md
+++ b/apps/docs/docs/development/architecture.md
@@ -203,6 +203,7 @@ Orchestrates batch location uploads with:
 - Exponential backoff on failure
 - Periodic sync scheduling
 - Manual flush support
+- One pass at a time: a periodic tick and a manual flush wait for the running pass. An instant send leaves its row queued while a pass runs, and a pass skips rows an instant send is still posting
 
 ### NetworkManager
 

--- a/apps/docs/docs/guides/data-management.md
+++ b/apps/docs/docs/guides/data-management.md
@@ -16,7 +16,7 @@ import ScreenshotGallery from '@site/src/components/ScreenshotGallery'
 
 | Control | What it does |
 | --- | --- |
-| **Sync now** | Uploads the queued locations immediately, whatever [Sync only on](/docs/configuration/sync-presets) says. The tracking notification appears for a moment if tracking was off, and nothing is recorded |
+| **Sync now** | Uploads the queued locations immediately, whatever [Sync only on](/docs/configuration/sync-presets) says. A sync already running finishes first. The tracking notification appears for a moment if tracking was off, and nothing is recorded |
 | **Compact database** | Rewrites the database to give unused space back. It deletes nothing. Deleting trips and points from Location History leaves gaps that only this reclaims, so press it after a round of track editing |
 | **Delete queued locations** | Deletes the locations waiting to upload, not their pending uploads. Nothing else holds a copy, so they leave Location History too |
 | **Delete synced locations** | Deletes locations already on your server. Those days leave Location History, notes included, and imported locations count as synced. Copies on your server stay |

--- a/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/service/LocationForegroundService.kt
@@ -1301,6 +1301,7 @@ class LocationForegroundService : Service() {
      * concerns here - gating the save on a successful send loses the stay entirely whenever
      * the server is unreachable or sync is not allowed. The send skips the sync interval: on
      * Power Saver a queued stay reaches the endpoint 15 minutes after the user got home.
+     * While a sync pass runs, the point waits in the queue for that pass or the next.
      */
     private suspend fun recordHeartbeatLocation() {
         if (!::config.isInitialized) {

--- a/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
+++ b/apps/mobile/android/app/src/main/java/com/colota/sync/SyncManager.kt
@@ -10,7 +10,10 @@ import com.Colota.bridge.LocationServiceModule
 import com.Colota.data.DatabaseHelper
 import com.Colota.util.TimedCache
 import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Two sync modes: instant (syncInterval=0) sends each location on arrival,
@@ -51,6 +54,15 @@ class SyncManager(
     @Volatile private var consecutiveFailures = 0
 
     private val queueCountCache = TimedCache(5000L) { dbHelper.getQueuedCount() }
+
+    /** One pass at a time: two passes fetch the same oldest rows and post each of them twice. */
+    private val syncMutex = Mutex()
+
+    /** Set while a manual flush waits on [syncMutex]; the running pass reports to its screen, which gives up on silence. */
+    @Volatile private var waitingFlushTotal: Int? = null
+
+    /** Queue rows an instant send is posting; a pass skips them instead of posting them a second time. */
+    private val instantInFlight: MutableSet<Long> = ConcurrentHashMap.newKeySet()
 
     fun updateConfig(
         endpoint: String,
@@ -94,21 +106,24 @@ class SyncManager(
                 }
 
                 if (endpoint.isNotBlank() && queued > 0) {
-                    val errorMessage: String? = try {
-                        val success = performSyncAndCheckSuccess()
+                    if (syncMutex.isLocked) AppLogger.d(TAG, "Sync tick waiting for the running sync")
+                    val errorMessage: String? = syncMutex.withLock {
+                        try {
+                            val success = performSyncAndCheckSuccess()
 
-                        if (success) {
-                            if (consecutiveFailures > 0) {
-                                AppLogger.i(TAG, "Sync restored")
+                            if (success) {
+                                if (consecutiveFailures > 0) {
+                                    AppLogger.i(TAG, "Sync restored")
+                                }
+                                consecutiveFailures = 0
+                                null
+                            } else {
+                                "Sync failed"
                             }
-                            consecutiveFailures = 0
-                            null
-                        } else {
-                            "Sync failed"
+                        } catch (e: Exception) {
+                            AppLogger.e(TAG, "Sync error", e)
+                            e.message ?: "Sync error"
                         }
-                    } catch (e: Exception) {
-                        AppLogger.e(TAG, "Sync error", e)
-                        e.message ?: "Sync error"
                     }
 
                     if (errorMessage != null) {
@@ -135,17 +150,24 @@ class SyncManager(
 
     suspend fun manualFlush() {
         if (endpoint.isBlank()) return
-        val total = dbHelper.getQueuedCount()
-        AppLogger.d(TAG, "Manual flush started: $total items in queue")
+        if (syncMutex.isLocked) AppLogger.d(TAG, "Manual flush waiting for the running sync")
+        waitingFlushTotal = dbHelper.getQueuedCount()
+        var total = 0
         var pass = SyncPass(0, 0)
         try {
-            pass = syncQueue { sent, failed -> LocationServiceModule.sendSyncProgressEvent(sent, failed, total) }
+            syncMutex.withLock {
+                waitingFlushTotal = null
+                total = dbHelper.getQueuedCount()
+                AppLogger.d(TAG, "Manual flush started: $total items in queue")
+                pass = syncQueue { sent, failed -> LocationServiceModule.sendSyncProgressEvent(sent, failed, total) }
+            }
         } finally {
+            waitingFlushTotal = null
             // A pass caps at MAX_BATCHES_PER_SYNC and stops when a batch moves nothing, so the
             // running count need not reach the queue it started with. Only this event ends the pass,
-            // and a throw or a cancellation must still send it or the caller waits out its own
-            // timeout and reports a failure over an upload that worked. The totals come from the
-            // pass, not from the last progress tick, which only fires when a batch succeeded.
+            // and a throw or a cancellation, even one while waiting for the lock, must still send it or
+            // the caller waits out its own timeout and reports a failure over an upload that worked.
+            // The totals come from the pass, not from the last progress tick.
             invalidateQueueCache()
             val remaining = runCatching { dbHelper.getQueuedCount() }.getOrDefault(total - pass.sent)
             LocationServiceModule.sendSyncProgressEvent(pass.sent, pass.failed, pass.sent + pass.failed, remaining)
@@ -169,16 +191,26 @@ class SyncManager(
 
         // Immediate send mode (syncInterval = 0)
         if ((syncIntervalSeconds == 0 || bypassInterval) && isSyncAllowed()) {
-            AppLogger.d(TAG, "Instant send")
-            val success = networkManager.sendToEndpoint(payload, endpoint, authHeaders, httpMethod, apiFormat)
+            // Registered before the lock check: a later pass skips this row, a running one may already hold it
+            instantInFlight.add(queueId)
+            try {
+                if (syncMutex.isLocked) {
+                    AppLogger.d(TAG, "Instant send deferred: a sync is running")
+                    return
+                }
+                AppLogger.d(TAG, "Instant send")
+                val success = networkManager.sendToEndpoint(payload, endpoint, authHeaders, httpMethod, apiFormat)
 
-            if (success) {
-                dbHelper.markLocationsSent(listOf(locationId))
-                dbHelper.removeFromQueueByLocationId(locationId)
-                invalidateQueueCache()
-                markSuccess()
-            } else {
-                dbHelper.incrementRetryCount(queueId, "Send failed")
+                if (success) {
+                    dbHelper.markLocationsSent(listOf(locationId))
+                    dbHelper.removeFromQueueByLocationId(locationId)
+                    invalidateQueueCache()
+                    markSuccess()
+                } else {
+                    dbHelper.incrementRetryCount(queueId, "Send failed")
+                }
+            } finally {
+                instantInFlight.remove(queueId)
             }
         }
         // Otherwise the periodic sync job will handle it
@@ -204,12 +236,13 @@ class SyncManager(
 
     private suspend fun performSyncAndCheckSuccess(): Boolean {
         val countBefore = dbHelper.getQueuedCount()
-        syncQueue(onProgress = null)
+        val pass = syncQueue(onProgress = null)
         val countAfter = dbHelper.getQueuedCount()
 
         invalidateQueueCache()
 
-        val success = countAfter < countBefore || countAfter == 0
+        // A pass that only skipped rows an instant send was still posting did not fail
+        val success = countAfter < countBefore || countAfter == 0 || (pass.sent + pass.failed == 0 && pass.skippedInFlight > 0)
         if (success && countAfter == 0) {
             markSuccess()
         }
@@ -232,7 +265,7 @@ class SyncManager(
     }
 
     /** What one pass moved. It caps at [MAX_BATCHES_PER_SYNC], so it need not empty the queue. */
-    data class SyncPass(val sent: Int, val failed: Int)
+    data class SyncPass(val sent: Int, val failed: Int, val skippedInFlight: Int = 0)
 
     private suspend fun syncQueue(onProgress: ((sent: Int, failed: Int) -> Unit)? = null): SyncPass = coroutineScope {
         // Snapshot volatile config so it stays consistent for the entire sync pass
@@ -244,11 +277,20 @@ class SyncManager(
         var totalProcessed = 0
         var totalSucceeded = 0
         var totalFailed = 0
+        var skippedInFlight = 0
         var batchNumber = 1
+
+        // Every chunk reports, sent or not: silence reads as a dead service and frees Sync Now mid-pass
+        fun reportProgress() {
+            if (onProgress != null) onProgress(totalSucceeded, totalFailed)
+            else waitingFlushTotal?.let { LocationServiceModule.sendSyncProgressEvent(totalSucceeded, totalFailed, it) }
+        }
 
         while (isActive && batchNumber <= MAX_BATCHES_PER_SYNC) {
             val fetchSize = if (currentApiFormat == ApiFormat.OVERLAND_BATCH) currentBatchSize else 50
-            val queued = dbHelper.getQueuedLocations(fetchSize)
+            val fetched = dbHelper.getQueuedLocations(fetchSize)
+            val queued = fetched.filterNot { it.queueId in instantInFlight }
+            skippedInFlight += fetched.size - queued.size
             if (queued.isEmpty()) {
                 if (totalProcessed > 0) {
                     AppLogger.d(TAG, "Sync complete: $totalProcessed items in $batchNumber batches")
@@ -266,7 +308,7 @@ class SyncManager(
                 totalProcessed += result.processed
                 totalSucceeded += result.processed
                 totalFailed += result.failed
-                if (result.processed > 0) onProgress?.invoke(totalSucceeded, totalFailed)
+                reportProgress()
                 if (result.stop) {
                     AppLogger.d(TAG, "Sync pass aborted by transport failure")
                     break
@@ -310,8 +352,8 @@ class SyncManager(
 
                         totalProcessed += successfulIds.size
                         totalSucceeded += successfulIds.size
-                        onProgress?.invoke(totalSucceeded, totalFailed)
                     }
+                    reportProgress()
 
                     yield()
                 }
@@ -336,7 +378,7 @@ class SyncManager(
             markSuccess()
         }
 
-        SyncPass(totalSucceeded, totalFailed)
+        SyncPass(totalSucceeded, totalFailed, skippedInFlight)
     }
 
     private data class BatchSendResult(val processed: Int, val failed: Int, val stop: Boolean)

--- a/apps/mobile/android/app/src/test/java/com/Colota/sync/SyncManagerTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/Colota/sync/SyncManagerTest.kt
@@ -1258,6 +1258,271 @@ class SyncManagerTest {
     }
 
     // ========================================================================
+    // One sender at a time
+    // ========================================================================
+
+    @Test
+    fun `a manual flush during another waits instead of posting the same rows again`() = scope.runTest {
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 0,
+            retryIntervalSeconds = 30,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        fakeQueue(20)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(1_000); true }
+
+        launch { syncManager.manualFlush() }
+        launch { syncManager.manualFlush() }
+        advanceUntilIdle()
+
+        // Both passes fetch the oldest rows first, so a second pass beside the first posts every row twice
+        coVerify(exactly = 20) { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a periodic tick during a manual flush waits and counts no failure`() = scope.runTest {
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 1,
+            retryIntervalSeconds = 1,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        coEvery { networkManager.isNetworkAvailable() } returns true
+        fakeQueue(20)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(1_500); true }
+
+        launch { syncManager.manualFlush() }
+        syncManager.startPeriodicSync()
+        // The ticks at 1 s and 2 s land while the flush still holds its chunks
+        advanceTimeBy(3_600)
+        syncManager.stopPeriodicSync()
+
+        coVerify(exactly = 20) { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) }
+        assertEquals(0, getField("consecutiveFailures"))
+    }
+
+    @Test
+    fun `an instant send during a pass is posted once, by the pass`() = scope.runTest {
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 0,
+            retryIntervalSeconds = 30,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        coEvery { networkManager.isNetworkAvailable() } returns true
+        fakeQueue(10)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(1_000); true }
+
+        launch { syncManager.manualFlush() }
+        syncManager.queueAndSend(500L, JSONObject().put("lat", 53.0))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            networkManager.sendToEndpoint(match { it.optDouble("lat") == 53.0 }, any(), any(), any(), any())
+        }
+        verify(exactly = 0) { dbHelper.removeFromQueueByLocationId(500L) }
+    }
+
+    @Test
+    fun `a manual flush reports progress after a chunk that sent nothing`() = scope.runTest {
+        mockkObject(LocationServiceModule.Companion)
+        every { LocationServiceModule.sendSyncProgressEvent(any(), any(), any(), any()) } returns true
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 0,
+            retryIntervalSeconds = 30,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        fakeQueue(10)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } returns false
+
+        syncManager.manualFlush()
+
+        // Sync Now frees its button after a silence, so a pass that only fails must still report
+        verify { LocationServiceModule.sendSyncProgressEvent(0, 10, 10, null) }
+
+        unmockkObject(LocationServiceModule.Companion)
+    }
+
+    @Test
+    fun `batch path reports progress after a batch that sent nothing`() = scope.runTest {
+        mockkObject(LocationServiceModule.Companion)
+        every { LocationServiceModule.sendSyncProgressEvent(any(), any(), any(), any()) } returns true
+        syncManager.updateConfig(
+            endpoint = "https://dawarich.example/api/v1/overland/batches",
+            syncIntervalSeconds = 300,
+            retryIntervalSeconds = 30,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap(),
+            apiFormat = ApiFormat.OVERLAND_BATCH,
+            overlandBatchSize = 50
+        )
+        val items = (1L..50L).map {
+            QueuedLocation(it, it + 100, """{"lat":52.0,"lon":13.0,"tst":1700000000}""", 0)
+        }
+        every { dbHelper.getQueuedLocations(50) } returns items
+        every { dbHelper.getQueuedCount() } returns 50
+        coEvery { networkManager.sendBatchToEndpoint(any(), any(), any(), any()) } returns BatchResult.NetworkError
+
+        syncManager.manualFlush()
+
+        // Sync Now frees its button after a silence, so a batch that only fails must still report
+        verify { LocationServiceModule.sendSyncProgressEvent(0, 50, 50, null) }
+
+        unmockkObject(LocationServiceModule.Companion)
+    }
+
+    @Test
+    fun `a manual flush waiting on a periodic pass hears that pass report`() = scope.runTest {
+        mockkObject(LocationServiceModule.Companion)
+        every { LocationServiceModule.sendSyncProgressEvent(any(), any(), any(), any()) } returns true
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 1,
+            retryIntervalSeconds = 1,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        coEvery { networkManager.isNetworkAvailable() } returns true
+        fakeQueue(20)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(1_500); true }
+
+        syncManager.startPeriodicSync()
+        advanceTimeBy(1_200)
+        launch { syncManager.manualFlush() }
+        advanceTimeBy(1_400)
+
+        // The periodic pass has no screen of its own, but the waiting flush does and would give up on silence
+        verify { LocationServiceModule.sendSyncProgressEvent(10, 0, 20, null) }
+        // Only the periodic pass has posted so far, so the event can only be its report
+        coVerify(exactly = 20) { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) }
+
+        syncManager.stopPeriodicSync()
+        unmockkObject(LocationServiceModule.Companion)
+    }
+
+    @Test
+    fun `a slow instant send does not hold back the next fix`() = scope.runTest {
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 0,
+            retryIntervalSeconds = 30,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        coEvery { networkManager.isNetworkAvailable() } returns true
+        fakeQueue(0)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(5_000); true }
+
+        launch { syncManager.queueAndSend(1L, JSONObject().put("lat", 1.0)) }
+        advanceTimeBy(1_000)
+        launch { syncManager.queueAndSend(2L, JSONObject().put("lat", 2.0)) }
+        advanceTimeBy(100)
+
+        // Two instant sends never carry the same row, so serialising them would buy nothing
+        coVerify(exactly = 1) {
+            networkManager.sendToEndpoint(match { it.optDouble("lat") == 2.0 }, any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `a manual flush started during an instant send does not post that row again`() = scope.runTest {
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 0,
+            retryIntervalSeconds = 30,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        coEvery { networkManager.isNetworkAvailable() } returns true
+        fakeQueue(0)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(1_000); true }
+
+        launch { syncManager.queueAndSend(500L, JSONObject().put("lat", 53.0), bypassInterval = true) }
+        launch { syncManager.manualFlush() }
+        advanceUntilIdle()
+
+        // Zone entry starts both together, and the flush fetches the heartbeat row the instant send is posting
+        coVerify(exactly = 1) {
+            networkManager.sendToEndpoint(match { it.optDouble("lat") == 53.0 }, any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `a manual flush cancelled while it waits still sends its ending event`() = scope.runTest {
+        mockkObject(LocationServiceModule.Companion)
+        every { LocationServiceModule.sendSyncProgressEvent(any(), any(), any(), any()) } returns true
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 0,
+            retryIntervalSeconds = 30,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        fakeQueue(20)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(1_500); true }
+
+        launch { syncManager.manualFlush() }
+        val waiting = launch { syncManager.manualFlush() }
+        advanceTimeBy(100)
+        waiting.cancel()
+        advanceTimeBy(100)
+
+        // Sync Now waits for this event, so a flush stopped before it got the lock must still send one
+        verify { LocationServiceModule.sendSyncProgressEvent(0, 0, 0, 20) }
+
+        advanceUntilIdle()
+        unmockkObject(LocationServiceModule.Companion)
+    }
+
+    @Test
+    fun `a tick that finds only a row an instant send is posting counts no failure`() = scope.runTest {
+        syncManager.updateConfig(
+            endpoint = "https://example.com",
+            syncIntervalSeconds = 0,
+            retryIntervalSeconds = 1,
+            isOfflineMode = false,
+            syncCondition = "any",
+            syncSsid = "",
+            authHeaders = emptyMap()
+        )
+        coEvery { networkManager.isNetworkAvailable() } returns true
+        fakeQueue(0)
+        coEvery { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) } coAnswers { delay(3_000); true }
+
+        launch { syncManager.queueAndSend(500L, JSONObject().put("lat", 53.0)) }
+        syncManager.startPeriodicSync()
+        advanceTimeBy(1_500)
+        syncManager.stopPeriodicSync()
+
+        assertEquals(0, getField("consecutiveFailures"))
+        coVerify(exactly = 1) { networkManager.sendToEndpoint(any(), any(), any(), any(), any()) }
+    }
+
+    // ========================================================================
     // Helpers
     // ========================================================================
 
@@ -1270,6 +1535,29 @@ class SyncManagerTest {
         method.isAccessible = true
         kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn<Unit> { cont ->
             method.invoke(syncManager, cont)
+        }
+    }
+
+    /** Rows leave only when a pass or an instant send removes them, so two senders running together see the same rows. */
+    private fun fakeQueue(size: Int) {
+        val queue = (1L..size.toLong()).map { QueuedLocation(it, it + 100, """{"lat":52.0}""", 0) }.toMutableList()
+        var nextId = size.toLong()
+        every { dbHelper.getQueuedLocations(50) } answers { queue.toList() }
+        every { dbHelper.getQueuedCount() } answers { queue.size }
+        every { dbHelper.addToQueue(any(), any()) } answers {
+            nextId++
+            queue.add(QueuedLocation(nextId, firstArg(), secondArg(), 0))
+            nextId
+        }
+        every { dbHelper.removeBatchFromQueue(any()) } answers {
+            val ids = firstArg<List<Long>>()
+            queue.removeAll { it.queueId in ids }
+        }
+        every { dbHelper.removeFromQueueByLocationId(any()) } answers {
+            val locationId = firstArg<Long>()
+            val before = queue.size
+            queue.removeAll { it.locationId == locationId }
+            before - queue.size
         }
     }
 


### PR DESCRIPTION
Sync passes could overlap, so the same queued rows were posted twice. Two Sync now taps, a periodic tick landing on a running flush, or the zone-entry flush beside a tick all did it, and a server that rejects the duplicate answered the pair with a 200 and a 500.

A mutex now allows one pass at a time, and the periodic tick and a manual flush wait for the running pass. Instant sends never take the lock, so a slow send does not hold back the next fix. Each registers its queue row while posting, a pass skips those rows, and an instant send made during a pass leaves its row to that pass or the next. A pass that only skipped rows an instant send was still posting no longer counts as a failed sync.